### PR TITLE
allow passing a namespace that limits found resources

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,7 +70,8 @@ func main() {
 	}
 
 	source := &source.ServiceSource{
-		Client: client,
+		Client:    client,
+		Namespace: cfg.Namespace,
 	}
 
 	gcloud, err := google.DefaultClient(context.TODO(), dns.NdevClouddnsReadwriteScope)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -27,6 +27,7 @@ var (
 type Config struct {
 	InCluster     bool
 	KubeConfig    string
+	Namespace     string
 	GoogleProject string
 	GoogleZone    string
 	HealthPort    string
@@ -45,6 +46,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 	flags.BoolVar(&cfg.InCluster, "in-cluster", false, "whether to use in-cluster config")
 	flags.StringVar(&cfg.KubeConfig, "kubeconfig", "", "path to a local kubeconfig file")
+	flags.StringVar(&cfg.Namespace, "namespace", "", "the namespace to look for endpoints")
 	flags.StringVar(&cfg.GoogleProject, "google-project", "", "gcloud project to target")
 	flags.StringVar(&cfg.GoogleZone, "google-zone", "", "gcloud dns hosted zone to target")
 	flags.StringVar(&cfg.HealthPort, "health-port", defaultHealthPort, "health port to listen on")

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package externaldns
 
-import "github.com/spf13/pflag"
+import (
+	"github.com/spf13/pflag"
+
+	"k8s.io/client-go/pkg/api/v1"
+)
 
 var (
 	defaultHealthPort = "9090"
@@ -46,7 +50,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 	flags.BoolVar(&cfg.InCluster, "in-cluster", false, "whether to use in-cluster config")
 	flags.StringVar(&cfg.KubeConfig, "kubeconfig", "", "path to a local kubeconfig file")
-	flags.StringVar(&cfg.Namespace, "namespace", "", "the namespace to look for endpoints")
+	flags.StringVar(&cfg.Namespace, "namespace", v1.NamespaceAll, "the namespace to look for endpoints; all namespaces by default")
 	flags.StringVar(&cfg.GoogleProject, "google-project", "", "gcloud project to target")
 	flags.StringVar(&cfg.GoogleZone, "google-zone", "", "gcloud dns hosted zone to target")
 	flags.StringVar(&cfg.HealthPort, "health-port", defaultHealthPort, "health port to listen on")

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -28,13 +28,14 @@ import (
 // Ingress implementation will use the spec.rules.host value for the hostname
 // Ingress annotations are ignored
 type IngressSource struct {
-	Client kubernetes.Interface
+	Client    kubernetes.Interface
+	Namespace string
 }
 
 // Endpoints returns endpoint objects for each host-target combination that should be processed.
 // Retrieves all ingress resources on all namespaces
 func (sc *IngressSource) Endpoints() ([]endpoint.Endpoint, error) {
-	ingresses, err := sc.Client.Extensions().Ingresses(v1.NamespaceAll).List(v1.ListOptions{})
+	ingresses, err := sc.Client.Extensions().Ingresses(sc.Namespace).List(v1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/source/service.go
+++ b/source/service.go
@@ -38,12 +38,13 @@ const (
 // matched services' external entrypoints it will return a corresponding
 // Endpoint object.
 type ServiceSource struct {
-	Client kubernetes.Interface
+	Client    kubernetes.Interface
+	Namespace string
 }
 
 // Endpoints returns endpoint objects for each service that should be processed.
 func (sc *ServiceSource) Endpoints() ([]endpoint.Endpoint, error) {
-	services, err := sc.Client.CoreV1().Services(v1.NamespaceAll).List(v1.ListOptions{})
+	services, err := sc.Client.CoreV1().Services(sc.Namespace).List(v1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows passing a namespace to limit the resources that are found by the sources. I'm currently wring a simple integration test and want to create a service in a "testing" namespace also validate that this service gets its dns entries created. I don't care about other services in the cluster.