### PR TITLE
Tutorial uses buggy version for GKE example

### DIFF
--- a/docs/tutorials/gke.md
+++ b/docs/tutorials/gke.md
@@ -73,7 +73,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.2.0
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.2.1
         args:
         - --in-cluster
         - --zone=external-dns-test-gcp-zalan-do


### PR DESCRIPTION
Bug in question: https://github.com/kubernetes-incubator/external-dns/issues/154

This is fixed in 0.2.1