### PR TITLE
ingress: should be ignored if other controller is annotated

### DIFF
--- a/source/ingress.go
+++ b/source/ingress.go
@@ -61,6 +61,12 @@ func (sc *ingressSource) Endpoints() ([]endpoint.Endpoint, error) {
 func endpointsFromIngress(ing *v1beta1.Ingress) []endpoint.Endpoint {
 	var endpoints []endpoint.Endpoint
 
+	// Check controller annotation to see if we are responsible.
+	controller, exists := ing.Annotations[controllerAnnotationKey]
+	if exists && controller != controllerAnnotationValue {
+		return endpoints
+	}
+
 	for _, rule := range ing.Spec.Rules {
 		if rule.Host == "" {
 			continue

--- a/source/service.go
+++ b/source/service.go
@@ -23,15 +23,6 @@ import (
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 )
 
-const (
-	// The annotation used for figuring out which controller is responsible
-	controllerAnnotationKey = "external-dns.alpha.kubernetes.io/controller"
-	// The annotation used for defining the desired hostname
-	hostnameAnnotationKey = "external-dns.alpha.kubernetes.io/hostname"
-	// The value of the controller annotation so that we feel resposible
-	controllerAnnotationValue = "dns-controller"
-)
-
 // serviceSource is an implementation of Source for Kubernetes service objects.
 // It will find all services that are under our jurisdiction, i.e. annotated
 // desired hostname and matching or no controller annotation. For each of the

--- a/source/source.go
+++ b/source/source.go
@@ -20,6 +20,15 @@ import (
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 )
 
+const (
+	// The annotation used for figuring out which controller is responsible
+	controllerAnnotationKey = "external-dns.alpha.kubernetes.io/controller"
+	// The annotation used for defining the desired hostname
+	hostnameAnnotationKey = "external-dns.alpha.kubernetes.io/hostname"
+	// The value of the controller annotation so that we feel resposible
+	controllerAnnotationValue = "dns-controller"
+)
+
 // Source defines the interface Endpoint sources should implement.
 type Source interface {
 	Endpoints() ([]endpoint.Endpoint, error)


### PR DESCRIPTION
It must be able to opt-out of being controlled by this controller. `IngressSource` was missing that.