### PR TITLE
take record type into account when determining ELBs

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -66,8 +66,10 @@ func (p *Plan) Calculate() *Plan {
 
 		// If there already is a record update it if it changed.
 		if desired.Target != current.Target {
-			desired.MergeLabels(current.Labels) //inherit the labels from the dns provider, including Owner ID
 			changes.UpdateOld = append(changes.UpdateOld, current)
+
+			desired.RecordType = current.RecordType // inherit the type from the dns provider
+			desired.MergeLabels(current.Labels)     // inherit the labels from the dns provider, including Owner ID
 			changes.UpdateNew = append(changes.UpdateNew, desired)
 		}
 	}

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -41,6 +41,11 @@ func TestCalculate(t *testing.T) {
 	labeledV2 := []*endpoint.Endpoint{newEndpointWithOwner("foo", "v2", "123")}
 	labeledV1 := []*endpoint.Endpoint{newEndpointWithOwner("foo", "v1", "123")}
 
+	// test case with type inheritance
+	noType := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", "v2", "")}
+	typedV2 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", "v2", "A")}
+	typedV1 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", "v1", "A")}
+
 	for _, tc := range []struct {
 		policy                               Policy
 		current, desired                     []*endpoint.Endpoint
@@ -62,6 +67,8 @@ func TestCalculate(t *testing.T) {
 		{&UpsertOnlyPolicy{}, fooV1, empty, empty, empty, empty, empty},
 		// Labels should be inherited
 		{&SyncPolicy{}, labeledV1, noLabels, empty, labeledV1, labeledV2, empty},
+		// RecordType should be inherited
+		{&SyncPolicy{}, typedV1, noType, empty, typedV1, typedV2, empty},
 	} {
 		// setup plan
 		plan := &Plan{

--- a/provider/aws.go
+++ b/provider/aws.go
@@ -205,7 +205,7 @@ func newChange(action string, endpoint *endpoint.Endpoint) *route53.Change {
 		},
 	}
 
-	if isAWSLoadBalancer(endpoint.Target) {
+	if isAWSLoadBalancer(endpoint) {
 		change.ResourceRecordSet.Type = aws.String(route53.RRTypeA)
 		change.ResourceRecordSet.AliasTarget = &route53.AliasTarget{
 			DNSName:              aws.String(endpoint.Target),
@@ -225,8 +225,12 @@ func newChange(action string, endpoint *endpoint.Endpoint) *route53.Change {
 	return change
 }
 
-func isAWSLoadBalancer(hostname string) bool {
-	return canonicalHostedZone(hostname) != ""
+func isAWSLoadBalancer(ep *endpoint.Endpoint) bool {
+	if ep.RecordType == "" {
+		return canonicalHostedZone(ep.Target) != ""
+	}
+
+	return ep.RecordType == "ALIAS"
 }
 
 func canonicalHostedZone(hostname string) string {


### PR DESCRIPTION
when detecting the type from the hostname, we have to take the `recordType` into account if it's set. ~~This allows to pres switch between CNAME and ALIAS and allows ExternalDNS to work correctly when removing one for the other.~~ It preserves the type which is required for deleting and updating records.