### PR TITLE
increase the timeout to 20minutes for goveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ install:
 script:
 - vendor/github.com/kubernetes/repo-infra/verify/verify-boilerplate.sh --rootdir=$(pwd)
 - vendor/github.com/kubernetes/repo-infra/verify/verify-go-src.sh -v --rootdir $(pwd)
-- goveralls -service=travis-ci
+- travis_wait 20 goveralls -service=travis-ci


### PR DESCRIPTION
/cc @linki seems like a lot of builds are timing out 

https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received