### PR TITLE
Ingress target annotation should set, not append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.4.3 - 2017-08-17
+
+  - Fix to have external target annotations on ingress resources replace existing endpoints instead of appending to them (#318)
 ## v0.4.2 - 2017-08-03
 
   - Fix to support multiple hostnames for Molecule Software's [route53-kubernetes](https://github.com/wearemolecule/route53-kubernetes) compatibility (#301)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -59,9 +59,11 @@ Regarding Ingress, we'll support:
 
 ### Are other Ingress Controllers supported?
 
-For Ingress objects, ExternalDNS will attempt to discover the target hostname of the relevant Ingress Controller automatically. If you are using an Ingress Controller that is not listed above you may have issues with ExternalDNS not discovering Endpoints and consequently not creating any DNS records. As a workaround, it is possible to force create an Endpoint by manually specifying a target host/IP for the records to be created by setting the annotation `external-dns.alpha.kubernetes.io/target` in the Ingress object. 
+For Ingress objects, ExternalDNS will attempt to discover the target hostname of the relevant Ingress Controller automatically. If you are using an Ingress Controller that is not listed above you may have issues with ExternalDNS not discovering Endpoints and consequently not creating any DNS records. As a workaround, it is possible to force create an Endpoint by manually specifying a target host/IP for the records to be created by setting the annotation `external-dns.alpha.kubernetes.io/target` in the Ingress object.
 
-Note that the hostname specified in the Ingress object's annotation must already exist. (i.e.: You have a Service resource for your Ingress Controller with the `external-dns.alpha.kubernetes.io/hostname` annotation set to the same value.)
+Another reason you may want to override the ingress hostname or IP address is if you have an external mechanism for handling failover across ingress endpoints.  Possible scenarios for this would include using [keepalived-vip](https://github.com/kubernetes/contrib/tree/master/keepalived-vip) to manage failover faster than DNS TTLs might expire.
+
+Note that if you set the target to a hostname, then a CNAME record will be created.  In this case, the hostname specified in the Ingress object's annotation must already exist. (i.e.: You have a Service resource for your Ingress Controller with the `external-dns.alpha.kubernetes.io/hostname` annotation set to the same value.)
 
 ### What about those other projects?
 

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -33,7 +33,8 @@ import (
 
 // ingressSource is an implementation of Source for Kubernetes ingress objects.
 // Ingress implementation will use the spec.rules.host value for the hostname
-// Use targetAnnotationKey to add an additional Endpoint. (useful if the ingress controller does not update)
+// Use targetAnnotationKey to explicitly set Endpoint. (useful if the ingress
+// controller does not update, or to override with alternative endpoint)
 type ingressSource struct {
 	client       kubernetes.Interface
 	namespace    string
@@ -103,8 +104,11 @@ func (sc *ingressSource) Endpoints() ([]*endpoint.Endpoint, error) {
 	return endpoints, nil
 }
 
-// append endpoints from optional "target" annotation
-func addEndpointsFromTargetAnnotation(ing *v1beta1.Ingress, hostname string, endpoints []*endpoint.Endpoint) []*endpoint.Endpoint {
+// get endpoints from optional "target" annotation
+// Returns empty endpoints array if none are found.
+func getEndpointsFromTargetAnnotation(ing *v1beta1.Ingress, hostname string) []*endpoint.Endpoint {
+	var endpoints []*endpoint.Endpoint
+
 	// Get the desired hostname of the ingress from the annotation.
 	targetAnnotation, exists := ing.Annotations[targetAnnotationKey]
 	if exists {
@@ -129,7 +133,11 @@ func (sc *ingressSource) endpointsFromTemplate(ing *v1beta1.Ingress) ([]*endpoin
 
 	hostname := buf.String()
 
-	endpoints = addEndpointsFromTargetAnnotation(ing, hostname, endpoints)
+	endpoints = getEndpointsFromTargetAnnotation(ing, hostname)
+
+	if len(endpoints) != 0 {
+		return endpoints, nil
+	}
 
 	for _, lb := range ing.Status.LoadBalancer.Ingress {
 		if lb.IP != "" {
@@ -152,7 +160,12 @@ func endpointsFromIngress(ing *v1beta1.Ingress) []*endpoint.Endpoint {
 			continue
 		}
 
-		endpoints = addEndpointsFromTargetAnnotation(ing, rule.Host, endpoints)
+		annotationEndpoints := getEndpointsFromTargetAnnotation(ing, rule.Host)
+
+		if len(annotationEndpoints) != 0 {
+			endpoints = append(endpoints, annotationEndpoints...)
+			continue
+		}
 
 		for _, lb := range ing.Status.LoadBalancer.Ingress {
 			if lb.IP != "" {

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -370,10 +370,6 @@ func testIngressEndpoints(t *testing.T) {
 					DNSName: "example2.org",
 					Target:  "ingress-target.com",
 				},
-				{
-					DNSName: "example2.org",
-					Target:  "8.8.8.8",
-				},
 			},
 		},
 		{
@@ -408,10 +404,6 @@ func testIngressEndpoints(t *testing.T) {
 				{
 					DNSName: "fake2.ext-dns.test.com",
 					Target:  "ingress-target.com",
-				},
-				{
-					DNSName: "fake2.ext-dns.test.com",
-					Target:  "8.8.8.8",
 				},
 			},
 			fqdnTemplate: "{{.Name}}.ext-dns.test.com",


### PR DESCRIPTION
If the user has specified a target for the ingress, treat that as
overriding any endpoints already set on the ingress, even if that list
is not empty.  This allows overriding the IP address or hostname set
when using a service like kube-keepalived-vip.

This is related to #312 