### PR TITLE
Move config to apimachinery

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -12,8 +12,6 @@ external-dns --in-cluster=false --dnsprovider=aws --source=ingress --source=serv
 
 ```
 ./main.go
-./config - store configurations, flag parsing
-    config.go 
 ./controller - main controlling loop
     controller.go 
 ./plan/
@@ -25,6 +23,8 @@ external-dns --in-cluster=false --dnsprovider=aws --source=ingress --source=serv
     google.go
     fake.go 
     dnsprovider.go - interface
+./pkg/apis/externaldns - types that we will want to be subject to apimachinery (e.g. configuration)
+./pkg/apis/externaldns/validation - validation for our types
 ./source/ - list of sources
     fake.go
     ingress.go

--- a/main.go
+++ b/main.go
@@ -26,14 +26,15 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/kubernetes-incubator/external-dns/config"
 	"github.com/kubernetes-incubator/external-dns/controller"
+	"github.com/kubernetes-incubator/external-dns/pkg/apis/externaldns"
+	"github.com/kubernetes-incubator/external-dns/pkg/apis/externaldns/validation"
 )
 
 func main() {
-	cfg := config.NewConfig()
+	cfg := externaldns.NewConfig()
 	cfg.ParseFlags()
-	if err := cfg.Validate(); err != nil {
+	if err := validation.ValidateConfig(cfg); err != nil {
 		log.Errorf("config validation failed: %v", err)
 	}
 

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -14,10 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package config
+package externaldns
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/pflag"
@@ -34,7 +33,7 @@ type Config struct {
 	LogFormat  string
 }
 
-// NewConfig returns new Configuration object
+// NewConfig returns new Config object
 func NewConfig() *Config {
 	return &Config{}
 }
@@ -46,12 +45,4 @@ func (cfg *Config) ParseFlags() {
 	flags.StringVar(&cfg.LogFormat, "log-format", "text", "log format output. options: [\"text\", \"json\"]")
 	flags.BoolVar(&cfg.Debug, "debug", false, "debug mode")
 	flags.Parse(os.Args)
-}
-
-// Validate custom validation for flags aside from flag library provided
-func (cfg *Config) Validate() error {
-	if cfg.LogFormat != "text" && cfg.LogFormat != "json" {
-		return fmt.Errorf("unsupported log format: %s", cfg.LogFormat)
-	}
-	return nil
 }

--- a/pkg/apis/externaldns/validation/validation.go
+++ b/pkg/apis/externaldns/validation/validation.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"github.com/kubernetes-incubator/external-dns/pkg/apis/externaldns"
+)
+
+// ValidateConfig performs validation on the Config object
+func ValidateConfig(cfg *externaldns.Config) error {
+	// TODO: Should probably return field.ErrorList
+	if cfg.LogFormat != "text" && cfg.LogFormat != "json" {
+		return fmt.Errorf("unsupported log format: %s", cfg.LogFormat)
+	}
+	return nil
+}

--- a/pkg/apis/externaldns/validation/validation_test.go
+++ b/pkg/apis/externaldns/validation/validation_test.go
@@ -14,25 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package config
+package validation
 
 import (
+	"github.com/kubernetes-incubator/external-dns/pkg/apis/externaldns"
 	"testing"
 )
 
 func TestValidateFlags(t *testing.T) {
-	cfg := NewConfig()
+	cfg := externaldns.NewConfig()
 	cfg.LogFormat = "test"
-	if err := cfg.Validate(); err == nil {
+	if err := ValidateConfig(cfg); err == nil {
 		t.Errorf("unsupported log format should fail: %s", cfg.LogFormat)
 	}
 	cfg.LogFormat = ""
-	if err := cfg.Validate(); err == nil {
+	if err := ValidateConfig(cfg); err == nil {
 		t.Errorf("unsupported log format should fail: %s", cfg.LogFormat)
 	}
 	for _, format := range []string{"text", "json"} {
 		cfg.LogFormat = format
-		if err := cfg.Validate(); err != nil {
+		if err := ValidateConfig(cfg); err != nil {
 			t.Errorf("supported log format: %s should not fail", format)
 		}
 	}


### PR DESCRIPTION
Types that we want to work using apimachinery typically go into
pkg/apis/X, and the validation goes into pkg/apis/X/validation.  We then
add versions into e.g. pkg/apis/X/v1alpha1, but this feels premature at
the moment.

Changing this later is annoyingly difficult, especially in terms of
validation and dependencies.

We will want the apimachinery, so that we can configure from a
configuration file that is versioned.  Hopefully dns-controller won't
end up so complicated that we will require it, but I think there is also
value in following the "standard" patterns for controllers that are
emerging from e.g. ingress.

For a fairly simple example of an API, please consult
https://github.com/kubernetes/kubernetes/tree/master/pkg/apis/certificates