### PR TITLE
Add support for Headless hostPort services

### DIFF
--- a/source/service.go
+++ b/source/service.go
@@ -192,14 +192,12 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string) []*
 	var endpoints []*endpoint.Endpoint
 
 	hostname = strings.TrimSuffix(hostname, ".")
-
 	switch svc.Spec.Type {
 	case v1.ServiceTypeLoadBalancer:
 		endpoints = append(endpoints, extractLoadBalancerEndpoints(svc, hostname)...)
 	case v1.ServiceTypeClusterIP:
 		if sc.publishInternal {
 			endpoints = append(endpoints, extractServiceIps(svc, hostname)...)
-
 		}
 	}
 

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -674,6 +674,144 @@ func TestClusterIpServices(t *testing.T) {
 	}
 }
 
+// TestHeadlessServices tests that headless services generate the correct endpoints.
+func TestHeadlessServices(t *testing.T) {
+	for _, tc := range []struct {
+		title           string
+		targetNamespace string
+		svcNamespace    string
+		svcName         string
+		svcType         v1.ServiceType
+		compatibility   string
+		fqdnTemplate    string
+		labels          map[string]string
+		annotations     map[string]string
+		clusterIP       string
+		hostIP          string
+		selector        map[string]string
+		lbs             []string
+		hostnames       []string
+		phases          []v1.PodPhase
+		expected        []*endpoint.Endpoint
+		expectError     bool
+	}{
+		{
+			"annotated Headless services return endpoints for each selected Pod",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeClusterIP,
+			"",
+			"",
+			map[string]string{"component": "foo"},
+			map[string]string{
+				headlessDomainAnnotationKey: ".example.org.",
+			},
+			v1.ClusterIPNone,
+			"1.1.1.1",
+			map[string]string{
+				"component": "foo",
+			},
+			[]string{},
+			[]string{"foo-0", "foo-1"},
+			[]v1.PodPhase{v1.PodRunning, v1.PodRunning},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo-0.example.org", Target: "1.1.1.1"},
+				{DNSName: "foo-1.example.org", Target: "1.1.1.1"},
+			},
+			false,
+		},
+		{
+			"annotated Headless services return endpoints for each selected Pod, which are in running state",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeClusterIP,
+			"",
+			"",
+			map[string]string{"component": "foo"},
+			map[string]string{
+				headlessDomainAnnotationKey: ".example.org.",
+			},
+			v1.ClusterIPNone,
+			"1.1.1.1",
+			map[string]string{
+				"component": "foo",
+			},
+			[]string{},
+			[]string{"foo-0", "foo-1"},
+			[]v1.PodPhase{v1.PodRunning, v1.PodFailed},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo-0.example.org", Target: "1.1.1.1"},
+			},
+			false,
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			// Create a Kubernetes testing client
+			kubernetes := fake.NewSimpleClientset()
+
+			service := &v1.Service{
+				Spec: v1.ServiceSpec{
+					Type:      tc.svcType,
+					ClusterIP: tc.clusterIP,
+					Selector:  tc.selector,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   tc.svcNamespace,
+					Name:        tc.svcName,
+					Labels:      tc.labels,
+					Annotations: tc.annotations,
+				},
+				Status: v1.ServiceStatus{},
+			}
+			_, err := kubernetes.CoreV1().Services(service.Namespace).Create(service)
+			require.NoError(t, err)
+			for i, hostname := range tc.hostnames {
+				pod := &v1.Pod{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{},
+						Hostname:   hostname,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   tc.svcNamespace,
+						Name:        hostname,
+						Labels:      tc.labels,
+						Annotations: tc.annotations,
+					},
+					Status: v1.PodStatus{
+						HostIP: tc.hostIP,
+						Phase:  tc.phases[i],
+					},
+				}
+
+				_, err := kubernetes.CoreV1().Pods(tc.svcNamespace).Create(pod)
+				require.NoError(t, err)
+			}
+
+			// Create our object under test and get the endpoints.
+			client, _ := NewServiceSource(
+				kubernetes,
+				tc.targetNamespace,
+				tc.fqdnTemplate,
+				tc.compatibility,
+				true,
+			)
+			require.NoError(t, err)
+
+			endpoints, err := client.Endpoints()
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Validate returned endpoints against desired endpoints.
+			validateEndpoints(t, endpoints, tc.expected)
+		})
+	}
+}
+
 func BenchmarkServiceEndpoints(b *testing.B) {
 	kubernetes := fake.NewSimpleClientset()
 

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -767,6 +767,7 @@ func TestHeadlessServices(t *testing.T) {
 			}
 			_, err := kubernetes.CoreV1().Services(service.Namespace).Create(service)
 			require.NoError(t, err)
+
 			for i, hostname := range tc.hostnames {
 				pod := &v1.Pod{
 					Spec: v1.PodSpec{
@@ -785,7 +786,7 @@ func TestHeadlessServices(t *testing.T) {
 					},
 				}
 
-				_, err := kubernetes.CoreV1().Pods(tc.svcNamespace).Create(pod)
+				_, err = kubernetes.CoreV1().Pods(tc.svcNamespace).Create(pod)
 				require.NoError(t, err)
 			}
 

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -705,7 +705,7 @@ func TestHeadlessServices(t *testing.T) {
 			"",
 			map[string]string{"component": "foo"},
 			map[string]string{
-				headlessDomainAnnotationKey: ".example.org.",
+				hostnameAnnotationKey: "service.example.org",
 			},
 			v1.ClusterIPNone,
 			"1.1.1.1",
@@ -716,8 +716,8 @@ func TestHeadlessServices(t *testing.T) {
 			[]string{"foo-0", "foo-1"},
 			[]v1.PodPhase{v1.PodRunning, v1.PodRunning},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo-0.example.org", Target: "1.1.1.1"},
-				{DNSName: "foo-1.example.org", Target: "1.1.1.1"},
+				{DNSName: "foo-0.service.example.org", Target: "1.1.1.1"},
+				{DNSName: "foo-1.service.example.org", Target: "1.1.1.1"},
 			},
 			false,
 		},
@@ -731,7 +731,7 @@ func TestHeadlessServices(t *testing.T) {
 			"",
 			map[string]string{"component": "foo"},
 			map[string]string{
-				headlessDomainAnnotationKey: ".example.org.",
+				hostnameAnnotationKey: "service.example.org",
 			},
 			v1.ClusterIPNone,
 			"1.1.1.1",
@@ -742,7 +742,7 @@ func TestHeadlessServices(t *testing.T) {
 			[]string{"foo-0", "foo-1"},
 			[]v1.PodPhase{v1.PodRunning, v1.PodFailed},
 			[]*endpoint.Endpoint{
-				{DNSName: "foo-0.example.org", Target: "1.1.1.1"},
+				{DNSName: "foo-0.service.example.org", Target: "1.1.1.1"},
 			},
 			false,
 		},

--- a/source/source.go
+++ b/source/source.go
@@ -25,8 +25,6 @@ const (
 	hostnameAnnotationKey = "external-dns.alpha.kubernetes.io/hostname"
 	// The annotation used for defining the desired ingress target
 	targetAnnotationKey = "external-dns.alpha.kubernetes.io/target"
-	// The annotation used for defining a subdomain the Pods of a headless service are going to be injected into
-	headlessDomainAnnotationKey = "external-dns.alpha.kubernetes.io/headlessDomain"
 	// The value of the controller annotation so that we feel resposible
 	controllerAnnotationValue = "dns-controller"
 )

--- a/source/source.go
+++ b/source/source.go
@@ -25,6 +25,8 @@ const (
 	hostnameAnnotationKey = "external-dns.alpha.kubernetes.io/hostname"
 	// The annotation used for defining the desired ingress target
 	targetAnnotationKey = "external-dns.alpha.kubernetes.io/target"
+	// The annotation used for defining a subdomain the Pods of a headless service are going to be injected into
+	headlessDomainAnnotationKey = "external-dns.alpha.kubernetes.io/headlessDomain"
 	// The value of the controller annotation so that we feel resposible
 	controllerAnnotationValue = "dns-controller"
 )


### PR DESCRIPTION
A simple implementation for #315 and based on #278.

The idea is, to assign a DNS address for every Pod running under a Headless service. This is a fairly important usecase in my mind, for exposing Stateful services, which have some kind of inbuilt discovery mechanism, like Apache Kafka. As these services can only really properly work with a HostPort(I did not find any other way), it makes sense to export their HostIP as a stable DNS record.

I thought about a number of approaches to parametrize this, but the simple approach was to add a subdomain annotation. Conceptually we would want  for each Pod appear with the hostname assigned to it by the StatefulSet, so we only  need to concerned with the subdomain where the Pods are registered.

So I added a new annotation `external-dns.alpha.kubernetes.io/headlessDomain`, which is basically the subdomain, i.e `.example.org`. I was unsure about adding the `.` in code or in the annotation.

It does not address generating a SRV record and simply generates A records for every running Pod, with the HostIP.

This is my first time coding against the Kubernetes API or in GO, so any comments about structure/style and other mistakes are welcome. I am also not 100% sure the approach I took is perfect, so comments are welcome.

