### PR TITLE
run tests for all but vendored packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,4 @@
 verify:
 	vendor/github.com/kubernetes/repo-infra/verify/verify-boilerplate.sh --rootdir=${CURDIR}
 	vendor/github.com/kubernetes/repo-infra/verify/verify-go-src.sh -v --rootdir ${CURDIR}
-	go test github.com/kubernetes-incubator/external-dns/pkg/...
-
+	go test -v $(shell go list ./... | grep -v /vendor/)


### PR DESCRIPTION
follow-up of https://github.com/kubernetes-incubator/external-dns/pull/38