### PR TITLE
add flag to override log-level

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,9 +54,12 @@ func main() {
 	if cfg.DryRun {
 		log.Info("running in dry-run mode. No changes to DNS records will be made.")
 	}
-	if cfg.Debug {
-		log.SetLevel(log.DebugLevel)
+
+	ll, err := log.ParseLevel(cfg.LogLevel)
+	if err != nil {
+		log.Fatalf("failed to parse log level: %v", err)
 	}
+	log.SetLevel(ll)
 
 	stopChan := make(chan struct{}, 1)
 

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -19,6 +19,7 @@ package externaldns
 import (
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/alecthomas/kingpin"
 )
 
@@ -49,7 +50,7 @@ type Config struct {
 	DryRun             bool
 	LogFormat          string
 	MetricsAddress     string
-	Debug              bool
+	LogLevel           string
 }
 
 var defaultConfig = &Config{
@@ -74,12 +75,21 @@ var defaultConfig = &Config{
 	DryRun:             false,
 	LogFormat:          "text",
 	MetricsAddress:     ":7979",
-	Debug:              false,
+	LogLevel:           logrus.InfoLevel.String(),
 }
 
 // NewConfig returns new Config object
 func NewConfig() *Config {
 	return &Config{}
+}
+
+// allLogLevelsAsStrings returns all logrus levels as a list of strings
+func allLogLevelsAsStrings() []string {
+	var levels []string
+	for _, level := range logrus.AllLevels {
+		levels = append(levels, level.String())
+	}
+	return levels
 }
 
 // ParseFlags adds and parses flags from command line
@@ -122,7 +132,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	// Miscellaneous flags
 	app.Flag("log-format", "The format in which log messages are printed (default: text, options: text, json)").Default(defaultConfig.LogFormat).EnumVar(&cfg.LogFormat, "text", "json")
 	app.Flag("metrics-address", "Specify where to serve the metrics and health check endpoint (default: :7979)").Default(defaultConfig.MetricsAddress).StringVar(&cfg.MetricsAddress)
-	app.Flag("debug", "When enabled, increases the logging output for debugging purposes (default: disabled)").BoolVar(&cfg.Debug)
+	app.Flag("log-level", "Set the level of logging. (default: info, options: panic, debug, info, warn, error, fatal").Default(defaultConfig.LogLevel).EnumVar(&cfg.LogLevel, allLogLevelsAsStrings()...)
 
 	_, err := app.Parse(args)
 	if err != nil {

--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,7 +48,7 @@ var (
 		DryRun:             false,
 		LogFormat:          "text",
 		MetricsAddress:     ":7979",
-		Debug:              false,
+		LogLevel:           logrus.InfoLevel.String(),
 	}
 
 	overriddenConfig = &Config{
@@ -71,7 +72,7 @@ var (
 		DryRun:             true,
 		LogFormat:          "json",
 		MetricsAddress:     "127.0.0.1:9099",
-		Debug:              true,
+		LogLevel:           logrus.DebugLevel.String(),
 	}
 )
 
@@ -116,7 +117,7 @@ func TestParseFlags(t *testing.T) {
 				"--dry-run",
 				"--log-format=json",
 				"--metrics-address=127.0.0.1:9099",
-				"--debug",
+				"--log-level=debug",
 			},
 			envVars:  map[string]string{},
 			expected: overriddenConfig,
@@ -145,7 +146,7 @@ func TestParseFlags(t *testing.T) {
 				"EXTERNAL_DNS_DRY_RUN":              "1",
 				"EXTERNAL_DNS_LOG_FORMAT":           "json",
 				"EXTERNAL_DNS_METRICS_ADDRESS":      "127.0.0.1:9099",
-				"EXTERNAL_DNS_DEBUG":                "1",
+				"EXTERNAL_DNS_LOG_LEVEL":            "debug",
 			},
 			expected: overriddenConfig,
 		},


### PR DESCRIPTION
Adds a new `--log-level` flag which sets the appropriate logrus log-level. Valid values are `debug`, `info`, `warn`, `error`, and `fatal`.

Removed the `--debug` flag in favor of the new, more flexible, `--log-level` flag.