### PR TITLE
add some stub questions to the FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -84,3 +84,11 @@ Yes — Zalando replaced [Mate](https://github.com/zalando-incubator/mate) with 
 ### How can we start using ExternalDNS?
 
 Check out the following decriptive tutorials on how to run ExternalDNS in [GKE](tutorials/gke.md) and [AWS](tutorials/aws.md). 
+
+### I have a Service/Ingress but it's ignored by ExternalDNS. Why?
+
+TODO (https://github.com/kubernetes-incubator/external-dns/issues/267)
+
+### I'm using an ELB with TXT registry but the CNAME record clashes with the TXT record. How to avoid this?
+
+TODO (https://github.com/kubernetes-incubator/external-dns/issues/262)


### PR DESCRIPTION
How about anyone can add a question to the FAQ section via a PR so that we can go through and answer them from time to time. It's also possible to answer the question directly in the PR.

Background: we have several issues with questions that were answered but it's difficult to find them later. Instead people could add a stub question to the FAQ so we have a single place to look them up.

I don't know if anyone else does it this way. Feedback welcome @ideahitme @Raffo @hjacobs 