### PR TITLE
Unique endpoint filtering

### DIFF
--- a/source/multi_source_test.go
+++ b/source/multi_source_test.go
@@ -31,8 +31,9 @@ func TestMultiSource(t *testing.T) {
 
 // testMultiSourceEndpoints tests merged endpoints from children are returned.
 func testMultiSourceEndpoints(t *testing.T) {
-	foo := &endpoint.Endpoint{DNSName: "foo", Target: "8.8.8.8"}
-	bar := &endpoint.Endpoint{DNSName: "bar", Target: "8.8.4.4"}
+	foo := &endpoint.Endpoint{DNSName: "foo", Target: "8.8.8.8", RecordType: "A"}
+	fooTxt := &endpoint.Endpoint{DNSName: "foo", Target: "8.8.8.8", RecordType: "TXT"}
+	bar := &endpoint.Endpoint{DNSName: "bar", Target: "8.8.4.4", RecordType: "A"}
 
 	for _, tc := range []struct {
 		title           string
@@ -58,6 +59,11 @@ func testMultiSourceEndpoints(t *testing.T) {
 			"multiple non-empty child sources returns merged children's endpoints",
 			[][]*endpoint.Endpoint{{foo}, {bar}},
 			[]*endpoint.Endpoint{foo, bar},
+		},
+		{
+			"duplicates are filtered out",
+			[][]*endpoint.Endpoint{{foo}, {foo, fooTxt}},
+			[]*endpoint.Endpoint{foo, fooTxt},
 		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {


### PR DESCRIPTION
Addressing #182 

- Adding in endpoint filtering to reduce issue with
  multiple ingress sources being processed for a single
  DNS entry

NOTE:  With the current DNS entry types generated I think this should be sufficient.  If there was ever a point where things like weighted record sets were to be introduced the "unique" identification would need to be reconsidered. 