### PR TITLE
refactor inmemory provider

### DIFF
--- a/provider/inmemory_test.go
+++ b/provider/inmemory_test.go
@@ -740,7 +740,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 			c.zones = init
 			im.client = c
 
-			err := im.ApplyChanges("", ti.changes)
+			err := im.ApplyChanges("_", ti.changes)
 			if ti.expectError && err == nil {
 				t.Errorf("should return an error")
 			}

--- a/provider/inmemory_test.go
+++ b/provider/inmemory_test.go
@@ -209,7 +209,7 @@ func testInMemoryRecords(t *testing.T) {
 			im.client = c
 			f := filter{domain: ti.zone}
 			im.filter = &f
-			records, err := im.Records("")
+			records, err := im.Records("_")
 			if ti.expectError && records != nil {
 				t.Errorf("wrong zone should not return records")
 			}

--- a/registry/noop_test.go
+++ b/registry/noop_test.go
@@ -46,25 +46,21 @@ func testNoopInit(t *testing.T) {
 
 func testNoopRecords(t *testing.T) {
 	p := provider.NewInMemoryProvider()
-	p.CreateZone("zone")
+	p.CreateZone("org")
 	providerRecords := []*endpoint.Endpoint{
 		{
-			DNSName: "example.org",
-			Target:  "example-lb.com",
+			DNSName:    "example.org",
+			Target:     "example-lb.com",
+			RecordType: "CNAME",
 		},
 	}
-	p.ApplyChanges("zone", &plan.Changes{
+	p.ApplyChanges("", &plan.Changes{
 		Create: providerRecords,
 	})
 
 	r, _ := NewNoopRegistry(p)
-	_, err := r.Records("wrong-zone")
-	if err == nil {
-		t.Error("Should fail for wrong zone: wrong-zone")
-	}
 
-	r, _ = NewNoopRegistry(p)
-	eps, err := r.Records("zone")
+	eps, err := r.Records("")
 	if err != nil {
 		t.Error(err)
 	}
@@ -76,7 +72,7 @@ func testNoopRecords(t *testing.T) {
 func testNoopApplyChanges(t *testing.T) {
 	// do some prep
 	p := provider.NewInMemoryProvider()
-	p.CreateZone("zone")
+	p.CreateZone("org")
 	providerRecords := []*endpoint.Endpoint{
 		{
 			DNSName: "example.org",
@@ -96,20 +92,13 @@ func testNoopApplyChanges(t *testing.T) {
 		},
 	}
 
-	p.ApplyChanges("zone", &plan.Changes{
+	p.ApplyChanges("", &plan.Changes{
 		Create: providerRecords,
 	})
 
-	// wrong zone
-	r, _ := NewNoopRegistry(p)
-	err := r.ApplyChanges("wrong-zone", &plan.Changes{})
-	if err != provider.ErrZoneNotFound {
-		t.Error("should return zone not found for apply changes on wrong zone")
-	}
-
 	// wrong changes
-	r, _ = NewNoopRegistry(p)
-	err = r.ApplyChanges("zone", &plan.Changes{
+	r, _ := NewNoopRegistry(p)
+	err := r.ApplyChanges("", &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			{
 				DNSName: "example.org",
@@ -122,7 +111,7 @@ func testNoopApplyChanges(t *testing.T) {
 	}
 
 	//correct changes
-	err = r.ApplyChanges("zone", &plan.Changes{
+	err = r.ApplyChanges("", &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			{
 				DNSName: "new-record.org",
@@ -145,7 +134,7 @@ func testNoopApplyChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, _ := p.Records("zone")
+	res, _ := p.Records("")
 	if !testutils.SameEndpoints(res, expectedUpdate) {
 		t.Error("incorrectly updated dns provider")
 	}

--- a/registry/noop_test.go
+++ b/registry/noop_test.go
@@ -60,7 +60,7 @@ func testNoopRecords(t *testing.T) {
 
 	r, _ := NewNoopRegistry(p)
 
-	eps, err := r.Records("")
+	eps, err := r.Records("_")
 	if err != nil {
 		t.Error(err)
 	}
@@ -134,7 +134,7 @@ func testNoopApplyChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, _ := p.Records("")
+	res, _ := p.Records("_")
 	if !testutils.SameEndpoints(res, expectedUpdate) {
 		t.Error("incorrectly updated dns provider")
 	}

--- a/registry/noop_test.go
+++ b/registry/noop_test.go
@@ -54,7 +54,7 @@ func testNoopRecords(t *testing.T) {
 			RecordType: "CNAME",
 		},
 	}
-	p.ApplyChanges("", &plan.Changes{
+	p.ApplyChanges("_", &plan.Changes{
 		Create: providerRecords,
 	})
 
@@ -92,13 +92,13 @@ func testNoopApplyChanges(t *testing.T) {
 		},
 	}
 
-	p.ApplyChanges("", &plan.Changes{
+	p.ApplyChanges("_", &plan.Changes{
 		Create: providerRecords,
 	})
 
 	// wrong changes
 	r, _ := NewNoopRegistry(p)
-	err := r.ApplyChanges("", &plan.Changes{
+	err := r.ApplyChanges("_", &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			{
 				DNSName: "example.org",
@@ -111,7 +111,7 @@ func testNoopApplyChanges(t *testing.T) {
 	}
 
 	//correct changes
-	err = r.ApplyChanges("", &plan.Changes{
+	err = r.ApplyChanges("_", &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			{
 				DNSName: "new-record.org",

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -70,7 +70,7 @@ func testTXTRegistryRecords(t *testing.T) {
 func testTXTRegistryRecordsPrefixed(t *testing.T) {
 	p := provider.NewInMemoryProvider()
 	p.CreateZone(testZone)
-	p.ApplyChanges("", &plan.Changes{
+	p.ApplyChanges("_", &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", "CNAME", ""),
 			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", "CNAME", ""),

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	testZone = "test-zone.example.com."
+	testZone = "test-zone.example.org"
 )
 
 func TestTXTRegistry(t *testing.T) {
@@ -60,11 +60,6 @@ func testTXTRegistryNew(t *testing.T) {
 	if _, ok := r.mapper.(prefixNameMapper); !ok {
 		t.Error("Incorrect type of prefix name mapper")
 	}
-
-	rs, err := r.Records("random-zone")
-	if err == nil || rs != nil {
-		t.Error("incorrect zone should trigger error")
-	}
 }
 
 func testTXTRegistryRecords(t *testing.T) {
@@ -75,7 +70,7 @@ func testTXTRegistryRecords(t *testing.T) {
 func testTXTRegistryRecordsPrefixed(t *testing.T) {
 	p := provider.NewInMemoryProvider()
 	p.CreateZone(testZone)
-	p.ApplyChanges(testZone, &plan.Changes{
+	p.ApplyChanges("", &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", "CNAME", ""),
 			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", "CNAME", ""),
@@ -294,13 +289,6 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 	err := r.ApplyChanges(testZone, changes)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	changes = &plan.Changes{}
-	p.OnApplyChanges = func(c *plan.Changes) {}
-	err = r.ApplyChanges("new-zone", changes)
-	if err == nil {
-		t.Error("expected error")
 	}
 }
 


### PR DESCRIPTION
Refactor InMemoryProvider to simulate current behaviour of other providers 

This PR is required to refactor interfaces and remove mentioning of zones from the codebase 

@linki 