### PR TITLE
Ingress: appends trailing dot to hostnames

### DIFF
--- a/source/ingress.go
+++ b/source/ingress.go
@@ -17,6 +17,8 @@ limitations under the License.
 package source
 
 import (
+	"strings"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
@@ -66,13 +68,13 @@ func endpointsFromIngress(ing *v1beta1.Ingress) []endpoint.Endpoint {
 		for _, lb := range ing.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {
 				endpoints = append(endpoints, endpoint.Endpoint{
-					DNSName: rule.Host,
+					DNSName: sanitizeHostname(rule.Host),
 					Target:  lb.IP,
 				})
 			}
 			if lb.Hostname != "" {
 				endpoints = append(endpoints, endpoint.Endpoint{
-					DNSName: rule.Host,
+					DNSName: sanitizeHostname(rule.Host),
 					Target:  lb.Hostname,
 				})
 			}
@@ -80,4 +82,9 @@ func endpointsFromIngress(ing *v1beta1.Ingress) []endpoint.Endpoint {
 	}
 
 	return endpoints
+}
+
+// sanitizeHostname appends a trailing dot to a hostname if it's missing.
+func sanitizeHostname(hostname string) string {
+	return strings.Trim(hostname, ".") + "."
 }

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -47,7 +47,7 @@ func testEndpointsFromIngress(t *testing.T) {
 			},
 			expected: []endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
+					DNSName: "foo.bar.",
 					Target:  "lb.com",
 				},
 			},
@@ -60,7 +60,7 @@ func testEndpointsFromIngress(t *testing.T) {
 			},
 			expected: []endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
+					DNSName: "foo.bar.",
 					Target:  "8.8.8.8",
 				},
 			},
@@ -74,19 +74,19 @@ func testEndpointsFromIngress(t *testing.T) {
 			},
 			expected: []endpoint.Endpoint{
 				{
-					DNSName: "foo.bar",
+					DNSName: "foo.bar.",
 					Target:  "8.8.8.8",
 				},
 				{
-					DNSName: "foo.bar",
+					DNSName: "foo.bar.",
 					Target:  "127.0.0.1",
 				},
 				{
-					DNSName: "foo.bar",
+					DNSName: "foo.bar.",
 					Target:  "elb.com",
 				},
 				{
-					DNSName: "foo.bar",
+					DNSName: "foo.bar.",
 					Target:  "alb.com",
 				},
 			},
@@ -154,11 +154,11 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []endpoint.Endpoint{
 				{
-					DNSName: "example.org",
+					DNSName: "example.org.",
 					Target:  "8.8.8.8",
 				},
 				{
-					DNSName: "new.org",
+					DNSName: "new.org.",
 					Target:  "lb.com",
 				},
 			},
@@ -182,11 +182,11 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []endpoint.Endpoint{
 				{
-					DNSName: "example.org",
+					DNSName: "example.org.",
 					Target:  "8.8.8.8",
 				},
 				{
-					DNSName: "new.org",
+					DNSName: "new.org.",
 					Target:  "lb.com",
 				},
 			},
@@ -210,7 +210,7 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			expected: []endpoint.Endpoint{
 				{
-					DNSName: "example.org",
+					DNSName: "example.org.",
 					Target:  "8.8.8.8",
 				},
 			},


### PR DESCRIPTION
This makes Ingress work with the Google provider. We should standardize either way. For now, I chose to add the dot before passing it onwards.