### PR TITLE
Mark compatibility with route53-kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Here's a rough outline on what is to come (subject to change):
 
 - [ ] Ability to replace Kops' [DNS Controller](https://github.com/kubernetes/kops/tree/master/dns-controller)
 - [ ] Ability to replace Zalando's [Mate](https://github.com/zalando-incubator/mate)
-- [ ] Ability to replace Molecule Software's [route53-kubernetes](https://github.com/wearemolecule/route53-kubernetes)
+- [x] Ability to replace Molecule Software's [route53-kubernetes](https://github.com/wearemolecule/route53-kubernetes)
 
 ### Yet to be defined
 


### PR DESCRIPTION
We've been running external-dns in compatibility mode with route53-kubernetes for a few weeks with no issues. I think it's safe to say that we've met this requirement for 1.0.

Awesome job everyone!

Also, I've officially deprecated route53-kubernetes and will be directing new users to this repo in the future.

lmk if there are any other docs I should update.