### PR TITLE
Google: ensure DNS records have trailing dot before sending

### DIFF
--- a/provider/google.go
+++ b/provider/google.go
@@ -285,8 +285,8 @@ func newRecords(endpoints []*endpoint.Endpoint) []*dns.ResourceRecordSet {
 // newRecord returns a RecordSet based on the given endpoint.
 func newRecord(endpoint *endpoint.Endpoint) *dns.ResourceRecordSet {
 	return &dns.ResourceRecordSet{
-		Name:    endpoint.DNSName,
-		Rrdatas: []string{endpoint.Target},
+		Name:    ensureTrailingDot(endpoint.DNSName),
+		Rrdatas: []string{ensureTrailingDot(endpoint.Target)},
 		Ttl:     300,
 		Type:    suitableType(endpoint),
 	}


### PR DESCRIPTION
When we decided to sanitize by removing a trailing dot we broke the Google provider.