### PR TITLE
log config on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,6 +57,8 @@ func main() {
 		os.Exit(0)
 	}
 
+	log.Infof("config: %+v", cfg)
+
 	if err := validation.ValidateConfig(cfg); err != nil {
 		log.Fatalf("config validation failed: %v", err)
 	}


### PR DESCRIPTION
To make it easier to detect config errors (like non-empty "domain")