### PR TITLE
Support multiple hostnames for molecule compatibility

### DIFF
--- a/source/service_test.go
+++ b/source/service_test.go
@@ -355,11 +355,12 @@ func testServiceSourceEndpoints(t *testing.T) {
 				"dns": "route53",
 			},
 			map[string]string{
-				"domainName": "foo.example.org.",
+				"domainName": "foo.example.org., bar.example.org",
 			},
 			[]string{"1.2.3.4"},
 			[]*endpoint.Endpoint{
 				{DNSName: "foo.example.org", Target: "1.2.3.4"},
+				{DNSName: "bar.example.org", Target: "1.2.3.4"},
 			},
 			false,
 		},


### PR DESCRIPTION
Molecule supports multiple hostnames split by `,` but it wasn't supported until now.

See:
* https://github.com/kubernetes-incubator/external-dns/pull/256#issuecomment-319504658
* https://github.com/wearemolecule/route53-kubernetes/blob/master/service_listener.go#L160
