### PR TITLE
collect metrics about issued API requests

### DIFF
--- a/provider/google.go
+++ b/provider/google.go
@@ -65,6 +65,7 @@ type resourceRecordSetsService struct {
 }
 
 func (r resourceRecordSetsService) List(project string, managedZone string) resourceRecordSetsListCallInterface {
+	trackAPICall()
 	return r.service.List(project, managedZone)
 }
 
@@ -73,10 +74,12 @@ type managedZonesService struct {
 }
 
 func (m managedZonesService) Create(project string, managedzone *dns.ManagedZone) managedZonesCreateCallInterface {
+	trackAPICall()
 	return m.service.Create(project, managedzone)
 }
 
 func (m managedZonesService) List(project string) managedZonesListCallInterface {
+	trackAPICall()
 	return m.service.List(project)
 }
 
@@ -85,6 +88,7 @@ type changesService struct {
 }
 
 func (c changesService) Create(project string, managedZone string, change *dns.Change) changesCreateCallInterface {
+	trackAPICall()
 	return c.service.Create(project, managedZone, change)
 }
 
@@ -259,6 +263,8 @@ func (p *googleProvider) submitChange(change *dns.Change) error {
 		}
 	}
 
+	trackAPICall()
+
 	return nil
 }
 
@@ -337,4 +343,8 @@ func newRecord(endpoint *endpoint.Endpoint) *dns.ResourceRecordSet {
 		Ttl:     300,
 		Type:    suitableType(endpoint),
 	}
+}
+
+func trackAPICall() {
+	metrics.APICallsTotal.WithLabelValues("google").Inc()
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"strings"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 	"github.com/kubernetes-incubator/external-dns/plan"
 )
@@ -28,6 +30,23 @@ import (
 type Provider interface {
 	Records(zone string) ([]*endpoint.Endpoint, error)
 	ApplyChanges(zone string, changes *plan.Changes) error
+}
+
+var metrics = struct {
+	APICallsTotal *prometheus.CounterVec
+}{
+	APICallsTotal: prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "external_dns",
+			Name:      "api_calls_total",
+			Help:      "Total number of API calls to DNS providers",
+		},
+		[]string{"dns_provider"},
+	),
+}
+
+func init() {
+	prometheus.MustRegister(metrics.APICallsTotal)
 }
 
 // suitableType returns the DNS resource record type suitable for the target.


### PR DESCRIPTION
This is an initial stub of metrics collection via prometheus. In light of our recent experience with API rate limits this seems like an interesting start to see whether our own tool has gone wild.

Example output from `/metrics`:
```
external_dns_api_calls_total{dns_provider="google"} 5
```

I guess one could use a prometheus `rate` aggregation to keep track of the issued API calls per timeframe and then set an alert if it exceeds some amount.

We had it in the past that an error would short circuit a loop, skipping some `sleep` and then issue a giant number of requests. This metric could catch it.

/cc @ideahitme @mikkeloscar @szuecs Let me know what you think.

Disclamer: I have little to no experience with prometheus metrics collection.

some other useful custom metrics: https://github.com/coreos/alb-ingress-controller/blob/master/pkg/cmd/controller/metrics.go