### PR TITLE
add once flag to exit loop after first sync

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,6 +97,13 @@ func main() {
 		DNSProvider: dnsProvider,
 	}
 
+	// immediately send stop signal when --once is set
+	if cfg.Once {
+		go func() {
+			stopChan <- struct{}{}
+		}()
+	}
+
 	ctrl.Run(stopChan)
 	for {
 		log.Infoln("pod waiting to be deleted")

--- a/main.go
+++ b/main.go
@@ -97,11 +97,13 @@ func main() {
 		DNSProvider: dnsProvider,
 	}
 
-	// immediately send stop signal when --once is set
 	if cfg.Once {
-		go func() {
-			stopChan <- struct{}{}
-		}()
+		err := ctrl.RunOnce()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		os.Exit(0)
 	}
 
 	ctrl.Run(stopChan)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -30,6 +30,7 @@ type Config struct {
 	GoogleProject string
 	GoogleZone    string
 	HealthPort    string
+	Once          bool
 	DryRun        bool
 	Debug         bool
 	LogFormat     string
@@ -49,6 +50,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	flags.StringVar(&cfg.GoogleZone, "google-zone", "", "gcloud dns hosted zone to target")
 	flags.StringVar(&cfg.HealthPort, "health-port", defaultHealthPort, "health port to listen on")
 	flags.StringVar(&cfg.LogFormat, "log-format", defaultLogFormat, "log format output. options: [\"text\", \"json\"]")
+	flags.BoolVar(&cfg.Once, "once", false, "run once and exit")
 	flags.BoolVar(&cfg.DryRun, "dry-run", true, "dry-run mode")
 	flags.BoolVar(&cfg.Debug, "debug", false, "debug mode")
 	return flags.Parse(args)


### PR DESCRIPTION
`--once` terminates the program after first sync.

@ideahitme I'm currently writing a simple integration test where I need this functionality. However, the busy loop at the end of the program still seems odd to me.