### PR TITLE
Support for multiple targets

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -43,32 +43,20 @@ func (p *mockProvider) Records() ([]*endpoint.Endpoint, error) {
 
 // ApplyChanges validates that the passed in changes satisfy the assumtions.
 func (p *mockProvider) ApplyChanges(changes *plan.Changes) error {
-	if len(changes.Create) != len(p.ExpectChanges.Create) {
-		return errors.New("number of created records is wrong")
+	if !testutils.SameEndpoints(p.ExpectChanges.Create, changes.Create) {
+		return errors.New("created record is wrong")
 	}
 
-	for i := range changes.Create {
-		if changes.Create[i].DNSName != p.ExpectChanges.Create[i].DNSName || changes.Create[i].Target != p.ExpectChanges.Create[i].Target {
-			return errors.New("created record is wrong")
-		}
+	if !testutils.SameEndpoints(p.ExpectChanges.UpdateNew, changes.UpdateNew) {
+		return errors.New("created record is wrong")
 	}
 
-	for i := range changes.UpdateNew {
-		if changes.UpdateNew[i].DNSName != p.ExpectChanges.UpdateNew[i].DNSName || changes.UpdateNew[i].Target != p.ExpectChanges.UpdateNew[i].Target {
-			return errors.New("delete record is wrong")
-		}
+	if !testutils.SameEndpoints(p.ExpectChanges.UpdateOld, changes.UpdateOld) {
+		return errors.New("created record is wrong")
 	}
 
-	for i := range changes.UpdateOld {
-		if changes.UpdateOld[i].DNSName != p.ExpectChanges.UpdateOld[i].DNSName || changes.UpdateOld[i].Target != p.ExpectChanges.UpdateOld[i].Target {
-			return errors.New("delete record is wrong")
-		}
-	}
-
-	for i := range changes.Delete {
-		if changes.Delete[i].DNSName != p.ExpectChanges.Delete[i].DNSName || changes.Delete[i].Target != p.ExpectChanges.Delete[i].Target {
-			return errors.New("delete record is wrong")
-		}
+	if !testutils.SameEndpoints(p.ExpectChanges.Delete, changes.Delete) {
+		return errors.New("created record is wrong")
 	}
 
 	return nil
@@ -91,11 +79,11 @@ func TestRunOnce(t *testing.T) {
 	source.On("Endpoints").Return([]*endpoint.Endpoint{
 		{
 			DNSName: "create-record",
-			Target:  "1.2.3.4",
+			Targets: []string{"1.2.3.4"},
 		},
 		{
 			DNSName: "update-record",
-			Target:  "8.8.4.4",
+			Targets: []string{"8.8.4.4"},
 		},
 	}, nil)
 
@@ -104,25 +92,25 @@ func TestRunOnce(t *testing.T) {
 		[]*endpoint.Endpoint{
 			{
 				DNSName: "update-record",
-				Target:  "8.8.8.8",
+				Targets: []string{"8.8.8.8"},
 			},
 			{
 				DNSName: "delete-record",
-				Target:  "4.3.2.1",
+				Targets: []string{"4.3.2.1"},
 			},
 		},
 		&plan.Changes{
 			Create: []*endpoint.Endpoint{
-				{DNSName: "create-record", Target: "1.2.3.4"},
+				{DNSName: "create-record", Targets: []string{"1.2.3.4"}},
 			},
 			UpdateNew: []*endpoint.Endpoint{
-				{DNSName: "update-record", Target: "8.8.4.4"},
+				{DNSName: "update-record", Targets: []string{"8.8.4.4"}},
 			},
 			UpdateOld: []*endpoint.Endpoint{
-				{DNSName: "update-record", Target: "8.8.8.8"},
+				{DNSName: "update-record", Targets: []string{"8.8.8.8"}},
 			},
 			Delete: []*endpoint.Endpoint{
-				{DNSName: "delete-record", Target: "4.3.2.1"},
+				{DNSName: "delete-record", Targets: []string{"4.3.2.1"}},
 			},
 		},
 	)

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -44,8 +44,8 @@ func (ttl TTL) IsConfigured() bool {
 type Endpoint struct {
 	// The hostname of the DNS record
 	DNSName string
-	// The target the DNS record points to
-	Target string
+	// The targets the DNS record points to
+	Targets []string
 	// RecordType type of record, e.g. CNAME, A, TXT etc
 	RecordType string
 	// TTL for the record
@@ -55,18 +55,34 @@ type Endpoint struct {
 }
 
 // NewEndpoint initialization method to be used to create an endpoint
-func NewEndpoint(dnsName, target, recordType string) *Endpoint {
-	return NewEndpointWithTTL(dnsName, target, recordType, TTL(0))
+func NewEndpoint(dnsName string, targets []string, recordType string) *Endpoint {
+	return NewEndpointWithTTL(dnsName, targets, recordType, TTL(0))
 }
 
 // NewEndpointWithTTL initialization method to be used to create an endpoint with a TTL struct
-func NewEndpointWithTTL(dnsName, target, recordType string, ttl TTL) *Endpoint {
+func NewEndpointWithTTL(dnsName string, targets []string, recordType string, ttl TTL) *Endpoint {
+	for i := range targets {
+		targets[i] = strings.TrimSuffix(targets[i], ".")
+	}
 	return &Endpoint{
 		DNSName:    strings.TrimSuffix(dnsName, "."),
-		Target:     strings.TrimSuffix(target, "."),
+		Targets:    targets,
 		RecordType: recordType,
 		Labels:     map[string]string{},
 		RecordTTL:  ttl,
+	}
+}
+
+func NewEndpointWithLabels(dnsName string, targets []string, recordType string, labels map[string]string) *Endpoint {
+	for i := range targets {
+		targets[i] = strings.TrimSuffix(targets[i], ".")
+	}
+	return &Endpoint{
+		DNSName:    strings.TrimSuffix(dnsName, "."),
+		Targets:    targets,
+		RecordType: recordType,
+		Labels:     labels,
+		RecordTTL:  TTL(0),
 	}
 }
 
@@ -80,5 +96,5 @@ func (e *Endpoint) MergeLabels(labels map[string]string) {
 }
 
 func (e *Endpoint) String() string {
-	return fmt.Sprintf("%s %d IN %s %s", e.DNSName, e.RecordTTL, e.RecordType, e.Target)
+	return fmt.Sprintf("%s %d IN %s %s %s", e.DNSName, e.RecordTTL, e.RecordType, e.Targets, e.Labels)
 }

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -23,22 +23,40 @@ import (
 )
 
 func TestNewEndpoint(t *testing.T) {
-	e := NewEndpoint("example.org", "foo.com", "CNAME")
-	if e.DNSName != "example.org" || e.Target != "foo.com" || e.RecordType != "CNAME" {
+	targets := []string{"foo.com", "bar.com"}
+	e := NewEndpoint("example.org", targets, "CNAME")
+	if e.DNSName != "example.org" || e.RecordType != "CNAME" {
 		t.Error("endpoint is not initialized correctly")
+	}
+	if len(e.Targets) != len(targets) {
+		t.Fatalf("expected %d target(s), got %d", len(targets), len(e.Targets))
+	}
+	for i := range e.Targets {
+		if e.Targets[i] != targets[i] {
+			t.Error("endpoint is not initialized correctly")
+		}
 	}
 	if e.Labels == nil {
 		t.Error("Labels is not initialized")
 	}
 
-	w := NewEndpoint("example.org.", "load-balancer.com.", "")
-	if w.DNSName != "example.org" || w.Target != "load-balancer.com" || w.RecordType != "" {
+	targets = []string{"load-balancer.com.", "load-balancer.bar."}
+	w := NewEndpoint("example.org.", targets, "")
+	if w.DNSName != "example.org" || w.RecordType != "" {
 		t.Error("endpoint is not initialized correctly")
+	}
+	if len(w.Targets) != len(targets) {
+		t.Fatalf("expected %d target(s), got %d", len(targets), len(w.Targets))
+	}
+	for i := range []string{"load-balancer.com", "elb.amazonaws.com"} {
+		if w.Targets[i] != targets[i] {
+			t.Error("endpoint is not initialized correctly")
+		}
 	}
 }
 
 func TestMergeLabels(t *testing.T) {
-	e := NewEndpoint("abc.com", "1.2.3.4", "A")
+	e := NewEndpoint("abc.com", []string{"1.2.3.4"}, "A")
 	e.Labels = map[string]string{
 		"foo": "bar",
 		"baz": "qux",

--- a/internal/testutils/endpoint_test.go
+++ b/internal/testutils/endpoint_test.go
@@ -19,52 +19,316 @@ package testutils
 import (
 	"fmt"
 	"sort"
+	"testing"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func ExampleSameEndpoints() {
 	eps := []*endpoint.Endpoint{
 		{
 			DNSName: "example.org",
-			Target:  "load-balancer.org",
+			Targets: []string{"load-balancer.org"},
+		},
+		{
+			DNSName: "example2.org",
+			Targets: []string{"load-balancer.org", "load-balancer.com"},
 		},
 		{
 			DNSName:    "example.org",
-			Target:     "load-balancer.org",
+			Targets:    []string{"load-balancer.org"},
 			RecordType: endpoint.RecordTypeTXT,
 		},
 		{
 			DNSName:    "abc.com",
-			Target:     "something",
+			Targets:    []string{"something"},
 			RecordType: endpoint.RecordTypeTXT,
 		},
 		{
 			DNSName:    "abc.com",
-			Target:     "1.2.3.4",
+			Targets:    []string{"1.2.3.4"},
 			RecordType: endpoint.RecordTypeA,
 		},
 		{
 			DNSName:    "bbc.com",
-			Target:     "foo.com",
+			Targets:    []string{"foo.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 		},
 		{
 			DNSName:    "cbc.com",
-			Target:     "foo.com",
+			Targets:    []string{"foo.com"},
 			RecordType: "CNAME",
 			RecordTTL:  endpoint.TTL(60),
 		},
 	}
-	sort.Sort(byAllFields(eps))
+	sort.Slice(eps, func(i, j int) bool { return eps[i].String() < eps[j].String() })
 	for _, ep := range eps {
 		fmt.Println(ep)
 	}
 	// Output:
-	// abc.com 0 IN A 1.2.3.4
-	// abc.com 0 IN TXT something
-	// bbc.com 0 IN CNAME foo.com
-	// cbc.com 60 IN CNAME foo.com
-	// example.org 0 IN  load-balancer.org
-	// example.org 0 IN TXT load-balancer.org
+	// abc.com 0 IN A [1.2.3.4]
+	// abc.com 0 IN TXT [something]
+	// bbc.com 0 IN CNAME [foo.com]
+	// cbc.com 60 IN CNAME [foo.com]
+	// example.org 0 IN  [load-balancer.org]
+	// example.org 0 IN TXT [load-balancer.org]
+	// example2.org 0 IN  [load-balancer.org load-balancer.com]
 }
+
+func TestSameEndpointDifferentHostnames(t *testing.T) {
+	// a blank endpoint
+	blank := &endpoint.Endpoint{}
+	// a foo endpoint
+	foo := endpoint.NewEndpoint("foo", []string{"8.8.8.8"}, "A")
+	// a bar endpoint
+	bar := endpoint.NewEndpoint("bar", []string{"8.8.8.8"}, "A")
+
+	for _, tc := range []struct {
+		endpoint  *endpoint.Endpoint
+		candidate *endpoint.Endpoint
+		same      bool
+	}{
+		// Two blank endpoints are equal
+		{blank, blank, true},
+		// Two endpoints with the same hostname are equal
+		{foo, foo, true},
+		// A blank endpoint differs from an endpoint with content
+		{blank, foo, false},
+		// Two endpoints with a different hostname are different
+		{foo, bar, false},
+	} {
+		assert.Equal(t, tc.same, SameEndpoint(tc.endpoint, tc.candidate))
+	}
+}
+
+func TestSameEndpointDifferentTypes(t *testing.T) {
+	// a blank endpoint
+	blank := &endpoint.Endpoint{}
+	// a foo endpoint
+	foo := endpoint.NewEndpoint("foo", []string{"8.8.8.8"}, "A")
+	// a bar endpoint
+	bar := endpoint.NewEndpoint("foo", []string{"8.8.8.8"}, "CNAME")
+
+	for _, tc := range []struct {
+		endpoint  *endpoint.Endpoint
+		candidate *endpoint.Endpoint
+		same      bool
+	}{
+		// Two blank endpoints are equal
+		{blank, blank, true},
+		// Two endpoints with the same types are equal
+		{foo, foo, true},
+		// A blank endpoint differs from an endpoint with a type
+		{blank, foo, false},
+		// Two endpoints with different types are different
+		{foo, bar, false},
+	} {
+		assert.Equal(t, tc.same, SameEndpoint(tc.endpoint, tc.candidate))
+	}
+}
+
+func TestSameEndpointDifferentTargets(t *testing.T) {
+	// a blank endpoint
+	blank := &endpoint.Endpoint{}
+	// a single-target endpoint
+	single := endpoint.NewEndpoint("foo", []string{"8.8.4.4"}, "A")
+	// another single-target endpoint
+	singleV2 := endpoint.NewEndpoint("foo", []string{"8.8.8.8"}, "A")
+	// a multiple-target endpoint
+	multiple := endpoint.NewEndpoint("foo", []string{"8.8.4.4", "8.8.8.8"}, "A")
+	// a multiple-target endpoint but in reverse order
+	multipleReverse := endpoint.NewEndpoint("foo", []string{"8.8.8.8", "8.8.4.4"}, "A")
+	// another multiple-target endpoint
+	multipleV2 := endpoint.NewEndpoint("foo", []string{"8.8.4.4", "1.2.3.4"}, "A")
+
+	for _, tc := range []struct {
+		endpoint  *endpoint.Endpoint
+		candidate *endpoint.Endpoint
+		same      bool
+	}{
+		// Two blank endpoints are equal
+		{blank, blank, true},
+		// The same single-target endpoint is equal
+		{single, single, true},
+		// The same multiple-target endpoint is equal
+		{multiple, multiple, true},
+		// The same multiple-target endpoint with different order is equal
+		{multiple, multipleReverse, true},
+		// A blank endpoint differs from an endpoint with a target
+		{blank, single, false},
+		// Two endpoints differ if their single target differs
+		{single, singleV2, false},
+		// Two endpoints differ if one of their targets differ
+		{multiple, multipleV2, false},
+		// Two endpoints always differ if their number of targets differ
+		{single, multiple, false},
+		// The order of comparison shouldn't lead to a panic
+		{multiple, single, false},
+	} {
+		assert.Equal(t, tc.same, SameEndpoint(tc.endpoint, tc.candidate))
+	}
+}
+
+func TestSameEndpointDifferentLabels(t *testing.T) {
+	// a blank endpoint
+	blank := &endpoint.Endpoint{}
+	// a single-label endpoint
+	single := endpoint.NewEndpointWithLabels("foo", []string{"8.8.8.8"}, "A", map[string]string{"foo": "bar"})
+	// another single-target endpoint
+	singleV2 := endpoint.NewEndpointWithLabels("foo", []string{"8.8.8.8"}, "A", map[string]string{"foo": "baz"})
+	// a multiple-target endpoint
+	multiple := endpoint.NewEndpointWithLabels("foo", []string{"8.8.8.8"}, "A", map[string]string{"foo": "bar", "qux": "wambo"})
+	// another multiple-target endpoint with a different label value
+	multipleV2 := endpoint.NewEndpointWithLabels("foo", []string{"8.8.8.8"}, "A", map[string]string{"foo": "bar", "qux": "rambo"})
+	// another multiple-target endpoint with a different label key
+	multipleV3 := endpoint.NewEndpointWithLabels("foo", []string{"8.8.8.8"}, "A", map[string]string{"foo": "bar", "quux": "wambo"})
+
+	for _, tc := range []struct {
+		endpoint  *endpoint.Endpoint
+		candidate *endpoint.Endpoint
+		same      bool
+	}{
+		// Two blank endpoints are equal
+		{blank, blank, true},
+		// The same single-label endpoint is equal
+		{single, single, true},
+		// The same multiple-label endpoint is equal
+		{multiple, multiple, true},
+		// A blank endpoint differs from an endpoint with a label
+		{blank, single, false},
+		// Two endpoints differ if their single label differs
+		{single, singleV2, false},
+		// Two endpoints differ if one of their labels differs
+		{multiple, multipleV2, false},
+		// Two endpoints differ if one of their labels differs
+		{multiple, multipleV3, false},
+		// Two endpoints always differ if their number of targets differ
+		{single, multiple, false},
+		// The order of comparison shouldn't lead to a panic
+		{multiple, single, false},
+	} {
+		assert.Equal(t, tc.same, SameEndpoint(tc.endpoint, tc.candidate))
+	}
+}
+
+func TestSameEndpoints(t *testing.T) {
+	// two simple endpoints
+	foo := endpoint.NewEndpoint("foo", []string{"8.8.8.8"}, "A")
+	bar := endpoint.NewEndpoint("bar", []string{"8.8.4.4"}, "A")
+	baz := endpoint.NewEndpoint("baz", []string{"1.2.3.4"}, "A")
+
+	// an empty list of endpoints
+	empty := []*endpoint.Endpoint{}
+	// a list containing a single endpoint
+	single := []*endpoint.Endpoint{foo}
+	// a list containing another single endpoint
+	singleV2 := []*endpoint.Endpoint{bar}
+	// a list containing multiple endpoints
+	multiple := []*endpoint.Endpoint{foo, bar}
+	// a list containing multiple endpoints in reverse order
+	multipleReverse := []*endpoint.Endpoint{bar, foo}
+	// a list containing other multiple endpoints
+	multipleV2 := []*endpoint.Endpoint{foo, baz}
+
+	for _, tc := range []struct {
+		endpoints  []*endpoint.Endpoint
+		candidates []*endpoint.Endpoint
+		same       bool
+	}{
+		// Two empty lists of endpoints are equal
+		{empty, empty, true},
+		// Two single-item list with the same item are equal
+		{single, single, true},
+		// Two multiple-item lists with the same items are equal
+		{multiple, multiple, true},
+		// The same multiple-item lists with different order are equal
+		{multiple, multipleReverse, true},
+		// An empty list of endpoints is different to a non-empty list
+		{empty, single, false},
+		// Two single-item list with different items are different
+		{single, singleV2, false},
+		// Two multiple-item lists with different items are different
+		{multiple, multipleV2, false},
+		// Two list always differ if their number of elements differ
+		{single, multiple, false},
+		// The order of comparison shouldn't lead to a panic
+		{multiple, single, false},
+	} {
+		assert.Equal(t, tc.same, SameEndpoints(tc.endpoints, tc.candidates))
+	}
+}
+
+// We need this?
+// eps := []*endpoint.Endpoint{
+// 	{
+// 		DNSName: "example.org",
+// 		Targets: []string{"load-balancer.org"},
+// 	},
+// 	{
+// 		DNSName:    "example.org",
+// 		Targets:    []string{"load-balancer.org"},
+// 		RecordType: endpoint.RecordTypeTXT,
+// 	},
+// 	{
+// 		DNSName:    "abc.com",
+// 		Targets:    []string{"something"},
+// 		RecordType: endpoint.RecordTypeTXT,
+// 	},
+// 	{
+// 		DNSName:    "abc.com",
+// 		Targets:    []string{"1.2.3.4"},
+// 		RecordType: endpoint.RecordTypeA,
+// 	},
+// 	{
+// 		DNSName:    "bbc.com",
+// 		Targets:    []string{"foo.com"},
+// 		RecordType: endpoint.RecordTypeCNAME,
+// 	},
+// 	{
+// 		DNSName:    "cbc.com",
+// 		Targets:    []string{"foo.com"},
+// 		RecordType: "CNAME",
+// 		RecordTTL:  endpoint.TTL(60),
+// 	},
+//
+
+// func ExampleSameEndpoints() {
+// 	eps := []*endpoint.Endpoint{
+// 		{
+// 			DNSName: "example.org",
+// 			Targets: []string{"load-balancer.org", "load-balancer-2.org"},
+// 		},
+// 		{
+// 			DNSName:    "example.org",
+// 			Targets:    []string{"load-balancer.org", "load-balancer-2.org"},
+// 			RecordType: "TXT",
+// 		},
+// 		{
+// 			DNSName:    "abc.com",
+// 			Targets:    []string{"something", "else"},
+// 			RecordType: "TXT",
+// 		},
+// 		{
+// 			DNSName:    "abc.com",
+// 			Targets:    []string{"1.2.3.4", "8.8.8.8"},
+// 			RecordType: "A",
+// 		},
+// 		{
+// 			DNSName:    "bbc.com",
+// 			Targets:    []string{"foo.com", "bar.com"},
+// 			RecordType: "CNAME",
+// 		},
+// 	}
+// 	sort.Sort(byAllFields(eps))
+// 	for _, ep := range eps {
+// 		fmt.Println(ep)
+// 	}
+// 	// Output:
+// 	// abc.com -> [something else] (type "TXT")
+// 	// abc.com -> [1.2.3.4 8.8.8.8] (type "A")
+// 	// bbc.com -> [foo.com bar.com] (type "CNAME")
+// 	// example.org -> [load-balancer.org load-balancer-2.org] (type "")
+// 	// example.org -> [load-balancer.org load-balancer-2.org] (type "TXT")
+// }

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 	"github.com/kubernetes-incubator/external-dns/internal/testutils"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestCalculate tests that a plan can calculate actions to move a list of
@@ -30,31 +32,31 @@ func TestCalculate(t *testing.T) {
 	// empty list of records
 	empty := []*endpoint.Endpoint{}
 	// a simple entry
-	fooV1 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", "v1", endpoint.RecordTypeCNAME)}
+	fooV1 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", []string{"v1", "vv1"}, endpoint.RecordTypeCNAME)}
 	// the same entry but with different target
-	fooV2 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", "v2", endpoint.RecordTypeCNAME)}
+	fooV2 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", []string{"v2", "vv2"}, endpoint.RecordTypeCNAME)}
 	// another simple entry
-	bar := []*endpoint.Endpoint{endpoint.NewEndpoint("bar", "v1", endpoint.RecordTypeCNAME)}
+	bar := []*endpoint.Endpoint{endpoint.NewEndpoint("bar", []string{"v1", "vv1"}, endpoint.RecordTypeCNAME)}
 
 	// test case with labels
-	noLabels := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", "v2", endpoint.RecordTypeCNAME)}
-	labeledV2 := []*endpoint.Endpoint{newEndpointWithOwner("foo", "v2", "123")}
-	labeledV1 := []*endpoint.Endpoint{newEndpointWithOwner("foo", "v1", "123")}
+	noLabels := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", []string{"v2", "vv2"}, endpoint.RecordTypeCNAME)}
+	labeledV2 := []*endpoint.Endpoint{newEndpointWithOwner("foo", []string{"v2", "vv2"}, "123")}
+	labeledV1 := []*endpoint.Endpoint{newEndpointWithOwner("foo", []string{"v1", "vv1"}, "123")}
 
 	// test case with type inheritance
-	noType := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", "v2", "")}
-	typedV2 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", "v2", endpoint.RecordTypeA)}
-	typedV1 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", "v1", endpoint.RecordTypeA)}
+	noType := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", []string{"v2", "vv2"}, "")}
+	typedV2 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", []string{"v2", "vv2"}, endpoint.RecordTypeA)}
+	typedV1 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", []string{"v1", "vv1"}, endpoint.RecordTypeA)}
 
 	// test case with TTL
 	ttl := endpoint.TTL(300)
 	ttl2 := endpoint.TTL(50)
-	ttlV1 := []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("foo", "v1", endpoint.RecordTypeCNAME, ttl)}
-	ttlV2 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", "v1", endpoint.RecordTypeCNAME)}
-	ttlV3 := []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("foo", "v1", endpoint.RecordTypeCNAME, ttl)}
-	ttlV4 := []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("foo", "v1", endpoint.RecordTypeCNAME, ttl2)}
-	ttlV5 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", "v2", endpoint.RecordTypeCNAME)}
-	ttlV6 := []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("foo", "v2", endpoint.RecordTypeCNAME, ttl)}
+	ttlV1 := []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("foo", []string{"v1", "vv1"}, endpoint.RecordTypeCNAME, ttl)}
+	ttlV2 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", []string{"v1", "vv1"}, endpoint.RecordTypeCNAME)}
+	ttlV3 := []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("foo", []string{"v1", "vv1"}, endpoint.RecordTypeCNAME, ttl)}
+	ttlV4 := []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("foo", []string{"v1", "vv1"}, endpoint.RecordTypeCNAME, ttl2)}
+	ttlV5 := []*endpoint.Endpoint{endpoint.NewEndpoint("foo", []string{"v2", "vv2"}, endpoint.RecordTypeCNAME)}
+	ttlV6 := []*endpoint.Endpoint{endpoint.NewEndpointWithTTL("foo", []string{"v2", "vv2"}, endpoint.RecordTypeCNAME, ttl)}
 
 	for _, tc := range []struct {
 		policies                             []Policy
@@ -107,10 +109,10 @@ func TestCalculate(t *testing.T) {
 
 // BenchmarkCalculate benchmarks the Calculate method.
 func BenchmarkCalculate(b *testing.B) {
-	foo := endpoint.NewEndpoint("foo", "v1", "")
-	barV1 := endpoint.NewEndpoint("bar", "v1", "")
-	barV2 := endpoint.NewEndpoint("bar", "v2", "")
-	baz := endpoint.NewEndpoint("baz", "v1", "")
+	foo := endpoint.NewEndpoint("foo", []string{"v1", "vv1"}, "")
+	barV1 := endpoint.NewEndpoint("bar", []string{"v1", "vv1"}, "")
+	barV2 := endpoint.NewEndpoint("bar", []string{"v2", "vv2"}, "")
+	baz := endpoint.NewEndpoint("baz", []string{"v1", "vv1"}, "")
 
 	plan := &Plan{
 		Current: []*endpoint.Endpoint{foo, barV1},
@@ -124,10 +126,10 @@ func BenchmarkCalculate(b *testing.B) {
 
 // ExamplePlan shows how plan can be used.
 func ExamplePlan() {
-	foo := endpoint.NewEndpoint("foo.example.com", "1.2.3.4", "")
-	barV1 := endpoint.NewEndpoint("bar.example.com", "8.8.8.8", "")
-	barV2 := endpoint.NewEndpoint("bar.example.com", "8.8.4.4", "")
-	baz := endpoint.NewEndpoint("baz.example.com", "6.6.6.6", "")
+	foo := endpoint.NewEndpoint("foo.example.com", []string{"1.2.3.4", "4.3.2.1"}, "")
+	barV1 := endpoint.NewEndpoint("bar.example.com", []string{"8.8.8.8", "7.7.7.7"}, "")
+	barV2 := endpoint.NewEndpoint("bar.example.com", []string{"8.8.4.4", "7.7.3.3"}, "")
+	baz := endpoint.NewEndpoint("baz.example.com", []string{"6.6.6.6", "5.5.5.5"}, "")
 
 	// Plan where
 	// * foo should be deleted
@@ -182,8 +184,52 @@ func validateEntries(t *testing.T, entries, expected []*endpoint.Endpoint) {
 	}
 }
 
-func newEndpointWithOwner(dnsName, target, ownerID string) *endpoint.Endpoint {
-	e := endpoint.NewEndpoint(dnsName, target, endpoint.RecordTypeCNAME)
+func newEndpointWithOwner(dnsName string, targets []string, ownerID string) *endpoint.Endpoint {
+	e := endpoint.NewEndpoint(dnsName, targets, endpoint.RecordTypeCNAME)
 	e.Labels[endpoint.OwnerLabelKey] = ownerID
 	return e
+}
+
+func TestSameTargets(t *testing.T) {
+	// an empty list of endpoints
+	empty := []string{}
+	// a list containing a single target
+	single := []string{"8.8.8.8"}
+	// a list containing another single target
+	singleV2 := []string{"1.2.3.4"}
+	// a list containing a multiple targets
+	multiple := []string{"8.8.4.4", "8.8.8.8"}
+	// a list containing a multiple targets in reverse order
+	multipleReverse := []string{"8.8.8.8", "8.8.4.4"}
+	// a list containing another multiple targets
+	multipleV2 := []string{"8.8.4.4", "1.2.3.4"}
+
+	for _, tc := range []struct {
+		targets    []string
+		candidates []string
+		same       bool
+		difference TargetDifference
+	}{
+		// Two empty lists are equal
+		{empty, empty, true, TargetDifference{}},
+		// Two single-target lists are equal
+		{single, single, true, TargetDifference{}},
+		// Two multiple-target lists are equal
+		{multiple, multiple, true, TargetDifference{}},
+		// Two multiple-target lists are equal
+		{multiple, multipleReverse, true, TargetDifference{}},
+		// An empty list differs from a single-target list
+		{empty, single, false, TargetDifference{Add: []string{"8.8.8.8"}}},
+		// Two single-item list with different items are different
+		{single, singleV2, false, TargetDifference{Add: []string{"1.2.3.4"}, Delete: []string{"8.8.8.8"}}},
+		// Two multiple-item lists with different items are different
+		{multiple, multipleV2, false, TargetDifference{Add: []string{"1.2.3.4"}, Delete: []string{"8.8.8.8"}}},
+		// Two list always differ if their number of elements differ
+		{single, multiple, false, TargetDifference{Add: []string{"8.8.4.4"}}},
+		// The order of comparison shouldn't lead to a panic
+		{multiple, single, false, TargetDifference{Delete: []string{"8.8.4.4"}}},
+	} {
+		assert.Equal(t, tc.same, SameTargets(tc.targets, tc.candidates))
+		assert.Equal(t, tc.difference, CalculateTargetDifference(tc.targets, tc.candidates))
+	}
 }

--- a/plan/policy_test.go
+++ b/plan/policy_test.go
@@ -28,12 +28,12 @@ func TestApply(t *testing.T) {
 	// empty list of records
 	empty := []*endpoint.Endpoint{}
 	// a simple entry
-	fooV1 := []*endpoint.Endpoint{{DNSName: "foo", Target: "v1"}}
+	fooV1 := []*endpoint.Endpoint{{DNSName: "foo", Targets: []string{"v1"}}}
 	// the same entry but with different target
-	fooV2 := []*endpoint.Endpoint{{DNSName: "foo", Target: "v2"}}
+	fooV2 := []*endpoint.Endpoint{{DNSName: "foo", Targets: []string{"v2"}}}
 	// another two simple entries
-	bar := []*endpoint.Endpoint{{DNSName: "bar", Target: "v1"}}
-	baz := []*endpoint.Endpoint{{DNSName: "baz", Target: "v1"}}
+	bar := []*endpoint.Endpoint{{DNSName: "bar", Targets: []string{"v1"}}}
+	baz := []*endpoint.Endpoint{{DNSName: "baz", Targets: []string{"v1"}}}
 
 	for _, tc := range []struct {
 		policy   Policy

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
+
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 	"github.com/kubernetes-incubator/external-dns/internal/testutils"
 	"github.com/kubernetes-incubator/external-dns/plan"
@@ -202,22 +203,22 @@ func TestAWSZones(t *testing.T) {
 
 func TestAWSRecords(t *testing.T) {
 	provider := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneTypeFilter(""), false, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("list-test.zone-1.ext-dns-test-2.teapot.zalan.do", "1.2.3.4", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("list-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("*.wildcard-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpoint("list-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("*.wildcard-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpointWithTTL("list-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("list-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("*.wildcard-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpoint("list-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.eu-central-1.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("*.wildcard-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.eu-central-1.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	})
 
 	records, err := provider.Records()
 	require.NoError(t, err)
 
 	validateEndpoints(t, records, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("list-test.zone-1.ext-dns-test-2.teapot.zalan.do", "1.2.3.4", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("list-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("*.wildcard-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpoint("list-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("*.wildcard-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpointWithTTL("list-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("list-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("*.wildcard-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpoint("list-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.eu-central-1.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("*.wildcard-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.eu-central-1.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	})
 }
 
@@ -226,10 +227,10 @@ func TestAWSCreateRecords(t *testing.T) {
 	provider := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneTypeFilter(""), false, []*endpoint.Endpoint{})
 
 	records := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpointWithTTL("create-test-cname-custom-ttl.zone-1.ext-dns-test-2.teapot.zalan.do", "172.17.0.1", endpoint.RecordTypeA, customTTL),
-		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpointWithTTL("create-test-cname-custom-ttl.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"172.17.0.1"}, endpoint.RecordTypeA, customTTL),
+		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	}
 
 	require.NoError(t, provider.CreateRecords(records))
@@ -238,29 +239,29 @@ func TestAWSCreateRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	validateEndpoints(t, records, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", "1.2.3.4", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("create-test-cname-custom-ttl.zone-1.ext-dns-test-2.teapot.zalan.do", "172.17.0.1", endpoint.RecordTypeA, customTTL),
-		endpoint.NewEndpointWithTTL("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("create-test-cname-custom-ttl.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"172.17.0.1"}, endpoint.RecordTypeA, customTTL),
+		endpoint.NewEndpointWithTTL("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
 	})
 }
 
 func TestAWSUpdateRecords(t *testing.T) {
 	provider := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneTypeFilter(""), false, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.4.4", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
 	})
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", "4.3.2.1", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"4.3.2.1"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	}
 
 	require.NoError(t, provider.UpdateRecords(updatedRecords, currentRecords))
@@ -269,19 +270,19 @@ func TestAWSUpdateRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	validateEndpoints(t, records, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", "1.2.3.4", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", "4.3.2.1", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"4.3.2.1"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
 	})
 }
 
 func TestAWSDeleteRecords(t *testing.T) {
 	originalEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", "1.2.3.4", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "baz.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"baz.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.eu-central-1.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.eu-central-1.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	}
 
 	provider := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneTypeFilter(""), false, originalEndpoints)
@@ -297,41 +298,41 @@ func TestAWSDeleteRecords(t *testing.T) {
 
 func TestAWSApplyChanges(t *testing.T) {
 	provider := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneTypeFilter(""), false, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.4.4", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.4.4", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "qux.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "qux.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"qux.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"qux.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
 	})
 
 	createRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("create-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", "4.3.2.1", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "baz.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "baz.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"4.3.2.1"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"baz.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"baz.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "qux.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "qux.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"qux.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"qux.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	}
 
 	changes := &plan.Changes{
@@ -347,56 +348,56 @@ func TestAWSApplyChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	validateEndpoints(t, records, []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", "1.2.3.4", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.4.4", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", "4.3.2.1", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "baz.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("create-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "baz.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"4.3.2.1"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"baz.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("create-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"baz.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
 	})
 }
 
 func TestAWSApplyChangesDryRun(t *testing.T) {
 	originalEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.4.4", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.4.4", endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "qux.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
-		endpoint.NewEndpointWithTTL("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "qux.elb.amazonaws.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"qux.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
+		endpoint.NewEndpointWithTTL("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"qux.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL)),
 	}
 
 	provider := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneTypeFilter(""), true, originalEndpoints)
 
 	createRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("create-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", "4.3.2.1", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "baz.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "baz.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"4.3.2.1"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"baz.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"baz.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", "qux.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", "qux.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"qux.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", []string{"qux.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	}
 
 	changes := &plan.Changes{
@@ -501,7 +502,7 @@ func TestAWSsubmitChanges(t *testing.T) {
 		for j := 1; j < (hosts + 1); j++ {
 			hostname := fmt.Sprintf("subnet%dhost%d.zone-1.ext-dns-test-2.teapot.zalan.do", i, j)
 			ip := fmt.Sprintf("1.1.%d.%d", i, j)
-			ep := endpoint.NewEndpointWithTTL(hostname, ip, endpoint.RecordTypeA, endpoint.TTL(recordTTL))
+			ep := endpoint.NewEndpointWithTTL(hostname, []string{ip}, endpoint.RecordTypeA, endpoint.TTL(recordTTL))
 			endpoints = append(endpoints, ep)
 		}
 	}
@@ -607,7 +608,7 @@ func TestAWSCreateRecordsWithCNAME(t *testing.T) {
 	provider := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneTypeFilter(""), false, []*endpoint.Endpoint{})
 
 	records := []*endpoint.Endpoint{
-		{DNSName: "create-test.zone-1.ext-dns-test-2.teapot.zalan.do", Target: "foo.example.org", RecordType: endpoint.RecordTypeCNAME},
+		{DNSName: "create-test.zone-1.ext-dns-test-2.teapot.zalan.do", Targets: []string{"foo.example.org"}, RecordType: endpoint.RecordTypeCNAME},
 	}
 
 	require.NoError(t, provider.CreateRecords(records))
@@ -632,7 +633,7 @@ func TestAWSCreateRecordsWithALIAS(t *testing.T) {
 	provider := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneTypeFilter(""), false, []*endpoint.Endpoint{})
 
 	records := []*endpoint.Endpoint{
-		{DNSName: "create-test.zone-1.ext-dns-test-2.teapot.zalan.do", Target: "foo.eu-central-1.elb.amazonaws.com", RecordType: endpoint.RecordTypeCNAME},
+		{DNSName: "create-test.zone-1.ext-dns-test-2.teapot.zalan.do", Targets: []string{"foo.eu-central-1.elb.amazonaws.com"}, RecordType: endpoint.RecordTypeCNAME},
 	}
 
 	require.NoError(t, provider.CreateRecords(records))
@@ -654,15 +655,15 @@ func TestAWSCreateRecordsWithALIAS(t *testing.T) {
 
 func TestAWSisLoadBalancer(t *testing.T) {
 	for _, tc := range []struct {
-		target     string
+		targets    []string
 		recordType string
 		expected   bool
 	}{
-		{"bar.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeCNAME, true},
-		{"foo.example.org", endpoint.RecordTypeCNAME, false},
+		{[]string{"bar.eu-central-1.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, true},
+		{[]string{"foo.example.org"}, endpoint.RecordTypeCNAME, false},
 	} {
 		ep := &endpoint.Endpoint{
-			Target:     tc.target,
+			Targets:    tc.targets,
 			RecordType: tc.recordType,
 		}
 		assert.Equal(t, tc.expected, isAWSLoadBalancer(ep))

--- a/provider/azure.go
+++ b/provider/azure.go
@@ -151,12 +151,12 @@ func (p *AzureProvider) Records() (endpoints []*endpoint.Endpoint, _ error) {
 				log.Errorf("Failed to extract target for '%s' with type '%s'.", name, recordType)
 				return true
 			}
-			ep := endpoint.NewEndpoint(name, target, recordType)
+			ep := endpoint.NewEndpoint(name, []string{target}, recordType)
 			log.Debugf(
 				"Found %s record for '%s' with target '%s'.",
 				ep.RecordType,
 				ep.DNSName,
-				ep.Target,
+				ep.Targets[0],
 			)
 			endpoints = append(endpoints, ep)
 			return true
@@ -306,7 +306,7 @@ func (p *AzureProvider) updateRecords(updated azureChangeMap) {
 					"Would update %s record named '%s' to '%s' for Azure DNS zone '%s'.",
 					endpoint.RecordType,
 					name,
-					endpoint.Target,
+					endpoint.Targets[0],
 					zone,
 				)
 				continue
@@ -316,7 +316,7 @@ func (p *AzureProvider) updateRecords(updated azureChangeMap) {
 				"Updating %s record named '%s' to '%s' for Azure DNS zone '%s'.",
 				endpoint.RecordType,
 				name,
-				endpoint.Target,
+				endpoint.Targets[0],
 				zone,
 			)
 
@@ -337,7 +337,7 @@ func (p *AzureProvider) updateRecords(updated azureChangeMap) {
 					"Failed to update %s record named '%s' to '%s' for DNS zone '%s': %v",
 					endpoint.RecordType,
 					name,
-					endpoint.Target,
+					endpoint.Targets[0],
 					zone,
 					err,
 				)
@@ -367,7 +367,7 @@ func (p *AzureProvider) newRecordSet(endpoint *endpoint.Endpoint) (dns.RecordSet
 				TTL: to.Int64Ptr(azureRecordTTL),
 				ARecords: &[]dns.ARecord{
 					{
-						Ipv4Address: to.StringPtr(endpoint.Target),
+						Ipv4Address: to.StringPtr(endpoint.Targets[0]),
 					},
 				},
 			},
@@ -377,7 +377,7 @@ func (p *AzureProvider) newRecordSet(endpoint *endpoint.Endpoint) (dns.RecordSet
 			RecordSetProperties: &dns.RecordSetProperties{
 				TTL: to.Int64Ptr(azureRecordTTL),
 				CnameRecord: &dns.CnameRecord{
-					Cname: to.StringPtr(endpoint.Target),
+					Cname: to.StringPtr(endpoint.Targets[0]),
 				},
 			},
 		}, nil
@@ -388,7 +388,7 @@ func (p *AzureProvider) newRecordSet(endpoint *endpoint.Endpoint) (dns.RecordSet
 				TxtRecords: &[]dns.TxtRecord{
 					{
 						Value: &[]string{
-							endpoint.Target,
+							endpoint.Targets[0],
 						},
 					},
 				},

--- a/provider/azure_test.go
+++ b/provider/azure_test.go
@@ -119,7 +119,7 @@ func (client *mockRecordsClient) Delete(resourceGroupName string, zoneName strin
 		client.deletedEndpoints,
 		endpoint.NewEndpoint(
 			formatAzureDNSName(relativeRecordSetName, zoneName),
-			"",
+			[]string{""},
 			string(recordType),
 		),
 	)
@@ -131,7 +131,7 @@ func (client *mockRecordsClient) CreateOrUpdate(resourceGroupName string, zoneNa
 		client.updatedEndpoints,
 		endpoint.NewEndpoint(
 			formatAzureDNSName(relativeRecordSetName, zoneName),
-			extractAzureTarget(&parameters),
+			[]string{extractAzureTarget(&parameters)},
 			string(recordType),
 		),
 	)
@@ -176,11 +176,11 @@ func TestAzureRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", "123.123.123.122", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("example.com", "heritage=external-dns,external-dns/owner=default", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("nginx.example.com", "123.123.123.123", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("nginx.example.com", "heritage=external-dns,external-dns/owner=default", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("hack.example.com", "hack.azurewebsites.net", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("example.com", []string{"123.123.123.122"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("example.com", []string{"heritage=external-dns,external-dns/owner=default"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("nginx.example.com", []string{"123.123.123.123"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("nginx.example.com", []string{"heritage=external-dns,external-dns/owner=default"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("hack.example.com", []string{"hack.azurewebsites.net"}, endpoint.RecordTypeCNAME),
 	}
 
 	validateEndpoints(t, actual, expected)
@@ -192,23 +192,23 @@ func TestAzureApplyChanges(t *testing.T) {
 	testAzureApplyChangesInternal(t, false, &recordsClient)
 
 	validateEndpoints(t, recordsClient.deletedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("old.example.com", "", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("oldcname.example.com", "", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("deleted.example.com", "", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("deletedcname.example.com", "", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("old.example.com", []string{""}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("oldcname.example.com", []string{""}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("deleted.example.com", []string{""}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("deletedcname.example.com", []string{""}, endpoint.RecordTypeCNAME),
 	})
 
 	validateEndpoints(t, recordsClient.updatedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("example.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("foo.example.com", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("foo.example.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("bar.example.com", "other.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("bar.example.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("other.com", "5.6.7.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("other.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("new.example.com", "111.222.111.222", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("newcname.example.com", "other.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("example.com", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("example.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("foo.example.com", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("foo.example.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("bar.example.com", []string{"other.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("bar.example.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("other.com", []string{"5.6.7.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("other.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("new.example.com", []string{"111.222.111.222"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("newcname.example.com", []string{"other.com"}, endpoint.RecordTypeCNAME),
 	})
 }
 
@@ -239,33 +239,33 @@ func testAzureApplyChangesInternal(t *testing.T, dryRun bool, client RecordsClie
 	)
 
 	createRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("example.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("foo.example.com", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("foo.example.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("bar.example.com", "other.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("bar.example.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("other.com", "5.6.7.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("other.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("nope.com", "4.4.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("nope.com", "tag", endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("example.com", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("example.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("foo.example.com", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("foo.example.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("bar.example.com", []string{"other.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("bar.example.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("other.com", []string{"5.6.7.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("other.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("nope.com", []string{"4.4.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("nope.com", []string{"tag"}, endpoint.RecordTypeTXT),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("old.example.com", "121.212.121.212", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("oldcname.example.com", "other.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("old.nope.com", "121.212.121.212", endpoint.RecordTypeA),
+		endpoint.NewEndpoint("old.example.com", []string{"121.212.121.212"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("oldcname.example.com", []string{"other.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("old.nope.com", []string{"121.212.121.212"}, endpoint.RecordTypeA),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("new.example.com", "111.222.111.222", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("newcname.example.com", "other.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("new.nope.com", "222.111.222.111", endpoint.RecordTypeA),
+		endpoint.NewEndpoint("new.example.com", []string{"111.222.111.222"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("newcname.example.com", []string{"other.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("new.nope.com", []string{"222.111.222.111"}, endpoint.RecordTypeA),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("deleted.example.com", "111.222.111.222", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("deletedcname.example.com", "other.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("deleted.nope.com", "222.111.222.111", endpoint.RecordTypeA),
+		endpoint.NewEndpoint("deleted.example.com", []string{"111.222.111.222"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("deletedcname.example.com", []string{"other.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("deleted.nope.com", []string{"222.111.222.111"}, endpoint.RecordTypeA),
 	}
 
 	changes := &plan.Changes{

--- a/provider/cloudflare.go
+++ b/provider/cloudflare.go
@@ -153,7 +153,7 @@ func (p *CloudFlareProvider) Records() ([]*endpoint.Endpoint, error) {
 
 		for _, r := range records {
 			if supportedRecordType(r.Type) {
-				endpoints = append(endpoints, endpoint.NewEndpoint(r.Name, r.Content, r.Type))
+				endpoints = append(endpoints, endpoint.NewEndpoint(r.Name, []string{r.Content}, r.Type))
 			}
 		}
 	}
@@ -274,6 +274,11 @@ func newCloudFlareChange(action string, endpoint *endpoint.Endpoint, proxied boo
 		proxied = false
 	}
 
+	// TODO: test
+	if len(endpoint.Targets) == 0 {
+		return &cloudFlareChange{}
+	}
+
 	return &cloudFlareChange{
 		Action: action,
 		ResourceRecordSet: cloudflare.DNSRecord{
@@ -282,7 +287,7 @@ func newCloudFlareChange(action string, endpoint *endpoint.Endpoint, proxied boo
 			TTL:     1,
 			Proxied: proxied,
 			Type:    endpoint.RecordType,
-			Content: endpoint.Target,
+			Content: endpoint.Targets[0],
 		},
 	}
 }

--- a/provider/cloudflare_test.go
+++ b/provider/cloudflare_test.go
@@ -336,12 +336,12 @@ func (m *mockCloudFlareUpdateRecordsFail) ListZones(zoneID ...string) ([]cloudfl
 }
 
 func TestNewCloudFlareChanges(t *testing.T) {
-	endpoints := []*endpoint.Endpoint{{DNSName: "new", Target: "target"}}
+	endpoints := []*endpoint.Endpoint{{DNSName: "new", Targets: []string{"target"}}}
 	newCloudFlareChanges(cloudFlareCreate, endpoints, true)
 }
 
 func TestNewCloudFlareChangeNoProxied(t *testing.T) {
-	change := newCloudFlareChange(cloudFlareCreate, &endpoint.Endpoint{DNSName: "new", RecordType: "A", Target: "target"}, false)
+	change := newCloudFlareChange(cloudFlareCreate, &endpoint.Endpoint{DNSName: "new", RecordType: "A", Targets: []string{"target"}}, false)
 	assert.False(t, change.ResourceRecordSet.Proxied)
 }
 
@@ -361,7 +361,7 @@ func TestNewCloudFlareChangeProxiable(t *testing.T) {
 	}
 
 	for _, cloudFlareType := range cloudFlareTypes {
-		change := newCloudFlareChange(cloudFlareCreate, &endpoint.Endpoint{DNSName: "new", RecordType: cloudFlareType.recordType, Target: "target"}, true)
+		change := newCloudFlareChange(cloudFlareCreate, &endpoint.Endpoint{DNSName: "new", RecordType: cloudFlareType.recordType, Targets: []string{"target"}}, true)
 
 		if cloudFlareType.proxiable {
 			assert.True(t, change.ResourceRecordSet.Proxied)
@@ -370,7 +370,7 @@ func TestNewCloudFlareChangeProxiable(t *testing.T) {
 		}
 	}
 
-	change := newCloudFlareChange(cloudFlareCreate, &endpoint.Endpoint{DNSName: "*.foo", RecordType: "A", Target: "target"}, true)
+	change := newCloudFlareChange(cloudFlareCreate, &endpoint.Endpoint{DNSName: "*.foo", RecordType: "A", Targets: []string{"target"}}, true)
 	assert.False(t, change.ResourceRecordSet.Proxied)
 }
 
@@ -432,10 +432,10 @@ func TestApplyChanges(t *testing.T) {
 	provider := &CloudFlareProvider{
 		Client: &mockCloudFlareClient{},
 	}
-	changes.Create = []*endpoint.Endpoint{{DNSName: "new.ext-dns-test.zalando.to.", Target: "target"}, {DNSName: "new.ext-dns-test.unrelated.to.", Target: "target"}}
-	changes.Delete = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.zalando.to.", Target: "target"}}
-	changes.UpdateOld = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.zalando.to.", Target: "target-old"}}
-	changes.UpdateNew = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.zalando.to.", Target: "target-new"}}
+	changes.Create = []*endpoint.Endpoint{{DNSName: "new.ext-dns-test.zalando.to.", Targets: []string{"target"}}, {DNSName: "new.ext-dns-test.unrelated.to.", Targets: []string{"target"}}}
+	changes.Delete = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.zalando.to.", Targets: []string{"target"}}}
+	changes.UpdateOld = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.zalando.to.", Targets: []string{"target-old"}}}
+	changes.UpdateNew = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.zalando.to.", Targets: []string{"target-new"}}}
 	err := provider.ApplyChanges(changes)
 	if err != nil {
 		t.Errorf("should not fail, %s", err)

--- a/provider/digital_ocean.go
+++ b/provider/digital_ocean.go
@@ -105,7 +105,7 @@ func (p *DigitalOceanProvider) Records() ([]*endpoint.Endpoint, error) {
 
 		for _, r := range records {
 			if supportedRecordType(r.Type) {
-				endpoints = append(endpoints, endpoint.NewEndpoint(r.Name, r.Data, r.Type))
+				endpoints = append(endpoints, endpoint.NewEndpoint(r.Name, []string{r.Data}, r.Type))
 			}
 		}
 	}
@@ -253,12 +253,17 @@ func newDigitalOceanChanges(action string, endpoints []*endpoint.Endpoint) []*Di
 }
 
 func newDigitalOceanChange(action string, endpoint *endpoint.Endpoint) *DigitalOceanChange {
+	// TODO: test
+	if len(endpoint.Targets) == 0 {
+		return &DigitalOceanChange{}
+	}
+
 	change := &DigitalOceanChange{
 		Action: action,
 		ResourceRecordSet: godo.DomainRecord{
 			Name: endpoint.DNSName,
 			Type: endpoint.RecordType,
-			Data: endpoint.Target,
+			Data: endpoint.Targets[0],
 		},
 	}
 	return change

--- a/provider/digital_ocean_test.go
+++ b/provider/digital_ocean_test.go
@@ -386,7 +386,7 @@ func (m *mockDigitalOceanCreateRecordsFail) Records(ctx context.Context, domain 
 
 func TestNewDigitalOceanChanges(t *testing.T) {
 	action := DigitalOceanCreate
-	endpoints := []*endpoint.Endpoint{{DNSName: "new", Target: "target"}}
+	endpoints := []*endpoint.Endpoint{{DNSName: "new", Targets: []string{"target"}}}
 	_ = newDigitalOceanChanges(action, endpoints)
 }
 
@@ -430,10 +430,10 @@ func TestDigitalOceanApplyChanges(t *testing.T) {
 	provider := &DigitalOceanProvider{
 		Client: &mockDigitalOceanClient{},
 	}
-	changes.Create = []*endpoint.Endpoint{{DNSName: "new.ext-dns-test.bar.com", Target: "target"}, {DNSName: "new.ext-dns-test.unexpected.com", Target: "target"}}
-	changes.Delete = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.bar.com", Target: "target"}}
-	changes.UpdateOld = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.bar.de", Target: "target-old"}}
-	changes.UpdateNew = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.foo.com", Target: "target-new"}}
+	changes.Create = []*endpoint.Endpoint{{DNSName: "new.ext-dns-test.bar.com", Targets: []string{"target"}}, {DNSName: "new.ext-dns-test.unexpected.com", Targets: []string{"target"}}}
+	changes.Delete = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.bar.com", Targets: []string{"target"}}}
+	changes.UpdateOld = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.bar.de", Targets: []string{"target-old"}}}
+	changes.UpdateNew = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.foo.com", Targets: []string{"target-new"}}}
 	err := provider.ApplyChanges(changes)
 	if err != nil {
 		t.Errorf("should not fail, %s", err)

--- a/provider/dnsimple.go
+++ b/provider/dnsimple.go
@@ -152,7 +152,7 @@ func (p *dnsimpleProvider) Records() (endpoints []*endpoint.Endpoint, _ error) {
 			default:
 				continue
 			}
-			endpoints = append(endpoints, endpoint.NewEndpoint(record.Name+"."+record.ZoneID, record.Content, record.Type))
+			endpoints = append(endpoints, endpoint.NewEndpoint(record.Name+"."+record.ZoneID, []string{record.Content}, record.Type))
 		}
 	}
 	return endpoints, nil
@@ -160,12 +160,17 @@ func (p *dnsimpleProvider) Records() (endpoints []*endpoint.Endpoint, _ error) {
 
 // newDnsimpleChange initializes a new change to dns records
 func newDnsimpleChange(action string, e *endpoint.Endpoint) *dnsimpleChange {
+	// TODO: test
+	if len(e.Targets) == 0 {
+		return &dnsimpleChange{}
+	}
+
 	change := &dnsimpleChange{
 		Action: action,
 		ResourceRecordSet: dnsimple.ZoneRecord{
 			Name:    e.DNSName,
 			Type:    e.RecordType,
-			Content: e.Target,
+			Content: e.Targets[0],
 		},
 	}
 	return change

--- a/provider/dnsimple_test.go
+++ b/provider/dnsimple_test.go
@@ -131,9 +131,9 @@ func testDnsimpleProviderRecords(t *testing.T) {
 }
 func testDnsimpleProviderApplyChanges(t *testing.T) {
 	changes := &plan.Changes{}
-	changes.Create = []*endpoint.Endpoint{{DNSName: "example.example.com", Target: "target", RecordType: endpoint.RecordTypeCNAME}}
-	changes.Delete = []*endpoint.Endpoint{{DNSName: "example-beta.example.com", Target: "127.0.0.1", RecordType: endpoint.RecordTypeA}}
-	changes.UpdateNew = []*endpoint.Endpoint{{DNSName: "example.example.com", Target: "target", RecordType: endpoint.RecordTypeCNAME}}
+	changes.Create = []*endpoint.Endpoint{{DNSName: "example.example.com", Targets: []string{"target"}, RecordType: endpoint.RecordTypeCNAME}}
+	changes.Delete = []*endpoint.Endpoint{{DNSName: "example-beta.example.com", Targets: []string{"127.0.0.1"}, RecordType: endpoint.RecordTypeA}}
+	changes.UpdateNew = []*endpoint.Endpoint{{DNSName: "example.example.com", Targets: []string{"target"}, RecordType: endpoint.RecordTypeCNAME}}
 
 	mockProvider.accountID = "1"
 	err := mockProvider.ApplyChanges(changes)

--- a/provider/google.go
+++ b/provider/google.go
@@ -175,7 +175,7 @@ func (p *GoogleProvider) Records() (endpoints []*endpoint.Endpoint, _ error) {
 			for _, rr := range r.Rrdatas {
 				// each page is processed sequentially, no need for a mutex here.
 				if supportedRecordType(r.Type) {
-					endpoints = append(endpoints, endpoint.NewEndpoint(r.Name, rr, r.Type))
+					endpoints = append(endpoints, endpoint.NewEndpoint(r.Name, []string{rr}, r.Type))
 				}
 			}
 		}
@@ -318,9 +318,11 @@ func newRecord(ep *endpoint.Endpoint) *dns.ResourceRecordSet {
 	// TODO(linki): works around appending a trailing dot to TXT records. I think
 	// we should go back to storing DNS names with a trailing dot internally. This
 	// way we can use it has is here and trim it off if it exists when necessary.
-	target := ep.Target
+	targets := ep.Targets
 	if ep.RecordType == endpoint.RecordTypeCNAME {
-		target = ensureTrailingDot(target)
+		for i := range targets {
+			targets[i] = ensureTrailingDot(targets[i])
+		}
 	}
 
 	// no annotation results in a Ttl of 0, default to 300 for backwards-compatability
@@ -331,7 +333,7 @@ func newRecord(ep *endpoint.Endpoint) *dns.ResourceRecordSet {
 
 	return &dns.ResourceRecordSet{
 		Name:    ensureTrailingDot(ep.DNSName),
-		Rrdatas: []string{target},
+		Rrdatas: targets,
 		Ttl:     ttl,
 		Type:    ep.RecordType,
 	}

--- a/provider/google_test.go
+++ b/provider/google_test.go
@@ -207,9 +207,10 @@ func TestGoogleZones(t *testing.T) {
 
 func TestGoogleRecords(t *testing.T) {
 	originalEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("list-test.zone-1.ext-dns-test-2.gcp.zalan.do", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("list-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("list-test-alias.zone-1.ext-dns-test-2.gcp.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("list-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("list-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("list-test-alias.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("list-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
 	}
 
 	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), false, originalEndpoints)
@@ -224,9 +225,10 @@ func TestGoogleCreateRecords(t *testing.T) {
 	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), false, []*endpoint.Endpoint{})
 
 	records := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
 	}
 
 	require.NoError(t, provider.CreateRecords(records))
@@ -235,28 +237,32 @@ func TestGoogleCreateRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	validateEndpoints(t, records, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
 	})
 }
 
 func TestGoogleUpdateRecords(t *testing.T) {
 	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), false, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, "A"),
 	})
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", "4.3.2.1", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"4.3.2.1"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4", "4.3.2.1"}, endpoint.RecordTypeA),
 	}
 
 	require.NoError(t, provider.UpdateRecords(updatedRecords, currentRecords))
@@ -265,17 +271,19 @@ func TestGoogleUpdateRecords(t *testing.T) {
 	require.NoError(t, err)
 
 	validateEndpoints(t, records, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", "4.3.2.1", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"4.3.2.1"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4", "4.3.2.1"}, endpoint.RecordTypeA),
 	})
 }
 
 func TestGoogleDeleteRecords(t *testing.T) {
 	originalEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "baz.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"baz.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("delete-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
 	}
 
 	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), false, originalEndpoints)
@@ -290,35 +298,41 @@ func TestGoogleDeleteRecords(t *testing.T) {
 
 func TestGoogleApplyChanges(t *testing.T) {
 	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), false, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "qux.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"qux.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
 	})
 
 	createRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", "4.3.2.1", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "baz.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"4.3.2.1"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"baz.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4", "4.3.2.1"}, endpoint.RecordTypeA),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "qux.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"qux.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("delete-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
 	}
 
 	changes := &plan.Changes{
@@ -334,48 +348,56 @@ func TestGoogleApplyChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	validateEndpoints(t, records, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", "4.3.2.1", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "baz.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"4.3.2.1"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"baz.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4", "4.3.2.1"}, endpoint.RecordTypeA),
 	})
 }
 
 func TestGoogleApplyChangesDryRun(t *testing.T) {
 	originalEndpoints := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "qux.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"qux.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
 	}
 
 	provider := newGoogleProvider(t, NewDomainFilter([]string{"ext-dns-test-2.gcp.zalan.do."}), true, originalEndpoints)
 
 	createRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "foo.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"foo.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("create-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
 	}
 	updatedRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", "4.3.2.1", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "baz.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"4.3.2.1"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"baz.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("update-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4", "4.3.2.1"}, endpoint.RecordTypeA),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "qux.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"qux.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("delete-test-multi.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"1.2.3.4", "8.8.8.8"}, endpoint.RecordTypeA),
 	}
 
 	changes := &plan.Changes{
@@ -400,13 +422,13 @@ func TestGoogleApplyChangesEmpty(t *testing.T) {
 
 func TestNewRecords(t *testing.T) {
 	records := newRecords([]*endpoint.Endpoint{
-		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA, 1),
-		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", "8.8.4.4", endpoint.RecordTypeA, 120),
-		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "bar.elb.amazonaws.com", endpoint.RecordTypeCNAME, 4000),
+		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA, 1),
+		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.gcp.zalan.do", []string{"8.8.4.4"}, endpoint.RecordTypeA, 120),
+		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"bar.elb.amazonaws.com"}, endpoint.RecordTypeCNAME, 4000),
 		// test fallback to Ttl:300 when Ttl==0 :
-		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA, 0),
-		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", "8.8.8.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", "qux.elb.amazonaws.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpointWithTTL("update-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA, 0),
+		endpoint.NewEndpoint("delete-test.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"8.8.8.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.gcp.zalan.do", []string{"qux.elb.amazonaws.com"}, endpoint.RecordTypeCNAME),
 	})
 
 	validateChangeRecords(t, records, []*dns.ResourceRecordSet{

--- a/provider/infoblox_test.go
+++ b/provider/infoblox_test.go
@@ -44,7 +44,7 @@ func (client *mockIBConnector) CreateObject(obj ibclient.IBObject) (ref string, 
 			client.createdEndpoints,
 			endpoint.NewEndpoint(
 				obj.(*ibclient.RecordA).Name,
-				obj.(*ibclient.RecordA).Ipv4Addr,
+				[]string{obj.(*ibclient.RecordA).Ipv4Addr},
 				endpoint.RecordTypeA,
 			),
 		)
@@ -55,7 +55,7 @@ func (client *mockIBConnector) CreateObject(obj ibclient.IBObject) (ref string, 
 			client.createdEndpoints,
 			endpoint.NewEndpoint(
 				obj.(*ibclient.RecordCNAME).Name,
-				obj.(*ibclient.RecordCNAME).Canonical,
+				[]string{obj.(*ibclient.RecordCNAME).Canonical},
 				endpoint.RecordTypeCNAME,
 			),
 		)
@@ -67,7 +67,7 @@ func (client *mockIBConnector) CreateObject(obj ibclient.IBObject) (ref string, 
 				client.createdEndpoints,
 				endpoint.NewEndpoint(
 					obj.(*ibclient.RecordHost).Name,
-					i.Ipv4Addr,
+					[]string{i.Ipv4Addr},
 					endpoint.RecordTypeA,
 				),
 			)
@@ -79,7 +79,7 @@ func (client *mockIBConnector) CreateObject(obj ibclient.IBObject) (ref string, 
 			client.createdEndpoints,
 			endpoint.NewEndpoint(
 				obj.(*ibclient.RecordTXT).Name,
-				obj.(*ibclient.RecordTXT).Text,
+				[]string{obj.(*ibclient.RecordTXT).Text},
 				endpoint.RecordTypeTXT,
 			),
 		)
@@ -183,7 +183,7 @@ func (client *mockIBConnector) DeleteObject(ref string) (refRes string, err erro
 				client.deletedEndpoints,
 				endpoint.NewEndpoint(
 					record.Name,
-					"",
+					[]string{""},
 					endpoint.RecordTypeA,
 				),
 			)
@@ -201,7 +201,7 @@ func (client *mockIBConnector) DeleteObject(ref string) (refRes string, err erro
 				client.deletedEndpoints,
 				endpoint.NewEndpoint(
 					record.Name,
-					"",
+					[]string{""},
 					endpoint.RecordTypeCNAME,
 				),
 			)
@@ -219,7 +219,7 @@ func (client *mockIBConnector) DeleteObject(ref string) (refRes string, err erro
 				client.deletedEndpoints,
 				endpoint.NewEndpoint(
 					record.Name,
-					"",
+					[]string{""},
 					endpoint.RecordTypeA,
 				),
 			)
@@ -237,7 +237,7 @@ func (client *mockIBConnector) DeleteObject(ref string) (refRes string, err erro
 				client.deletedEndpoints,
 				endpoint.NewEndpoint(
 					record.Name,
-					"",
+					[]string{""},
 					endpoint.RecordTypeTXT,
 				),
 			)
@@ -253,7 +253,7 @@ func (client *mockIBConnector) UpdateObject(obj ibclient.IBObject, ref string) (
 			client.updatedEndpoints,
 			endpoint.NewEndpoint(
 				obj.(*ibclient.RecordA).Name,
-				obj.(*ibclient.RecordA).Ipv4Addr,
+				[]string{obj.(*ibclient.RecordA).Ipv4Addr},
 				endpoint.RecordTypeA,
 			),
 		)
@@ -262,7 +262,7 @@ func (client *mockIBConnector) UpdateObject(obj ibclient.IBObject, ref string) (
 			client.updatedEndpoints,
 			endpoint.NewEndpoint(
 				obj.(*ibclient.RecordCNAME).Name,
-				obj.(*ibclient.RecordCNAME).Canonical,
+				[]string{obj.(*ibclient.RecordCNAME).Canonical},
 				endpoint.RecordTypeCNAME,
 			),
 		)
@@ -272,7 +272,7 @@ func (client *mockIBConnector) UpdateObject(obj ibclient.IBObject, ref string) (
 				client.updatedEndpoints,
 				endpoint.NewEndpoint(
 					obj.(*ibclient.RecordHost).Name,
-					i.Ipv4Addr,
+					[]string{i.Ipv4Addr},
 					endpoint.RecordTypeA,
 				),
 			)
@@ -282,7 +282,7 @@ func (client *mockIBConnector) UpdateObject(obj ibclient.IBObject, ref string) (
 			client.updatedEndpoints,
 			endpoint.NewEndpoint(
 				obj.(*ibclient.RecordTXT).Name,
-				obj.(*ibclient.RecordTXT).Text,
+				[]string{obj.(*ibclient.RecordTXT).Text},
 				endpoint.RecordTypeTXT,
 			),
 		)
@@ -358,13 +358,13 @@ func TestInfobloxRecords(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", "123.123.123.122", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("example.com", "\"heritage=external-dns,external-dns/owner=default\"", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("nginx.example.com", "123.123.123.123", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("nginx.example.com", "\"heritage=external-dns,external-dns/owner=default\"", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("whitespace.example.com", "123.123.123.124", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("whitespace.example.com", "\"heritage=external-dns,external-dns/owner=white space\"", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("hack.example.com", "cerberus.infoblox.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("example.com", []string{"123.123.123.122"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("example.com", []string{"\"heritage=external-dns,external-dns/owner=default\""}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("nginx.example.com", []string{"123.123.123.123"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("nginx.example.com", []string{"\"heritage=external-dns,external-dns/owner=default\""}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("whitespace.example.com", []string{"123.123.123.124"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("whitespace.example.com", []string{"\"heritage=external-dns,external-dns/owner=white space\""}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("hack.example.com", []string{"cerberus.infoblox.com"}, endpoint.RecordTypeCNAME),
 	}
 	validateEndpoints(t, actual, expected)
 }
@@ -375,23 +375,23 @@ func TestInfobloxApplyChanges(t *testing.T) {
 	testInfobloxApplyChangesInternal(t, false, &client)
 
 	validateEndpoints(t, client.createdEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("example.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("foo.example.com", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("foo.example.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("bar.example.com", "other.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("bar.example.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("other.com", "5.6.7.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("other.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("new.example.com", "111.222.111.222", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("newcname.example.com", "other.com", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("example.com", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("example.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("foo.example.com", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("foo.example.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("bar.example.com", []string{"other.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("bar.example.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("other.com", []string{"5.6.7.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("other.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("new.example.com", []string{"111.222.111.222"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("newcname.example.com", []string{"other.com"}, endpoint.RecordTypeCNAME),
 	})
 
 	validateEndpoints(t, client.deletedEndpoints, []*endpoint.Endpoint{
-		endpoint.NewEndpoint("old.example.com", "", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("oldcname.example.com", "", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("deleted.example.com", "", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("deletedcname.example.com", "", endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("old.example.com", []string{""}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("oldcname.example.com", []string{""}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("deleted.example.com", []string{""}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("deletedcname.example.com", []string{""}, endpoint.RecordTypeCNAME),
 	})
 
 	validateEndpoints(t, client.updatedEndpoints, []*endpoint.Endpoint{})
@@ -430,34 +430,34 @@ func testInfobloxApplyChangesInternal(t *testing.T, dryRun bool, client ibclient
 	)
 
 	createRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("example.com", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("example.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("foo.example.com", "1.2.3.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("foo.example.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("bar.example.com", "other.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("bar.example.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("other.com", "5.6.7.8", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("other.com", "tag", endpoint.RecordTypeTXT),
-		endpoint.NewEndpoint("nope.com", "4.4.4.4", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("nope.com", "tag", endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("example.com", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("example.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("foo.example.com", []string{"1.2.3.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("foo.example.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("bar.example.com", []string{"other.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("bar.example.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("other.com", []string{"5.6.7.8"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("other.com", []string{"tag"}, endpoint.RecordTypeTXT),
+		endpoint.NewEndpoint("nope.com", []string{"4.4.4.4"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("nope.com", []string{"tag"}, endpoint.RecordTypeTXT),
 	}
 
 	updateOldRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("old.example.com", "121.212.121.212", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("oldcname.example.com", "other.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("old.nope.com", "121.212.121.212", endpoint.RecordTypeA),
+		endpoint.NewEndpoint("old.example.com", []string{"121.212.121.212"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("oldcname.example.com", []string{"other.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("old.nope.com", []string{"121.212.121.212"}, endpoint.RecordTypeA),
 	}
 
 	updateNewRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("new.example.com", "111.222.111.222", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("newcname.example.com", "other.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("new.nope.com", "222.111.222.111", endpoint.RecordTypeA),
+		endpoint.NewEndpoint("new.example.com", []string{"111.222.111.222"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("newcname.example.com", []string{"other.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("new.nope.com", []string{"222.111.222.111"}, endpoint.RecordTypeA),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
-		endpoint.NewEndpoint("deleted.example.com", "121.212.121.212", endpoint.RecordTypeA),
-		endpoint.NewEndpoint("deletedcname.example.com", "other.com", endpoint.RecordTypeCNAME),
-		endpoint.NewEndpoint("deleted.nope.com", "222.111.222.111", endpoint.RecordTypeA),
+		endpoint.NewEndpoint("deleted.example.com", []string{"121.212.121.212"}, endpoint.RecordTypeA),
+		endpoint.NewEndpoint("deletedcname.example.com", []string{"other.com"}, endpoint.RecordTypeCNAME),
+		endpoint.NewEndpoint("deleted.nope.com", []string{"222.111.222.111"}, endpoint.RecordTypeA),
 	}
 
 	changes := &plan.Changes{

--- a/provider/inmemory_test.go
+++ b/provider/inmemory_test.go
@@ -155,9 +155,9 @@ func testInMemoryRecords(t *testing.T) {
 				"org": {
 					"example.org": []*inMemoryRecord{
 						{
-							Name:   "example.org",
-							Target: "8.8.8.8",
-							Type:   endpoint.RecordTypeA,
+							Name:    "example.org",
+							Targets: []string{"8.8.8.8"},
+							Type:    endpoint.RecordTypeA,
 						},
 						{
 							Name: "example.org",
@@ -166,18 +166,18 @@ func testInMemoryRecords(t *testing.T) {
 					},
 					"foo.org": []*inMemoryRecord{
 						{
-							Name:   "foo.org",
-							Target: "4.4.4.4",
-							Type:   endpoint.RecordTypeCNAME,
+							Name:    "foo.org",
+							Targets: []string{"4.4.4.4"},
+							Type:    endpoint.RecordTypeCNAME,
 						},
 					},
 				},
 				"com": {
 					"example.com": []*inMemoryRecord{
 						{
-							Name:   "example.com",
-							Target: "4.4.4.4",
-							Type:   endpoint.RecordTypeCNAME,
+							Name:    "example.com",
+							Targets: []string{"4.4.4.4"},
+							Type:    endpoint.RecordTypeCNAME,
 						},
 					},
 				},
@@ -186,7 +186,7 @@ func testInMemoryRecords(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName:    "example.org",
-					Target:     "8.8.8.8",
+					Targets:    []string{"8.8.8.8"},
 					RecordType: endpoint.RecordTypeA,
 				},
 				{
@@ -195,7 +195,7 @@ func testInMemoryRecords(t *testing.T) {
 				},
 				{
 					DNSName:    "foo.org",
-					Target:     "4.4.4.4",
+					Targets:    []string{"4.4.4.4"},
 					RecordType: endpoint.RecordTypeCNAME,
 				},
 			},
@@ -225,9 +225,9 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 		"org": {
 			"example.org": []*inMemoryRecord{
 				{
-					Name:   "example.org",
-					Target: "8.8.8.8",
-					Type:   endpoint.RecordTypeA,
+					Name:    "example.org",
+					Targets: []string{"8.8.8.8"},
+					Type:    endpoint.RecordTypeA,
 				},
 				{
 					Name: "example.org",
@@ -235,25 +235,25 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			},
 			"foo.org": []*inMemoryRecord{
 				{
-					Name:   "foo.org",
-					Target: "bar.org",
-					Type:   endpoint.RecordTypeCNAME,
+					Name:    "foo.org",
+					Targets: []string{"bar.org"},
+					Type:    endpoint.RecordTypeCNAME,
 				},
 			},
 			"foo.bar.org": []*inMemoryRecord{
 				{
-					Name:   "foo.bar.org",
-					Target: "5.5.5.5",
-					Type:   endpoint.RecordTypeA,
+					Name:    "foo.bar.org",
+					Targets: []string{"5.5.5.5"},
+					Type:    endpoint.RecordTypeA,
 				},
 			},
 		},
 		"com": {
 			"example.com": []*inMemoryRecord{
 				{
-					Name:   "example.com",
-					Target: "another-example.com",
-					Type:   endpoint.RecordTypeCNAME,
+					Name:    "example.com",
+					Targets: []string{"another-example.com"},
+					Type:    endpoint.RecordTypeCNAME,
 				},
 			},
 		},
@@ -314,7 +314,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 				Create: []*endpoint.Endpoint{
 					{
 						DNSName:    "example.org",
-						Target:     "8.8.8.8",
+						Targets:    []string{"8.8.8.8"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -333,14 +333,14 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 				Create: []*endpoint.Endpoint{
 					{
 						DNSName:    "foo.org",
-						Target:     "4.4.4.4",
+						Targets:    []string{"4.4.4.4"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
 				UpdateNew: []*endpoint.Endpoint{
 					{
 						DNSName:    "foo.org",
-						Target:     "4.4.4.4",
+						Targets:    []string{"4.4.4.4"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -358,14 +358,14 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 				Create: []*endpoint.Endpoint{
 					{
 						DNSName:    "foo.org",
-						Target:     "4.4.4.4",
+						Targets:    []string{"4.4.4.4"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
 				UpdateNew: []*endpoint.Endpoint{
 					{
 						DNSName:    "foo.org",
-						Target:     "4.4.4.4",
+						Targets:    []string{"4.4.4.4"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -383,12 +383,12 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 				Create: []*endpoint.Endpoint{
 					{
 						DNSName:    "foo.org",
-						Target:     "4.4.4.4",
+						Targets:    []string{"4.4.4.4"},
 						RecordType: endpoint.RecordTypeA,
 					},
 					{
 						DNSName:    "foo.org",
-						Target:     "4.4.4.4",
+						Targets:    []string{"4.4.4.4"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -408,7 +408,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 				UpdateNew: []*endpoint.Endpoint{
 					{
 						DNSName:    "example.org",
-						Target:     "8.8.8.8",
+						Targets:    []string{"8.8.8.8"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -416,7 +416,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 				Delete: []*endpoint.Endpoint{
 					{
 						DNSName:    "example.org",
-						Target:     "8.8.8.8",
+						Targets:    []string{"8.8.8.8"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -433,12 +433,12 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 				UpdateNew: []*endpoint.Endpoint{
 					{
 						DNSName:    "example.org",
-						Target:     "8.8.8.8",
+						Targets:    []string{"8.8.8.8"},
 						RecordType: endpoint.RecordTypeA,
 					},
 					{
 						DNSName:    "example.org",
-						Target:     "8.8.8.8",
+						Targets:    []string{"8.8.8.8"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -458,7 +458,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 				UpdateOld: []*endpoint.Endpoint{
 					{
 						DNSName:    "new.org",
-						Target:     "8.8.8.8",
+						Targets:    []string{"8.8.8.8"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -478,7 +478,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 				Delete: []*endpoint.Endpoint{
 					{
 						DNSName:    "new.org",
-						Target:     "8.8.8.8",
+						Targets:    []string{"8.8.8.8"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -497,7 +497,7 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 				Delete: []*endpoint.Endpoint{
 					{
 						DNSName:    "foo.bar.org",
-						Target:     "5.5.5.5",
+						Targets:    []string{"5.5.5.5"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -512,21 +512,21 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 				Create: []*endpoint.Endpoint{
 					{
 						DNSName:    "foo.bar.new.org",
-						Target:     "4.8.8.9",
+						Targets:    []string{"4.8.8.9"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
 				UpdateNew: []*endpoint.Endpoint{
 					{
 						DNSName:    "foo.bar.org",
-						Target:     "4.8.8.4",
+						Targets:    []string{"4.8.8.4"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
 				UpdateOld: []*endpoint.Endpoint{
 					{
 						DNSName:    "foo.bar.org",
-						Target:     "5.5.5.5",
+						Targets:    []string{"5.5.5.5"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -558,9 +558,9 @@ func getInitData() map[string]zone {
 		"org": {
 			"example.org": []*inMemoryRecord{
 				{
-					Name:   "example.org",
-					Target: "8.8.8.8",
-					Type:   endpoint.RecordTypeA,
+					Name:    "example.org",
+					Targets: []string{"8.8.8.8"},
+					Type:    endpoint.RecordTypeA,
 				},
 				{
 					Name: "example.org",
@@ -569,25 +569,25 @@ func getInitData() map[string]zone {
 			},
 			"foo.org": []*inMemoryRecord{
 				{
-					Name:   "foo.org",
-					Target: "4.4.4.4",
-					Type:   endpoint.RecordTypeCNAME,
+					Name:    "foo.org",
+					Targets: []string{"4.4.4.4"},
+					Type:    endpoint.RecordTypeCNAME,
 				},
 			},
 			"foo.bar.org": []*inMemoryRecord{
 				{
-					Name:   "foo.bar.org",
-					Target: "5.5.5.5",
-					Type:   endpoint.RecordTypeA,
+					Name:    "foo.bar.org",
+					Targets: []string{"5.5.5.5"},
+					Type:    endpoint.RecordTypeA,
 				},
 			},
 		},
 		"com": {
 			"example.com": []*inMemoryRecord{
 				{
-					Name:   "example.com",
-					Target: "4.4.4.4",
-					Type:   endpoint.RecordTypeCNAME,
+					Name:    "example.com",
+					Targets: []string{"4.4.4.4"},
+					Type:    endpoint.RecordTypeCNAME,
 				},
 			},
 		},
@@ -608,7 +608,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 			changes: &plan.Changes{
 				Create: []*endpoint.Endpoint{{
 					DNSName:    "example.de",
-					Target:     "8.8.8.8",
+					Targets:    []string{"8.8.8.8"},
 					RecordType: endpoint.RecordTypeA,
 				}},
 				UpdateNew: []*endpoint.Endpoint{},
@@ -625,7 +625,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 				UpdateNew: []*endpoint.Endpoint{
 					{
 						DNSName:    "example.org",
-						Target:     "8.8.8.8",
+						Targets:    []string{"8.8.8.8"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -633,7 +633,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 				Delete: []*endpoint.Endpoint{
 					{
 						DNSName:    "example.org",
-						Target:     "8.8.8.8",
+						Targets:    []string{"8.8.8.8"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -649,7 +649,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 				Delete: []*endpoint.Endpoint{
 					{
 						DNSName:    "foo.bar.org",
-						Target:     "5.5.5.5",
+						Targets:    []string{"5.5.5.5"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -659,9 +659,9 @@ func testInMemoryApplyChanges(t *testing.T) {
 					"example.org": []*inMemoryRecord{
 						{
 
-							Name:   "example.org",
-							Target: "8.8.8.8",
-							Type:   endpoint.RecordTypeA,
+							Name:    "example.org",
+							Targets: []string{"8.8.8.8"},
+							Type:    endpoint.RecordTypeA,
 						},
 						{
 
@@ -672,9 +672,9 @@ func testInMemoryApplyChanges(t *testing.T) {
 					"foo.org": []*inMemoryRecord{
 						{
 
-							Name:   "foo.org",
-							Target: "4.4.4.4",
-							Type:   endpoint.RecordTypeCNAME,
+							Name:    "foo.org",
+							Targets: []string{"4.4.4.4"},
+							Type:    endpoint.RecordTypeCNAME,
 						},
 					},
 					"foo.bar.org": []*inMemoryRecord{},
@@ -682,9 +682,9 @@ func testInMemoryApplyChanges(t *testing.T) {
 				"com": {
 					"example.com": []*inMemoryRecord{
 						{
-							Name:   "example.com",
-							Target: "4.4.4.4",
-							Type:   endpoint.RecordTypeCNAME,
+							Name:    "example.com",
+							Targets: []string{"4.4.4.4"},
+							Type:    endpoint.RecordTypeCNAME,
 						},
 					},
 				},
@@ -697,28 +697,28 @@ func testInMemoryApplyChanges(t *testing.T) {
 				Create: []*endpoint.Endpoint{
 					{
 						DNSName:    "foo.bar.new.org",
-						Target:     "4.8.8.9",
+						Targets:    []string{"4.8.8.9"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
 				UpdateNew: []*endpoint.Endpoint{
 					{
 						DNSName:    "foo.bar.org",
-						Target:     "4.8.8.4",
+						Targets:    []string{"4.8.8.4"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
 				UpdateOld: []*endpoint.Endpoint{
 					{
 						DNSName:    "foo.bar.org",
-						Target:     "5.5.5.5",
+						Targets:    []string{"5.5.5.5"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
 				Delete: []*endpoint.Endpoint{
 					{
 						DNSName:    "example.org",
-						Target:     "8.8.8.8",
+						Targets:    []string{"8.8.8.8"},
 						RecordType: endpoint.RecordTypeA,
 					},
 				},
@@ -733,32 +733,32 @@ func testInMemoryApplyChanges(t *testing.T) {
 					},
 					"foo.org": []*inMemoryRecord{
 						{
-							Name:   "foo.org",
-							Target: "4.4.4.4",
-							Type:   endpoint.RecordTypeCNAME,
+							Name:    "foo.org",
+							Targets: []string{"4.4.4.4"},
+							Type:    endpoint.RecordTypeCNAME,
 						},
 					},
 					"foo.bar.org": []*inMemoryRecord{
 						{
-							Name:   "foo.bar.org",
-							Target: "4.8.8.4",
-							Type:   endpoint.RecordTypeA,
+							Name:    "foo.bar.org",
+							Targets: []string{"4.8.8.4"},
+							Type:    endpoint.RecordTypeA,
 						},
 					},
 					"foo.bar.new.org": []*inMemoryRecord{
 						{
-							Name:   "foo.bar.new.org",
-							Target: "4.8.8.9",
-							Type:   endpoint.RecordTypeA,
+							Name:    "foo.bar.new.org",
+							Targets: []string{"4.8.8.9"},
+							Type:    endpoint.RecordTypeA,
 						},
 					},
 				},
 				"com": {
 					"example.com": []*inMemoryRecord{
 						{
-							Name:   "example.com",
-							Target: "4.4.4.4",
-							Type:   endpoint.RecordTypeCNAME,
+							Name:    "example.com",
+							Targets: []string{"4.4.4.4"},
+							Type:    endpoint.RecordTypeCNAME,
 						},
 					},
 				},

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -38,3 +38,12 @@ func ensureTrailingDot(hostname string) string {
 
 	return strings.TrimSuffix(hostname, ".") + "."
 }
+
+// // ensureTrailingDot ensures that the hostname receives a trailing dot if it hasn't already.
+// func ensureTrailingDots(hostnames []string) (sanitizedHostnames []string) {
+// 	for _, h := range hostnames {
+// 		sanitizedHostnames = append(sanitizedHostnames, ensureTrailingDot(h))
+// 	}
+//
+// 	return
+// }

--- a/registry/noop_test.go
+++ b/registry/noop_test.go
@@ -49,7 +49,7 @@ func testNoopRecords(t *testing.T) {
 	providerRecords := []*endpoint.Endpoint{
 		{
 			DNSName:    "example.org",
-			Target:     "example-lb.com",
+			Targets:    []string{"example-lb.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 		},
 	}
@@ -71,19 +71,19 @@ func testNoopApplyChanges(t *testing.T) {
 	providerRecords := []*endpoint.Endpoint{
 		{
 			DNSName:    "example.org",
-			Target:     "old-lb.com",
+			Targets:    []string{"old-lb.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 		},
 	}
 	expectedUpdate := []*endpoint.Endpoint{
 		{
 			DNSName:    "example.org",
-			Target:     "new-example-lb.com",
+			Targets:    []string{"new-example-lb.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 		},
 		{
 			DNSName:    "new-record.org",
-			Target:     "new-lb.org",
+			Targets:    []string{"new-lb.org"},
 			RecordType: endpoint.RecordTypeCNAME,
 		},
 	}
@@ -98,7 +98,7 @@ func testNoopApplyChanges(t *testing.T) {
 		Create: []*endpoint.Endpoint{
 			{
 				DNSName:    "example.org",
-				Target:     "lb.com",
+				Targets:    []string{"lb.com"},
 				RecordType: endpoint.RecordTypeCNAME,
 			},
 		},
@@ -110,21 +110,21 @@ func testNoopApplyChanges(t *testing.T) {
 		Create: []*endpoint.Endpoint{
 			{
 				DNSName:    "new-record.org",
-				Target:     "new-lb.org",
+				Targets:    []string{"new-lb.org"},
 				RecordType: endpoint.RecordTypeCNAME,
 			},
 		},
 		UpdateNew: []*endpoint.Endpoint{
 			{
 				DNSName:    "example.org",
-				Target:     "new-example-lb.com",
+				Targets:    []string{"new-example-lb.com"},
 				RecordType: endpoint.RecordTypeCNAME,
 			},
 		},
 		UpdateOld: []*endpoint.Endpoint{
 			{
 				DNSName:    "example.org",
-				Target:     "old-lb.com",
+				Targets:    []string{"old-lb.com"},
 				RecordType: endpoint.RecordTypeCNAME,
 			},
 		},

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -73,7 +73,7 @@ func (im *TXTRegistry) Records() ([]*endpoint.Endpoint, error) {
 			endpoints = append(endpoints, record)
 			continue
 		}
-		ownerID := im.extractOwnerID(record.Target)
+		ownerID := im.extractOwnerID(record.Targets[0])
 		if ownerID == "" {
 			//case when value of txt record cannot be identified
 			//record will not be removed as it will have empty owner
@@ -102,12 +102,12 @@ func (im *TXTRegistry) ApplyChanges(changes *plan.Changes) error {
 	}
 
 	for _, r := range filteredChanges.Create {
-		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), im.getTXTLabel(), endpoint.RecordTypeTXT)
+		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), []string{im.getTXTLabel()}, endpoint.RecordTypeTXT)
 		filteredChanges.Create = append(filteredChanges.Create, txt)
 	}
 
 	for _, r := range filteredChanges.Delete {
-		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), im.getTXTLabel(), endpoint.RecordTypeTXT)
+		txt := endpoint.NewEndpoint(im.mapper.toTXTName(r.DNSName), []string{im.getTXTLabel()}, endpoint.RecordTypeTXT)
 
 		filteredChanges.Delete = append(filteredChanges.Delete, txt)
 	}

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -68,21 +68,21 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 	p.CreateZone(testZone)
 	p.ApplyChanges(&plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("foo.test-zone.example.org", []string{"foo.loadbalancer.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("bar.test-zone.example.org", []string{"my-domain.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("txt.bar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("txt.bar.test-zone.example.org", []string{"baz.test-zone.example.org"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("qux.test-zone.example.org", []string{"random"}, endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("tar.test-zone.example.org", []string{"tar.loadbalancer.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("txt.tar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner-2\""}, endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("foobar.test-zone.example.org", []string{"foobar.loadbalancer.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("foobar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
 		{
 			DNSName:    "foo.test-zone.example.org",
-			Target:     "foo.loadbalancer.com",
+			Targets:    []string{"foo.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "",
@@ -90,7 +90,7 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 		},
 		{
 			DNSName:    "bar.test-zone.example.org",
-			Target:     "my-domain.com",
+			Targets:    []string{"my-domain.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "owner",
@@ -98,7 +98,7 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 		},
 		{
 			DNSName:    "txt.bar.test-zone.example.org",
-			Target:     "baz.test-zone.example.org",
+			Targets:    []string{"baz.test-zone.example.org"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "",
@@ -106,7 +106,7 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 		},
 		{
 			DNSName:    "qux.test-zone.example.org",
-			Target:     "random",
+			Targets:    []string{"random"},
 			RecordType: endpoint.RecordTypeTXT,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "",
@@ -114,7 +114,7 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 		},
 		{
 			DNSName:    "tar.test-zone.example.org",
-			Target:     "tar.loadbalancer.com",
+			Targets:    []string{"tar.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "owner-2",
@@ -122,7 +122,7 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 		},
 		{
 			DNSName:    "foobar.test-zone.example.org",
-			Target:     "foobar.loadbalancer.com",
+			Targets:    []string{"foobar.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "",
@@ -140,21 +140,21 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 	p.CreateZone(testZone)
 	p.ApplyChanges(&plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("foo.test-zone.example.org", []string{"foo.loadbalancer.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("bar.test-zone.example.org", []string{"my-domain.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("txt.bar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("txt.bar.test-zone.example.org", []string{"baz.test-zone.example.org"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("qux.test-zone.example.org", []string{"random"}, endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("tar.test-zone.example.org", []string{"tar.loadbalancer.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("txt.tar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner-2\""}, endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("foobar.test-zone.example.org", []string{"foobar.loadbalancer.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("foobar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
 		{
 			DNSName:    "foo.test-zone.example.org",
-			Target:     "foo.loadbalancer.com",
+			Targets:    []string{"foo.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "",
@@ -162,7 +162,7 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 		},
 		{
 			DNSName:    "bar.test-zone.example.org",
-			Target:     "my-domain.com",
+			Targets:    []string{"my-domain.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "",
@@ -170,7 +170,7 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 		},
 		{
 			DNSName:    "txt.bar.test-zone.example.org",
-			Target:     "baz.test-zone.example.org",
+			Targets:    []string{"baz.test-zone.example.org"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "owner",
@@ -178,7 +178,7 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 		},
 		{
 			DNSName:    "qux.test-zone.example.org",
-			Target:     "random",
+			Targets:    []string{"random"},
 			RecordType: endpoint.RecordTypeTXT,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "",
@@ -186,7 +186,7 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 		},
 		{
 			DNSName:    "tar.test-zone.example.org",
-			Target:     "tar.loadbalancer.com",
+			Targets:    []string{"tar.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "",
@@ -194,7 +194,7 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 		},
 		{
 			DNSName:    "foobar.test-zone.example.org",
-			Target:     "foobar.loadbalancer.com",
+			Targets:    []string{"foobar.loadbalancer.com"},
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "owner",
@@ -218,47 +218,47 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 	p.CreateZone(testZone)
 	p.ApplyChanges(&plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("foo.test-zone.example.org", []string{"foo.loadbalancer.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("bar.test-zone.example.org", []string{"my-domain.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("txt.bar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("txt.bar.test-zone.example.org", []string{"baz.test-zone.example.org"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("qux.test-zone.example.org", []string{"random"}, endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("tar.test-zone.example.org", []string{"tar.loadbalancer.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("txt.tar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("foobar.test-zone.example.org", []string{"foobar.loadbalancer.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("txt.foobar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
 		},
 	})
 	r, _ := NewTXTRegistry(p, "txt.", "owner")
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", "", ""),
+			newEndpointWithOwner("new-record-1.test-zone.example.org", []string{"new-loadbalancer-1.lb.com"}, "", ""),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("foobar.test-zone.example.org", []string{"foobar.loadbalancer.com"}, endpoint.RecordTypeCNAME, "owner"),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("tar.test-zone.example.org", []string{"new-tar.loadbalancer.com"}, endpoint.RecordTypeCNAME, "owner"),
 		},
 		UpdateOld: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("tar.test-zone.example.org", []string{"tar.loadbalancer.com"}, endpoint.RecordTypeCNAME, "owner"),
 		},
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", "", ""),
-			newEndpointWithOwner("txt.new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("new-record-1.test-zone.example.org", []string{"new-loadbalancer-1.lb.com"}, "", ""),
+			newEndpointWithOwner("txt.new-record-1.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwner("txt.foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("foobar.test-zone.example.org", []string{"foobar.loadbalancer.com"}, endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("txt.foobar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("tar.test-zone.example.org", []string{"new-tar.loadbalancer.com"}, endpoint.RecordTypeCNAME, "owner"),
 		},
 		UpdateOld: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("tar.test-zone.example.org", []string{"tar.loadbalancer.com"}, endpoint.RecordTypeCNAME, "owner"),
 		},
 	}
 	p.OnApplyChanges = func(got *plan.Changes) {
@@ -285,41 +285,41 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 	p.CreateZone(testZone)
 	p.ApplyChanges(&plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("foo.test-zone.example.org", []string{"foo.loadbalancer.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("bar.test-zone.example.org", []string{"my-domain.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("txt.bar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("txt.bar.test-zone.example.org", []string{"baz.test-zone.example.org"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("qux.test-zone.example.org", []string{"random"}, endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("tar.test-zone.example.org", []string{"tar.loadbalancer.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("txt.tar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("foobar.test-zone.example.org", []string{"foobar.loadbalancer.com"}, endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwner("foobar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
 		},
 	})
 	r, _ := NewTXTRegistry(p, "", "owner")
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", "", ""),
+			newEndpointWithOwner("new-record-1.test-zone.example.org", []string{"new-loadbalancer-1.lb.com"}, "", ""),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("foobar.test-zone.example.org", []string{"foobar.loadbalancer.com"}, endpoint.RecordTypeCNAME, "owner"),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner-2"),
+			newEndpointWithOwner("tar.test-zone.example.org", []string{"new-tar.loadbalancer.com"}, endpoint.RecordTypeCNAME, "owner-2"),
 		},
 		UpdateOld: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner-2"),
+			newEndpointWithOwner("tar.test-zone.example.org", []string{"tar.loadbalancer.com"}, endpoint.RecordTypeCNAME, "owner-2"),
 		},
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", "", ""),
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("new-record-1.test-zone.example.org", []string{"new-loadbalancer-1.lb.com"}, "", ""),
+			newEndpointWithOwner("new-record-1.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			newEndpointWithOwner("foobar.test-zone.example.org", []string{"foobar.loadbalancer.com"}, endpoint.RecordTypeCNAME, "owner"),
+			newEndpointWithOwner("foobar.test-zone.example.org", []string{"\"heritage=external-dns,external-dns/owner=owner\""}, endpoint.RecordTypeTXT, ""),
 		},
 		UpdateNew: []*endpoint.Endpoint{},
 		UpdateOld: []*endpoint.Endpoint{},
@@ -349,8 +349,10 @@ helper methods
 
 */
 
-func newEndpointWithOwner(dnsName, target, recordType, ownerID string) *endpoint.Endpoint {
-	e := endpoint.NewEndpoint(dnsName, target, recordType)
-	e.Labels[endpoint.OwnerLabelKey] = ownerID
+func newEndpointWithOwner(dnsName string, targets []string, recordType, ownerID string) *endpoint.Endpoint {
+	e := endpoint.NewEndpoint(dnsName, targets, recordType)
+	if ownerID != "" {
+		e.Labels[endpoint.OwnerLabelKey] = ownerID
+	}
 	return e
 }

--- a/source/compatibility.go
+++ b/source/compatibility.go
@@ -56,10 +56,10 @@ func legacyEndpointsFromMateService(svc *v1.Service) []*endpoint.Endpoint {
 	// Create a corresponding endpoint for each configured external entrypoint.
 	for _, lb := range svc.Status.LoadBalancer.Ingress {
 		if lb.IP != "" {
-			endpoints = append(endpoints, endpoint.NewEndpoint(hostname, lb.IP, endpoint.RecordTypeA))
+			endpoints = append(endpoints, endpoint.NewEndpoint(hostname, []string{lb.IP}, endpoint.RecordTypeA))
 		}
 		if lb.Hostname != "" {
-			endpoints = append(endpoints, endpoint.NewEndpoint(hostname, lb.Hostname, endpoint.RecordTypeCNAME))
+			endpoints = append(endpoints, endpoint.NewEndpoint(hostname, []string{lb.Hostname}, endpoint.RecordTypeCNAME))
 		}
 	}
 
@@ -88,10 +88,10 @@ func legacyEndpointsFromMoleculeService(svc *v1.Service) []*endpoint.Endpoint {
 		// Create a corresponding endpoint for each configured external entrypoint.
 		for _, lb := range svc.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {
-				endpoints = append(endpoints, endpoint.NewEndpoint(hostname, lb.IP, endpoint.RecordTypeA))
+				endpoints = append(endpoints, endpoint.NewEndpoint(hostname, []string{lb.IP}, endpoint.RecordTypeA))
 			}
 			if lb.Hostname != "" {
-				endpoints = append(endpoints, endpoint.NewEndpoint(hostname, lb.Hostname, endpoint.RecordTypeCNAME))
+				endpoints = append(endpoints, endpoint.NewEndpoint(hostname, []string{lb.Hostname}, endpoint.RecordTypeCNAME))
 			}
 		}
 	}

--- a/source/dedup_source.go
+++ b/source/dedup_source.go
@@ -17,6 +17,8 @@ limitations under the License.
 package source
 
 import (
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
@@ -43,7 +45,7 @@ func (ms *dedupSource) Endpoints() ([]*endpoint.Endpoint, error) {
 	}
 
 	for _, ep := range endpoints {
-		identifier := ep.DNSName + " / " + ep.Target
+		identifier := ep.DNSName + " / " + fmt.Sprintf("%v", ep.Targets)
 
 		if _, ok := collected[identifier]; ok {
 			log.Debugf("Removing duplicate endpoint %s", ep)

--- a/source/dedup_source_test.go
+++ b/source/dedup_source_test.go
@@ -40,53 +40,62 @@ func testDedupEndpoints(t *testing.T) {
 		{
 			"one endpoint returns one endpoint",
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
 			},
 		},
 		{
 			"two different endpoints return two endpoints",
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
-				{DNSName: "bar.example.org", Target: "4.5.6.7"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
+				{DNSName: "bar.example.org", Targets: []string{"4.5.6.7"}},
 			},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
-				{DNSName: "bar.example.org", Target: "4.5.6.7"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
+				{DNSName: "bar.example.org", Targets: []string{"4.5.6.7"}},
 			},
 		},
 		{
 			"two endpoints with same dnsname and different targets return two endpoints",
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
-				{DNSName: "foo.example.org", Target: "4.5.6.7"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
+				{DNSName: "foo.example.org", Targets: []string{"4.5.6.7"}},
 			},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
-				{DNSName: "foo.example.org", Target: "4.5.6.7"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
+				{DNSName: "foo.example.org", Targets: []string{"4.5.6.7"}},
 			},
 		},
 		{
 			"two endpoints with different dnsname and same target return two endpoints",
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
-				{DNSName: "bar.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
+				{DNSName: "bar.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
-				{DNSName: "bar.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
+				{DNSName: "bar.example.org", Targets: []string{"1.2.3.4"}},
 			},
 		},
 		{
 			"two endpoints with same dnsname and same target return one endpoint",
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
+			},
+		},
+		{
+			"one endpoint with multiple targets returns one endpoint with original targets",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4", "4.5.6.7"}},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4", "4.5.6.7"}},
 			},
 		},
 	} {

--- a/source/fake.go
+++ b/source/fake.go
@@ -68,7 +68,7 @@ func (sc *fakeSource) Endpoints() ([]*endpoint.Endpoint, error) {
 func (sc *fakeSource) generateEndpoint() (*endpoint.Endpoint, error) {
 	endpoint := endpoint.NewEndpoint(
 		generateDNSName(4, sc.dnsName),
-		generateIPAddress(),
+		[]string{generateIPAddress()},
 		endpoint.RecordTypeA,
 	)
 

--- a/source/fake_test.go
+++ b/source/fake_test.go
@@ -60,10 +60,12 @@ func TestFakeEndpointsResolveToIPAddresses(t *testing.T) {
 	endpoints := generateTestEndpoints()
 
 	for _, e := range endpoints {
-		ip := net.ParseIP(e.Target)
+		for _, target := range e.Targets {
+			ip := net.ParseIP(target)
 
-		if ip == nil {
-			t.Error(e)
+			if ip == nil {
+				t.Error(e)
+			}
 		}
 	}
 }

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -127,7 +127,7 @@ func getEndpointsFromTargetAnnotation(ing *v1beta1.Ingress, hostname string) []*
 		targetsList := strings.Split(strings.Replace(targetAnnotation, " ", "", -1), ",")
 		for _, targetHostname := range targetsList {
 			targetHostname = strings.TrimSuffix(targetHostname, ".")
-			endpoints = append(endpoints, endpoint.NewEndpointWithTTL(hostname, targetHostname, suitableType(targetHostname), ttl))
+			endpoints = append(endpoints, endpoint.NewEndpointWithTTL(hostname, []string{targetHostname}, suitableType(targetHostname), ttl))
 		}
 	}
 	return endpoints
@@ -156,10 +156,10 @@ func (sc *ingressSource) endpointsFromTemplate(ing *v1beta1.Ingress) ([]*endpoin
 	}
 	for _, lb := range ing.Status.LoadBalancer.Ingress {
 		if lb.IP != "" {
-			endpoints = append(endpoints, endpoint.NewEndpointWithTTL(hostname, lb.IP, endpoint.RecordTypeA, ttl))
+			endpoints = append(endpoints, endpoint.NewEndpointWithTTL(hostname, []string{lb.IP}, endpoint.RecordTypeA, ttl))
 		}
 		if lb.Hostname != "" {
-			endpoints = append(endpoints, endpoint.NewEndpointWithTTL(hostname, lb.Hostname, endpoint.RecordTypeCNAME, ttl))
+			endpoints = append(endpoints, endpoint.NewEndpointWithTTL(hostname, []string{lb.Hostname}, endpoint.RecordTypeCNAME, ttl))
 		}
 	}
 
@@ -220,10 +220,10 @@ func endpointsFromIngress(ing *v1beta1.Ingress) []*endpoint.Endpoint {
 
 		for _, lb := range ing.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {
-				endpoints = append(endpoints, endpoint.NewEndpointWithTTL(rule.Host, lb.IP, endpoint.RecordTypeA, ttl))
+				endpoints = append(endpoints, endpoint.NewEndpointWithTTL(rule.Host, []string{lb.IP}, endpoint.RecordTypeA, ttl))
 			}
 			if lb.Hostname != "" {
-				endpoints = append(endpoints, endpoint.NewEndpointWithTTL(rule.Host, lb.Hostname, endpoint.RecordTypeCNAME, ttl))
+				endpoints = append(endpoints, endpoint.NewEndpointWithTTL(rule.Host, []string{lb.Hostname}, endpoint.RecordTypeCNAME, ttl))
 			}
 		}
 	}

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -96,7 +96,7 @@ func testEndpointsFromIngress(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName: "foo.bar",
-					Target:  "lb.com",
+					Targets: []string{"lb.com"},
 				},
 			},
 		},
@@ -109,7 +109,7 @@ func testEndpointsFromIngress(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName: "foo.bar",
-					Target:  "8.8.8.8",
+					Targets: []string{"8.8.8.8"},
 				},
 			},
 		},
@@ -123,19 +123,7 @@ func testEndpointsFromIngress(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName: "foo.bar",
-					Target:  "8.8.8.8",
-				},
-				{
-					DNSName: "foo.bar",
-					Target:  "127.0.0.1",
-				},
-				{
-					DNSName: "foo.bar",
-					Target:  "elb.com",
-				},
-				{
-					DNSName: "foo.bar",
-					Target:  "alb.com",
+					Targets: []string{"8.8.8.8", "127.0.0.1", "elb.com", "alb.com"},
 				},
 			},
 		},
@@ -206,11 +194,11 @@ func testIngressEndpoints(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName: "example.org",
-					Target:  "8.8.8.8",
+					Targets: []string{"8.8.8.8"},
 				},
 				{
 					DNSName: "new.org",
-					Target:  "lb.com",
+					Targets: []string{"lb.com"},
 				},
 			},
 		},
@@ -234,11 +222,11 @@ func testIngressEndpoints(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName: "example.org",
-					Target:  "8.8.8.8",
+					Targets: []string{"8.8.8.8"},
 				},
 				{
 					DNSName: "new.org",
-					Target:  "lb.com",
+					Targets: []string{"lb.com"},
 				},
 			},
 		},
@@ -262,7 +250,7 @@ func testIngressEndpoints(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName: "example.org",
-					Target:  "8.8.8.8",
+					Targets: []string{"8.8.8.8"},
 				},
 			},
 		},
@@ -284,7 +272,7 @@ func testIngressEndpoints(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName: "example.org",
-					Target:  "8.8.8.8",
+					Targets: []string{"8.8.8.8"},
 				},
 			},
 		},
@@ -341,7 +329,7 @@ func testIngressEndpoints(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName: "example.org",
-					Target:  "8.8.8.8",
+					Targets: []string{"8.8.8.8"},
 				},
 			},
 		},
@@ -379,7 +367,7 @@ func testIngressEndpoints(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName: "example.org",
-					Target:  "8.8.8.8",
+					Targets: []string{"8.8.8.8"},
 				},
 			},
 		},
@@ -417,11 +405,7 @@ func testIngressEndpoints(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName: "fake1.ext-dns.test.com",
-					Target:  "8.8.8.8",
-				},
-				{
-					DNSName: "fake1.ext-dns.test.com",
-					Target:  "elb.com",
+					Targets: []string{"8.8.8.8", "elb.com"},
 				},
 			},
 			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
@@ -478,17 +462,17 @@ func testIngressEndpoints(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName:    "example.org",
-					Target:     "ingress-target.com",
+					Targets:    []string{"ingress-target.com"},
 					RecordType: endpoint.RecordTypeCNAME,
 				},
 				{
 					DNSName:    "example2.org",
-					Target:     "ingress-target.com",
+					Targets:    []string{"ingress-target.com"},
 					RecordType: endpoint.RecordTypeCNAME,
 				},
 				{
 					DNSName:    "example3.org",
-					Target:     "1.2.3.4",
+					Targets:    []string{"1.2.3.4"},
 					RecordType: endpoint.RecordTypeA,
 				},
 			},
@@ -521,12 +505,12 @@ func testIngressEndpoints(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName:   "example.org",
-					Target:    "ingress-target.com",
+					Targets:   []string{"ingress-target.com"},
 					RecordTTL: endpoint.TTL(6),
 				},
 				{
 					DNSName:   "example2.org",
-					Target:    "ingress-target.com",
+					Targets:   []string{"ingress-target.com"},
 					RecordTTL: endpoint.TTL(1),
 				},
 			},
@@ -568,17 +552,17 @@ func testIngressEndpoints(t *testing.T) {
 			expected: []*endpoint.Endpoint{
 				{
 					DNSName:    "fake1.ext-dns.test.com",
-					Target:     "ingress-target.com",
+					Targets:    []string{"ingress-target.com"},
 					RecordType: endpoint.RecordTypeCNAME,
 				},
 				{
 					DNSName:    "fake2.ext-dns.test.com",
-					Target:     "ingress-target.com",
+					Targets:    []string{"ingress-target.com"},
 					RecordType: endpoint.RecordTypeCNAME,
 				},
 				{
 					DNSName:    "fake3.ext-dns.test.com",
-					Target:     "1.2.3.4",
+					Targets:    []string{"1.2.3.4"},
 					RecordType: endpoint.RecordTypeA,
 				},
 			},

--- a/source/multi_source_test.go
+++ b/source/multi_source_test.go
@@ -40,8 +40,8 @@ func testMultiSourceImplementsSource(t *testing.T) {
 
 // testMultiSourceEndpoints tests merged endpoints from children are returned.
 func testMultiSourceEndpoints(t *testing.T) {
-	foo := &endpoint.Endpoint{DNSName: "foo", Target: "8.8.8.8"}
-	bar := &endpoint.Endpoint{DNSName: "bar", Target: "8.8.4.4"}
+	foo := &endpoint.Endpoint{DNSName: "foo", Targets: []string{"8.8.8.8"}}
+	bar := &endpoint.Endpoint{DNSName: "bar", Targets: []string{"8.8.4.4"}}
 
 	for _, tc := range []struct {
 		title           string

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -138,7 +138,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			false,
 		},
@@ -176,8 +176,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
-				{DNSName: "bar.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
+				{DNSName: "bar.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			false,
 		},
@@ -197,8 +197,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
-				{DNSName: "bar.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
+				{DNSName: "bar.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			false,
 		},
@@ -218,7 +218,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"lb.example.com"}, // Kubernetes omits the trailing dot
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "lb.example.com"},
+				{DNSName: "foo.example.org", Targets: []string{"lb.example.com"}},
 			},
 			false,
 		},
@@ -238,8 +238,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4", "lb.example.com"}, // Kubernetes omits the trailing dot
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
-				{DNSName: "foo.example.org", Target: "lb.example.com"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4", "lb.example.com"}},
 			},
 			false,
 		},
@@ -260,7 +259,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			false,
 		},
@@ -299,7 +298,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			false,
 		},
@@ -337,7 +336,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			false,
 		},
@@ -358,7 +357,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			false,
 		},
@@ -417,7 +416,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			false,
 		},
@@ -458,8 +457,10 @@ func testServiceSourceEndpoints(t *testing.T) {
 			[]*endpoint.Endpoint{},
 			false,
 		},
+		// test multiple services with different name
+		// test multiple services with same name
 		{
-			"multiple external entrypoints return multiple endpoints",
+			"multiple external entrypoints return single endpoint with multiple targets",
 			"",
 			"",
 			"testing",
@@ -474,8 +475,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4", "8.8.8.8"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
-				{DNSName: "foo.example.org", Target: "8.8.8.8"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4", "8.8.8.8"}},
 			},
 			false,
 		},
@@ -513,7 +513,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			false,
 		},
@@ -535,8 +535,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
-				{DNSName: "bar.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
+				{DNSName: "bar.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			false,
 		},
@@ -554,8 +554,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4", "elb.com"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.bar.example.com", Target: "1.2.3.4"},
-				{DNSName: "foo.bar.example.com", Target: "elb.com"},
+				{DNSName: "foo.bar.example.com", Targets: []string{"1.2.3.4"}},
+				{DNSName: "foo.bar.example.com", Targets: []string{"elb.com"}},
 			},
 			false,
 		},
@@ -575,8 +575,8 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4", "elb.com"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
-				{DNSName: "foo.example.org", Target: "elb.com"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
+				{DNSName: "foo.example.org", Targets: []string{"elb.com"}},
 			},
 			false,
 		},
@@ -596,7 +596,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "mate.example.org", Target: "1.2.3.4"},
+				{DNSName: "mate.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			false,
 		},
@@ -632,7 +632,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4", RecordTTL: endpoint.TTL(0)},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}, RecordTTL: endpoint.TTL(0)},
 			},
 			false,
 		},
@@ -653,7 +653,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4", RecordTTL: endpoint.TTL(0)},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}, RecordTTL: endpoint.TTL(0)},
 			},
 			false,
 		},
@@ -674,7 +674,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4", RecordTTL: endpoint.TTL(10)},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}, RecordTTL: endpoint.TTL(10)},
 			},
 			false,
 		},
@@ -695,7 +695,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			"",
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4", RecordTTL: endpoint.TTL(0)},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}, RecordTTL: endpoint.TTL(0)},
 			},
 			false,
 		},
@@ -793,7 +793,7 @@ func TestClusterIpServices(t *testing.T) {
 			"1.2.3.4",
 			[]string{},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Target: "1.2.3.4"},
+				{DNSName: "foo.example.org", Targets: []string{"1.2.3.4"}},
 			},
 			false,
 		},
@@ -811,7 +811,7 @@ func TestClusterIpServices(t *testing.T) {
 			"4.5.6.7",
 			[]string{},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.bar.example.com", Target: "4.5.6.7"},
+				{DNSName: "foo.bar.example.com", Targets: []string{"4.5.6.7"}},
 			},
 			false,
 		},
@@ -933,8 +933,8 @@ func TestHeadlessServices(t *testing.T) {
 			[]string{"foo-0", "foo-1"},
 			[]v1.PodPhase{v1.PodRunning, v1.PodRunning},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo-0.service.example.org", Target: "1.1.1.1"},
-				{DNSName: "foo-1.service.example.org", Target: "1.1.1.1"},
+				{DNSName: "foo-0.service.example.org", Targets: []string{"1.1.1.1"}},
+				{DNSName: "foo-1.service.example.org", Targets: []string{"1.1.1.1"}},
 			},
 			false,
 		},
@@ -959,7 +959,7 @@ func TestHeadlessServices(t *testing.T) {
 			[]string{"foo-0", "foo-1"},
 			[]v1.PodPhase{v1.PodRunning, v1.PodFailed},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo-0.service.example.org", Target: "1.1.1.1"},
+				{DNSName: "foo-0.service.example.org", Targets: []string{"1.1.1.1"}},
 			},
 			false,
 		},

--- a/source/shared_test.go
+++ b/source/shared_test.go
@@ -39,8 +39,14 @@ func validateEndpoint(t *testing.T, endpoint, expected *endpoint.Endpoint) {
 		t.Errorf("expected %s, got %s", expected.DNSName, endpoint.DNSName)
 	}
 
-	if endpoint.Target != expected.Target {
-		t.Errorf("expected %s, got %s", expected.Target, endpoint.Target)
+	if len(endpoint.Targets) != len(expected.Targets) {
+		t.Fatalf("expected %d targets, got %d", len(expected.Targets), len(endpoint.Targets))
+	}
+
+	for i := range endpoint.Targets {
+		if endpoint.Targets[i] != expected.Targets[i] {
+			t.Errorf("expected %s, got %s", expected.Targets[i], endpoint.Targets[i])
+		}
 	}
 
 	if endpoint.RecordTTL != expected.RecordTTL {


### PR DESCRIPTION
This is a work in progress to allow endpoints to have multiple targets, e.g. for NodePort services.

Issue: https://github.com/kubernetes-incubator/external-dns/issues/239

/cc @sethpollack