### PR TITLE
simplify cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,9 +3,6 @@ steps:
   args:
   - build
   - -o=build/linux-amd64/external-dns
-  - -v
-  - -ldflags
-  - -X main.version=$REVISION_ID -w -s
   - .
   env:
   - PROJECT_ROOT=github.com/kubernetes-incubator/external-dns
@@ -13,9 +10,7 @@ steps:
   args:
   - build
   - --tag=gcr.io/$PROJECT_ID/external-dns
-  - --tag=gcr.io/$PROJECT_ID/external-dns:$REVISION_ID
   - .
 
 images:
 - gcr.io/$PROJECT_ID/external-dns
-- gcr.io/$PROJECT_ID/external-dns:$REVISION_ID


### PR DESCRIPTION
Google's Container Builder doesn't work so well for us at the moment:
* difficult to support github tags as  docker tags
* difficult to support abbrev revisions as tags
* I can't setup triggers b/c I'm no org owner

I've setup a job on our internal Jenkins to do it for now and push the image to our opensource registry, i.e. `docker pull registry.opensource.zalan.do/teapot/external-dns`

I'm leaving the simplest version of cloudbuild here for reference. You can use it to push an image to your Google project's registry without having docker installed.