### PR TITLE
Add external-ip annotation for ingress

### DIFF
--- a/source/source.go
+++ b/source/source.go
@@ -21,6 +21,8 @@ import "github.com/kubernetes-incubator/external-dns/endpoint"
 const (
 	// The annotation used for figuring out which controller is responsible
 	controllerAnnotationKey = "external-dns.alpha.kubernetes.io/controller"
+	// The annotation used for overriding the ingress IP address
+	ingressExternalIPKey = "external-dns.alpha.kubernetes.io/external-ip"
 	// The annotation used for defining the desired hostname
 	hostnameAnnotationKey = "external-dns.alpha.kubernetes.io/hostname"
 	// The value of the controller annotation so that we feel resposible


### PR DESCRIPTION
Allow overriding the IP addresses used for ingress DNS records by
specifying an annotation.  This is intended to allow use with
keepalived-vip or other external (non-DNS) mechanisms for handling
failover between ingress instances.

This addresses #307.