### PR TITLE
validate that current sources adhere to the Source interface

### DIFF
--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -25,6 +25,9 @@ import (
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
+// Validates that IngressSource is a Source
+var _ Source = &IngressSource{}
+
 func TestIngress(t *testing.T) {
 	t.Run("endpointsFromIngress", testEndpointsFromIngress)
 	t.Run("Endpoints", testIngressEndpoints)

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -26,6 +26,9 @@ import (
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 )
 
+// Validates that ServiceSource is a Source
+var _ Source = &ServiceSource{}
+
 func TestService(t *testing.T) {
 	t.Run("Endpoints", testServiceEndpoints)
 }


### PR DESCRIPTION
Ensures that these sources implement `Source`.