### PR TITLE
Add Travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+dist: trusty
+
+os:
+- linux
+
+language: go
+
+go:
+- 1.7
+- 1.8
+- tip
+
+before_install:
+- go get github.com/mattn/goveralls
+
+script:
+- goveralls -service=travis-ci


### PR DESCRIPTION
This adds a simple travis config that runs tests and uses https://coveralls.io for the converage report.

An admin of this project needs to enable this repository on https://travis-ci.org.