### PR TITLE
build docker image with google container builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM alpine:3.5
 
 COPY build/linux-amd64/external-dns /external-dns

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.5
+
+COPY build/linux-amd64/external-dns /external-dns
+
+ENTRYPOINT ["/external-dns"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,16 @@
+steps:
+- name: gcr.io/cloud-builders/go
+  args:
+  - build
+  - -o=build/linux-amd64/external-dns
+  - .
+  env:
+  - PROJECT_ROOT=github.com/kubernetes-incubator/external-dns
+- name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - --tag=gcr.io/$PROJECT_ID/external-dns
+  - .
+
+images:
+- gcr.io/$PROJECT_ID/external-dns


### PR DESCRIPTION
Builds a docker image for `external-dns` using Google's Container Builder.

You can build your own by enabling the Container Builder API in your project and run:
```
gcloud --project your-project container builds submit --config=cloudbuild.yaml .
```

or find the latest commit at: `gcr.io/zalando-docker/external-dns`

---

I would like to setup triggers so it gets built automatically. Unfortunately, that requires an owner to allow to read `kubernetes-incubator` projects from Google via my Github account.

@justinsb That seems a little odd. Do you have better ideas?