### PR TITLE
make all provider implementation public, return struct instead of interface

### DIFF
--- a/provider/aws.go
+++ b/provider/aws.go
@@ -74,7 +74,7 @@ type AWSProvider struct {
 }
 
 // NewAWSProvider initializes a new AWS Route53 based Provider.
-func NewAWSProvider(domainFilter string, dryRun bool) (Provider, error) {
+func NewAWSProvider(domainFilter string, dryRun bool) (*AWSProvider, error) {
 	config := aws.NewConfig()
 
 	config = config.WithHTTPClient(

--- a/provider/azure.go
+++ b/provider/azure.go
@@ -75,7 +75,7 @@ type AzureProvider struct {
 // NewAzureProvider creates a new Azure provider.
 //
 // Returns the provider or an error if a provider could not be created.
-func NewAzureProvider(configFile string, domainFilter string, resourceGroup string, dryRun bool) (Provider, error) {
+func NewAzureProvider(configFile string, domainFilter string, resourceGroup string, dryRun bool) (*AzureProvider, error) {
 	contents, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read Azure config file '%s': %v", configFile, err)

--- a/provider/google.go
+++ b/provider/google.go
@@ -89,8 +89,8 @@ func (c changesService) Create(project string, managedZone string, change *dns.C
 	return c.service.Create(project, managedZone, change)
 }
 
-// googleProvider is an implementation of Provider for Google CloudDNS.
-type googleProvider struct {
+// GoogleProvider is an implementation of Provider for Google CloudDNS.
+type GoogleProvider struct {
 	// The Google project to work in
 	project string
 	// Enabled dry-run will print any modifying actions rather than execute them.
@@ -106,7 +106,7 @@ type googleProvider struct {
 }
 
 // NewGoogleProvider initializes a new Google CloudDNS based Provider.
-func NewGoogleProvider(project string, domainFilter string, dryRun bool) (Provider, error) {
+func NewGoogleProvider(project string, domainFilter string, dryRun bool) (*GoogleProvider, error) {
 	gcloud, err := google.DefaultClient(context.TODO(), dns.NdevClouddnsReadwriteScope)
 	if err != nil {
 		return nil, err
@@ -124,7 +124,7 @@ func NewGoogleProvider(project string, domainFilter string, dryRun bool) (Provid
 		return nil, err
 	}
 
-	provider := &googleProvider{
+	provider := &GoogleProvider{
 		project:      project,
 		domainFilter: domainFilter,
 		dryRun:       dryRun,
@@ -137,7 +137,7 @@ func NewGoogleProvider(project string, domainFilter string, dryRun bool) (Provid
 }
 
 // Zones returns the list of hosted zones.
-func (p *googleProvider) Zones() (map[string]*dns.ManagedZone, error) {
+func (p *GoogleProvider) Zones() (map[string]*dns.ManagedZone, error) {
 	zones := make(map[string]*dns.ManagedZone)
 
 	f := func(resp *dns.ManagedZonesListResponse) error {
@@ -158,7 +158,7 @@ func (p *googleProvider) Zones() (map[string]*dns.ManagedZone, error) {
 }
 
 // Records returns the list of records in all relevant zones.
-func (p *googleProvider) Records() (endpoints []*endpoint.Endpoint, _ error) {
+func (p *GoogleProvider) Records() (endpoints []*endpoint.Endpoint, _ error) {
 	zones, err := p.Zones()
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ func (p *googleProvider) Records() (endpoints []*endpoint.Endpoint, _ error) {
 }
 
 // CreateRecords creates a given set of DNS records in the given hosted zone.
-func (p *googleProvider) CreateRecords(endpoints []*endpoint.Endpoint) error {
+func (p *GoogleProvider) CreateRecords(endpoints []*endpoint.Endpoint) error {
 	change := &dns.Change{}
 
 	change.Additions = append(change.Additions, newRecords(endpoints)...)
@@ -203,7 +203,7 @@ func (p *googleProvider) CreateRecords(endpoints []*endpoint.Endpoint) error {
 }
 
 // UpdateRecords updates a given set of old records to a new set of records in a given hosted zone.
-func (p *googleProvider) UpdateRecords(records, oldRecords []*endpoint.Endpoint) error {
+func (p *GoogleProvider) UpdateRecords(records, oldRecords []*endpoint.Endpoint) error {
 	change := &dns.Change{}
 
 	change.Additions = append(change.Additions, newRecords(records)...)
@@ -213,7 +213,7 @@ func (p *googleProvider) UpdateRecords(records, oldRecords []*endpoint.Endpoint)
 }
 
 // DeleteRecords deletes a given set of DNS records in a given zone.
-func (p *googleProvider) DeleteRecords(endpoints []*endpoint.Endpoint) error {
+func (p *GoogleProvider) DeleteRecords(endpoints []*endpoint.Endpoint) error {
 	change := &dns.Change{}
 
 	change.Deletions = append(change.Deletions, newRecords(endpoints)...)
@@ -222,7 +222,7 @@ func (p *googleProvider) DeleteRecords(endpoints []*endpoint.Endpoint) error {
 }
 
 // ApplyChanges applies a given set of changes in a given zone.
-func (p *googleProvider) ApplyChanges(changes *plan.Changes) error {
+func (p *GoogleProvider) ApplyChanges(changes *plan.Changes) error {
 	change := &dns.Change{}
 
 	change.Additions = append(change.Additions, newRecords(changes.Create)...)
@@ -236,7 +236,7 @@ func (p *googleProvider) ApplyChanges(changes *plan.Changes) error {
 }
 
 // submitChange takes a zone and a Change and sends it to Google.
-func (p *googleProvider) submitChange(change *dns.Change) error {
+func (p *GoogleProvider) submitChange(change *dns.Change) error {
 	if len(change.Additions) == 0 && len(change.Deletions) == 0 {
 		log.Info("All records are already up to date")
 		return nil

--- a/provider/google_test.go
+++ b/provider/google_test.go
@@ -496,8 +496,8 @@ func validateChangeRecord(t *testing.T, record *dns.ResourceRecordSet, expected 
 	assert.Equal(t, expected.Ttl, record.Ttl)
 }
 
-func newGoogleProvider(t *testing.T, domainFilter string, dryRun bool, records []*endpoint.Endpoint) *googleProvider {
-	provider := &googleProvider{
+func newGoogleProvider(t *testing.T, domainFilter string, dryRun bool, records []*endpoint.Endpoint) *GoogleProvider {
+	provider := &GoogleProvider{
 		project:      "zalando-external-dns-test",
 		domainFilter: domainFilter,
 		dryRun:       false,
@@ -528,7 +528,7 @@ func newGoogleProvider(t *testing.T, domainFilter string, dryRun bool, records [
 	return provider
 }
 
-func createZone(t *testing.T, provider *googleProvider, zone *dns.ManagedZone) {
+func createZone(t *testing.T, provider *GoogleProvider, zone *dns.ManagedZone) {
 	zone.Description = "Testing zone for kubernetes.io/external-dns"
 
 	if _, err := provider.managedZonesClient.Create("zalando-external-dns-test", zone).Do(); err != nil {
@@ -538,7 +538,7 @@ func createZone(t *testing.T, provider *googleProvider, zone *dns.ManagedZone) {
 	}
 }
 
-func setupGoogleRecords(t *testing.T, provider *googleProvider, endpoints []*endpoint.Endpoint) {
+func setupGoogleRecords(t *testing.T, provider *GoogleProvider, endpoints []*endpoint.Endpoint) {
 	clearGoogleRecords(t, provider, "zone-1-ext-dns-test-2-gcp-zalan-do")
 	clearGoogleRecords(t, provider, "zone-2-ext-dns-test-2-gcp-zalan-do")
 
@@ -555,7 +555,7 @@ func setupGoogleRecords(t *testing.T, provider *googleProvider, endpoints []*end
 	validateEndpoints(t, records, endpoints)
 }
 
-func clearGoogleRecords(t *testing.T, provider *googleProvider, zone string) {
+func clearGoogleRecords(t *testing.T, provider *GoogleProvider, zone string) {
 	recordSets := []*dns.ResourceRecordSet{}
 	require.NoError(t, provider.resourceRecordSetsClient.List(provider.project, zone).Pages(context.TODO(), func(resp *dns.ResourceRecordSetsListResponse) error {
 		for _, r := range resp.Rrsets {


### PR DESCRIPTION
This PR unifies implementation details of providers (previously only google implementation is made private) and in the view of that it makes sense to not hide the implementation details of each provider, therefore return actual struct. 

/cc @linki 