### PR TITLE
try out go-kit's log package

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -58,5 +58,5 @@ func (e *Endpoint) MergeLabels(labels map[string]string) {
 }
 
 func (e *Endpoint) String() string {
-	return fmt.Sprintf(`%s -> %s (type "%s")`, e.DNSName, e.Target, e.RecordType)
+	return fmt.Sprintf("(%s,%s,%s)", e.DNSName, e.Target, e.RecordType)
 }

--- a/main.go
+++ b/main.go
@@ -58,16 +58,15 @@ func main() {
 	}
 
 	logger := kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stderr))
+	if cfg.Debug {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		logger = level.NewFilter(logger, level.AllowInfo())
+	}
 	logger = kitlog.With(logger, "time", kitlog.DefaultTimestampUTC, "caller", kitlog.DefaultCaller)
 
 	if cfg.DryRun {
 		log.Info("running in dry-run mode. No changes to DNS records will be made.")
-	}
-	if cfg.Debug {
-		log.SetLevel(log.DebugLevel)
-		logger = level.NewFilter(logger, level.AllowDebug())
-	} else {
-		logger = level.NewFilter(logger, level.AllowInfo())
 	}
 
 	stopChan := make(chan struct{}, 1)

--- a/source/dedup_source_test.go
+++ b/source/dedup_source_test.go
@@ -19,6 +19,8 @@ package source
 import (
 	"testing"
 
+	"github.com/go-kit/kit/log"
+
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 )
 
@@ -91,7 +93,7 @@ func testDedupEndpoints(t *testing.T) {
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			// Create our object under test and get the endpoints.
-			source := NewDedupSource(NewMockSource(tc.endpoints))
+			source := NewDedupSource(NewMockSource(tc.endpoints), log.NewNopLogger())
 
 			endpoints, err := source.Endpoints()
 			if err != nil {


### PR DESCRIPTION
An example how logging would log with go-kit's logger, e.g.

```
time=2017-05-05T15:28:45.749852014Z caller=level.go:63 level=debug source=dedup msg="removing duplicate endpoint" endpoint=(nginx.external-dns-test.teapot.zalan.do,a68ed2b06193a11e789e106c98a7b4d3-1598269060.eu-central-1.elb.amazonaws.com,)
```
