### PR TITLE
WIP: Support AWS policy for weighted records

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ LDFLAGS       ?= -X github.com/kubernetes-incubator/external-dns/pkg/apis/extern
 build: build/$(BINARY)
 
 build/$(BINARY): $(SOURCES)
-	CGO_ENABLED=0 go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
+	CGO_ENABLED=0 GOOS=linux go build -o build/$(BINARY) $(BUILD_FLAGS) -ldflags "$(LDFLAGS)" .
 
 build.push: build.docker
 	docker push "$(IMAGE):$(VERSION)"

--- a/endpoint/aws_route53_policy.go
+++ b/endpoint/aws_route53_policy.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"fmt"
+)
+
+// AWSRoute53Policy stores the policy attributes for the Route53 record
+type AWSRoute53Policy struct {
+	// Weight is the weight of the RecordSet
+	Weight int64
+	// SetIdentifier for the RecordSet
+	SetIdentifier string
+}
+
+// NewAWSRoute53Policy does basic validation according to AWS requirements and returns the Route53 policy
+func NewAWSRoute53Policy(weight int64, setIdentifier string) (*AWSRoute53Policy, error) {
+	if weight < 0 || weight > 255 {
+		return &AWSRoute53Policy{}, fmt.Errorf("Weight must be between 0-255. Actual: %d", weight)
+	}
+
+	if len(setIdentifier) < 1 || len(setIdentifier) > 128 {
+		return &AWSRoute53Policy{}, fmt.Errorf("Set Identifier must be between 1-128 characters. Actual: %s",
+			setIdentifier)
+	}
+
+	return &AWSRoute53Policy{
+		Weight:        weight,
+		SetIdentifier: setIdentifier,
+	}, nil
+}

--- a/endpoint/aws_route53_policy_test.go
+++ b/endpoint/aws_route53_policy_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoute53WeightPolicy(t *testing.T) {
+	t.Run("AWSRoute53Policy", TestNewAWSRoute53Policy)
+}
+
+func TestNewAWSRoute53Policy(t *testing.T) {
+	for _, ti := range []struct {
+		title         string
+		weight        int64
+		setIdentifier string
+		expectError   bool
+	}{
+		{
+			title:         "invalid weight",
+			weight:        -1,
+			setIdentifier: "cluster/id",
+			expectError:   true,
+		},
+		{
+			title:         "invalid weight",
+			weight:        256,
+			setIdentifier: "cluster/id",
+			expectError:   true,
+		},
+		{
+			title:  "invalid set identifier",
+			weight: 1,
+			setIdentifier: "11111111111111111111111111111111111111111111111111111111111111111111111111111" +
+				"1111111111111111111111111111111111111111111111111111",
+			expectError: true,
+		},
+		{
+			title:         "invalid set identifier",
+			weight:        1,
+			setIdentifier: "",
+			expectError:   true,
+		},
+		{
+			title:         "valid weight and set identifier",
+			weight:        1,
+			setIdentifier: "cluster/id",
+			expectError:   false,
+		},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			_, err := NewAWSRoute53Policy(
+				ti.weight,
+				ti.setIdentifier,
+			)
+			if ti.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAWSRoute53Policy_SetIdentifier(t *testing.T) {
+	for _, ti := range []struct {
+		title         string
+		weight        int64
+		setIdentifier string
+		expected      string
+	}{
+		{
+			title:         "valid weight ID",
+			weight:        1,
+			setIdentifier: "cluster/id",
+			expected:      "cluster/id",
+		},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			policy, _ := NewAWSRoute53Policy(
+				ti.weight,
+				ti.setIdentifier,
+			)
+			assert.Equal(t, policy.SetIdentifier, ti.expected)
+		})
+	}
+}
+
+func TestAWSRoute53Policy_Weight(t *testing.T) {
+	for _, ti := range []struct {
+		title         string
+		weight        int64
+		setIdentifier string
+		expected      int64
+	}{
+		{
+			title:         "valid weight ID",
+			weight:        1,
+			setIdentifier: "cluster/id",
+			expected:      1,
+		},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			policy, _ := NewAWSRoute53Policy(
+				ti.weight,
+				ti.setIdentifier,
+			)
+			assert.Equal(t, policy.Weight, ti.expected)
+		})
+	}
+}

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -30,6 +30,8 @@ const (
 	RecordTypeCNAME = "CNAME"
 	// RecordTypeTXT is a RecordType enum value
 	RecordTypeTXT = "TXT"
+	// TxtOwnedLabelKey is label that helps determine when TXT records are created or deleted for the endpoint
+	TxtOwnedLabelKey = "txt-owned"
 )
 
 // Endpoint is a high-level way of a connection between a service and an IP
@@ -40,6 +42,8 @@ type Endpoint struct {
 	Target string
 	// RecordType type of record, e.g. CNAME, A, TXT etc
 	RecordType string
+	// Policy stores policies for the endpoint
+	Policy Policy
 	// Labels stores labels defined for the Endpoint
 	Labels map[string]string
 }
@@ -50,6 +54,7 @@ func NewEndpoint(dnsName, target, recordType string) *Endpoint {
 		DNSName:    strings.TrimSuffix(dnsName, "."),
 		Target:     strings.TrimSuffix(target, "."),
 		RecordType: recordType,
+		Policy:     Policy{},
 		Labels:     map[string]string{},
 	}
 }

--- a/endpoint/policy.go
+++ b/endpoint/policy.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+// Policy is a generic policy that stores provider-specific policies
+type Policy struct {
+	// AWSRoute53 is the AWS Route53 policy for the endpoint
+	AWSRoute53 *AWSRoute53Policy
+}
+
+// AttachAWSRoute53Policy attaches a Route53 policy to an endpoint
+func (e *Policy) AttachAWSRoute53Policy(awsRoute53Policy *AWSRoute53Policy) {
+	e.AWSRoute53 = awsRoute53Policy
+}
+
+// HasAWSRoute53Policy checks whether an endpoint has a Route53 policy attached
+func (e *Policy) HasAWSRoute53Policy() bool {
+	// Return false when no attributes of the AWS Route 53 policy have been set
+	if e.AWSRoute53 != nil {
+		if e.AWSRoute53.Weight >= 0 && e.AWSRoute53.SetIdentifier != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/endpoint/policy_test.go
+++ b/endpoint/policy_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoint
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	"testing"
+)
+
+func TestEndpointPolicy_AttachAWSRoute53Policy(t *testing.T) {
+	p := Policy{}
+	w, _ := NewAWSRoute53Policy(1, "cluster/id")
+	p.AttachAWSRoute53Policy(w)
+	assert.True(t, p.HasAWSRoute53Policy())
+}
+
+func TestHasAWSRoute53Policy(t *testing.T) {
+	p := Policy{}
+	assert.False(t, p.HasAWSRoute53Policy())
+}

--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -16,8 +16,10 @@ limitations under the License.
 
 package testutils
 
-import "github.com/kubernetes-incubator/external-dns/endpoint"
-import "sort"
+import (
+	"github.com/kubernetes-incubator/external-dns/endpoint"
+	"sort"
+)
 
 /** test utility functions for endpoints verifications */
 

--- a/provider/azure.go
+++ b/provider/azure.go
@@ -150,14 +150,14 @@ func (p *AzureProvider) Records() (endpoints []*endpoint.Endpoint, _ error) {
 					log.Errorf("Failed to extract target for '%s' with type '%s'.", name, recordType)
 					return true
 				}
-				endpoint := endpoint.NewEndpoint(name, target, recordType)
+				ep := endpoint.NewEndpoint(name, target, recordType)
 				log.Debugf(
 					"Found %s record for '%s' with target '%s'.",
-					endpoint.RecordType,
-					endpoint.DNSName,
-					endpoint.Target,
+					ep.RecordType,
+					ep.DNSName,
+					ep.Target,
 				)
-				endpoints = append(endpoints, endpoint)
+				endpoints = append(endpoints, ep)
 			default:
 			}
 			return true

--- a/provider/inmemory.go
+++ b/provider/inmemory.go
@@ -52,6 +52,12 @@ type InMemoryProvider struct {
 // InMemoryOption allows to extend in-memory provider
 type InMemoryOption func(*InMemoryProvider)
 
+// InMemoryZone stores endpoints for each zone
+type InMemoryZone struct {
+	ZoneID    string
+	Endpoints []*endpoint.Endpoint
+}
+
 // InMemoryWithLogging injects logging when ApplyChanges is called
 func InMemoryWithLogging() InMemoryOption {
 	return func(p *InMemoryProvider) {
@@ -102,7 +108,7 @@ func (im *InMemoryProvider) CreateZone(newZone string) error {
 }
 
 // Zones returns filtered zones as specified by domain
-func (im *InMemoryProvider) Zones() map[string]string {
+func (im *InMemoryProvider) Zones() []InMemoryZone {
 	return im.filter.Zones(im.client.Zones())
 }
 
@@ -112,15 +118,13 @@ func (im *InMemoryProvider) Records() ([]*endpoint.Endpoint, error) {
 
 	endpoints := make([]*endpoint.Endpoint, 0)
 
-	for zoneID := range im.Zones() {
-		records, err := im.client.Records(zoneID)
+	for _, zone := range im.Zones() {
+		records, err := im.client.Records(zone.ZoneID)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, record := range records {
-			endpoints = append(endpoints, endpoint.NewEndpoint(record.Name, record.Target, record.Type))
-		}
+		endpoints = append(endpoints, records...)
 	}
 
 	return endpoints, nil
@@ -137,10 +141,9 @@ func (im *InMemoryProvider) ApplyChanges(changes *plan.Changes) error {
 	perZoneChanges := map[string]*plan.Changes{}
 
 	zones := im.Zones()
-	for zoneID := range zones {
-		perZoneChanges[zoneID] = &plan.Changes{}
+	for _, zone := range zones {
+		perZoneChanges[zone.ZoneID] = &plan.Changes{}
 	}
-
 	for _, ep := range changes.Create {
 		zoneID := im.filter.EndpointZoneID(ep, zones)
 		perZoneChanges[zoneID].Create = append(perZoneChanges[zoneID].Create, ep)
@@ -160,10 +163,10 @@ func (im *InMemoryProvider) ApplyChanges(changes *plan.Changes) error {
 
 	for zoneID := range perZoneChanges {
 		change := &inMemoryChange{
-			Create:    convertToInMemoryRecord(perZoneChanges[zoneID].Create),
-			UpdateNew: convertToInMemoryRecord(perZoneChanges[zoneID].UpdateNew),
-			UpdateOld: convertToInMemoryRecord(perZoneChanges[zoneID].UpdateOld),
-			Delete:    convertToInMemoryRecord(perZoneChanges[zoneID].Delete),
+			Create:    perZoneChanges[zoneID].Create,
+			UpdateNew: perZoneChanges[zoneID].UpdateNew,
+			UpdateOld: perZoneChanges[zoneID].UpdateOld,
+			Delete:    perZoneChanges[zoneID].Delete,
 		}
 		err := im.client.ApplyChanges(zoneID, change)
 		if err != nil {
@@ -174,98 +177,79 @@ func (im *InMemoryProvider) ApplyChanges(changes *plan.Changes) error {
 	return nil
 }
 
-func convertToInMemoryRecord(endpoints []*endpoint.Endpoint) []*inMemoryRecord {
-	records := []*inMemoryRecord{}
-	for _, ep := range endpoints {
-		records = append(records, &inMemoryRecord{
-			Type:   ep.RecordType,
-			Name:   ep.DNSName,
-			Target: ep.Target,
-		})
-	}
-	return records
-}
-
 type filter struct {
 	domain string
 }
 
 // Zones filters map[zoneID]zoneName for names having f.domain as suffix
-func (f *filter) Zones(zones map[string]string) map[string]string {
-	result := map[string]string{}
-	for zoneID, zoneName := range zones {
-		if strings.HasSuffix(zoneName, f.domain) {
-			result[zoneID] = zoneName
+func (f *filter) Zones(zones []InMemoryZone) []InMemoryZone {
+	result := []InMemoryZone{}
+	for _, zone := range zones {
+		if strings.HasSuffix(zone.ZoneID, f.domain) {
+			result = append(result, InMemoryZone{ZoneID: zone.ZoneID, Endpoints: zone.Endpoints})
 		}
 	}
 	return result
 }
 
-// EndpointZoneID determines zoneID for endpoint from map[zoneID]zoneName by taking longest suffix zoneName match in endpoint DNSName
+// EndpointZoneID determines zoneID for an endpoint from []InMemoryZone by taking the highest level domain which has an
+// endpoint.DNSName that matches the suffix of the zone
 // returns empty string if no match found
-func (f *filter) EndpointZoneID(endpoint *endpoint.Endpoint, zones map[string]string) (zoneID string) {
-	var matchZoneID, matchZoneName string
-	for zoneID, zoneName := range zones {
-		if strings.HasSuffix(endpoint.DNSName, zoneName) && len(zoneName) > len(matchZoneName) {
-			matchZoneName = zoneName
-			matchZoneID = zoneID
+func (f *filter) EndpointZoneID(endpoint *endpoint.Endpoint, zones []InMemoryZone) string {
+	var matchZoneName string
+	var domainLevel int
+	for _, zone := range zones {
+		domainLevel = len(strings.Split(endpoint.DNSName, ".")[1:])
+		if strings.HasSuffix(endpoint.DNSName, zone.ZoneID) &&
+			domainLevel >= len(strings.Split(matchZoneName, ".")) {
+			matchZoneName = zone.ZoneID
 		}
 	}
-	return matchZoneID
+	return matchZoneName
 }
-
-// inMemoryRecord - record stored in memory
-// Type - type of record
-// Name - DNS name assigned to the record
-// Target - target of the record
-type inMemoryRecord struct {
-	Type   string
-	Name   string
-	Target string
-}
-
-type zone map[string][]*inMemoryRecord
 
 type inMemoryChange struct {
-	Create    []*inMemoryRecord
-	UpdateNew []*inMemoryRecord
-	UpdateOld []*inMemoryRecord
-	Delete    []*inMemoryRecord
+	Create    []*endpoint.Endpoint
+	UpdateNew []*endpoint.Endpoint
+	UpdateOld []*endpoint.Endpoint
+	Delete    []*endpoint.Endpoint
 }
 
 type inMemoryClient struct {
-	zones map[string]zone
+	zones []InMemoryZone
 }
 
 func newInMemoryClient() *inMemoryClient {
-	return &inMemoryClient{map[string]zone{}}
+	return &inMemoryClient{zones: []InMemoryZone{}}
 }
 
-func (c *inMemoryClient) Records(zone string) ([]*inMemoryRecord, error) {
-	if _, ok := c.zones[zone]; !ok {
+func (c *inMemoryClient) Records(zone string) ([]*endpoint.Endpoint, error) {
+	zoneExists := false
+	records := []*endpoint.Endpoint{}
+	for _, z := range c.zones {
+		if z.ZoneID == zone {
+			zoneExists = true
+			records = append(records, z.Endpoints...)
+		}
+	}
+	if !zoneExists {
 		return nil, ErrZoneNotFound
 	}
 
-	records := []*inMemoryRecord{}
-	for _, rec := range c.zones[zone] {
-		records = append(records, rec...)
-	}
 	return records, nil
 }
 
-func (c *inMemoryClient) Zones() map[string]string {
-	zones := map[string]string{}
-	for zone := range c.zones {
-		zones[zone] = zone
-	}
-	return zones
+func (c *inMemoryClient) Zones() []InMemoryZone {
+	return c.zones
 }
 
 func (c *inMemoryClient) CreateZone(zone string) error {
-	if _, ok := c.zones[zone]; ok {
-		return ErrZoneAlreadyExists
+	for _, z := range c.zones {
+		if z.ZoneID == zone {
+			return ErrZoneAlreadyExists
+		}
 	}
-	c.zones[zone] = map[string][]*inMemoryRecord{}
+	c.zones = append(c.zones, InMemoryZone{ZoneID: zone})
 
 	return nil
 }
@@ -275,52 +259,69 @@ func (c *inMemoryClient) ApplyChanges(zoneID string, changes *inMemoryChange) er
 		return err
 	}
 	for _, newEndpoint := range changes.Create {
-		if _, ok := c.zones[zoneID][newEndpoint.Name]; !ok {
-			c.zones[zoneID][newEndpoint.Name] = make([]*inMemoryRecord, 0)
+		for i, z := range c.zones {
+			if z.ZoneID == zoneID {
+				c.zones[i].Endpoints = append(c.zones[i].Endpoints, newEndpoint)
+			}
 		}
-		c.zones[zoneID][newEndpoint.Name] = append(c.zones[zoneID][newEndpoint.Name], newEndpoint)
 	}
 	for _, updateEndpoint := range changes.UpdateNew {
-		for _, rec := range c.zones[zoneID][updateEndpoint.Name] {
-			if rec.Type == updateEndpoint.Type {
-				rec.Target = updateEndpoint.Target
-				break
+		for i, z := range c.zones {
+			if z.ZoneID == zoneID {
+				for i2, rec := range z.Endpoints {
+					if c.recordsAreTheSame(rec, updateEndpoint) {
+						c.zones[i].Endpoints[i2] = updateEndpoint
+					}
+				}
 			}
 		}
 	}
 	for _, deleteEndpoint := range changes.Delete {
-		newSet := make([]*inMemoryRecord, 0)
-		for _, rec := range c.zones[zoneID][deleteEndpoint.Name] {
-			if rec.Type != deleteEndpoint.Type {
-				newSet = append(newSet, rec)
+		newSet := make([]*endpoint.Endpoint, 0)
+		for _, z := range c.zones {
+			if z.ZoneID == zoneID {
+				for _, rec := range z.Endpoints {
+					if !c.recordsAreTheSame(rec, deleteEndpoint) {
+						newSet = append(newSet, rec)
+					}
+				}
 			}
 		}
-		c.zones[zoneID][deleteEndpoint.Name] = newSet
+		for i, z := range c.zones {
+			if z.ZoneID == zoneID {
+				c.zones[i].Endpoints = newSet
+			}
+		}
+
 	}
 	return nil
 }
 
-func (c *inMemoryClient) updateMesh(mesh map[string]map[string]bool, record *inMemoryRecord) error {
-	if _, exists := mesh[record.Name]; exists {
-		if mesh[record.Name][record.Type] {
-			return ErrDuplicateRecordFound
-		}
-		mesh[record.Name][record.Type] = true
-		return nil
+func (c *inMemoryClient) updateMesh(mesh *InMemoryZone, record *endpoint.Endpoint) error {
+	if rec := c.findRecord(record, mesh.Endpoints); rec != nil {
+		return ErrDuplicateRecordFound
 	}
-	mesh[record.Name] = map[string]bool{record.Type: true}
+	mesh.Endpoints = append(mesh.Endpoints, record)
 	return nil
 }
 
 // validateChangeBatch validates that the changes passed to InMemory DNS provider is valid
 func (c *inMemoryClient) validateChangeBatch(zone string, changes *inMemoryChange) error {
-	curZone, ok := c.zones[zone]
-	if !ok {
+	zoneExists := false
+	var curZone InMemoryZone
+	for _, z := range c.zones {
+		if z.ZoneID == zone {
+			curZone = z
+			zoneExists = true
+		}
+	}
+	if !zoneExists {
 		return ErrZoneNotFound
 	}
-	mesh := map[string]map[string]bool{}
+
+	mesh := &InMemoryZone{}
 	for _, newEndpoint := range changes.Create {
-		if c.findByType(newEndpoint.Type, curZone[newEndpoint.Name]) != nil {
+		if c.findRecord(newEndpoint, curZone.Endpoints) != nil {
 			return ErrRecordAlreadyExists
 		}
 		if err := c.updateMesh(mesh, newEndpoint); err != nil {
@@ -328,7 +329,7 @@ func (c *inMemoryClient) validateChangeBatch(zone string, changes *inMemoryChang
 		}
 	}
 	for _, updateEndpoint := range changes.UpdateNew {
-		if c.findByType(updateEndpoint.Type, curZone[updateEndpoint.Name]) == nil {
+		if c.findRecord(updateEndpoint, curZone.Endpoints) == nil {
 			return ErrRecordNotFound
 		}
 		if err := c.updateMesh(mesh, updateEndpoint); err != nil {
@@ -336,12 +337,12 @@ func (c *inMemoryClient) validateChangeBatch(zone string, changes *inMemoryChang
 		}
 	}
 	for _, updateOldEndpoint := range changes.UpdateOld {
-		if rec := c.findByType(updateOldEndpoint.Type, curZone[updateOldEndpoint.Name]); rec == nil || rec.Target != updateOldEndpoint.Target {
+		if rec := c.findRecord(updateOldEndpoint, curZone.Endpoints); rec == nil || rec.Target != updateOldEndpoint.Target {
 			return ErrRecordNotFound
 		}
 	}
 	for _, deleteEndpoint := range changes.Delete {
-		if rec := c.findByType(deleteEndpoint.Type, curZone[deleteEndpoint.Name]); rec == nil || rec.Target != deleteEndpoint.Target {
+		if rec := c.findRecord(deleteEndpoint, curZone.Endpoints); rec == nil || rec.Target != deleteEndpoint.Target {
 			return ErrRecordNotFound
 		}
 		if err := c.updateMesh(mesh, deleteEndpoint); err != nil {
@@ -351,11 +352,24 @@ func (c *inMemoryClient) validateChangeBatch(zone string, changes *inMemoryChang
 	return nil
 }
 
-func (c *inMemoryClient) findByType(recordType string, records []*inMemoryRecord) *inMemoryRecord {
-	for _, record := range records {
-		if record.Type == recordType {
-			return record
+func (c *inMemoryClient) findRecord(record *endpoint.Endpoint, records []*endpoint.Endpoint) *endpoint.Endpoint {
+	for _, r := range records {
+		if c.recordsAreTheSame(r, record) {
+			return r
 		}
 	}
 	return nil
+}
+
+func (c *inMemoryClient) recordsAreTheSame(recordOne *endpoint.Endpoint, recordTwo *endpoint.Endpoint) bool {
+	if recordOne != nil && recordOne.DNSName == recordTwo.DNSName && recordOne.RecordType == recordTwo.RecordType {
+		if recordOne.Policy.HasAWSRoute53Policy() {
+			if recordOne.Policy.AWSRoute53.SetIdentifier == recordTwo.Policy.AWSRoute53.SetIdentifier {
+				return true
+			}
+		} else {
+			return true
+		}
+	}
+	return false
 }

--- a/source/fake.go
+++ b/source/fake.go
@@ -66,13 +66,13 @@ func (sc *fakeSource) Endpoints() ([]*endpoint.Endpoint, error) {
 }
 
 func (sc *fakeSource) generateEndpoint() (*endpoint.Endpoint, error) {
-	endpoint := endpoint.NewEndpoint(
+	ep := endpoint.NewEndpoint(
 		generateDNSName(4, sc.dnsName),
 		generateIPAddress(),
 		endpoint.RecordTypeA,
 	)
 
-	return endpoint, nil
+	return ep, nil
 }
 
 func generateIPAddress() string {

--- a/source/raw.go
+++ b/source/raw.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"github.com/kubernetes-incubator/external-dns/endpoint"
+)
+
+// rawSource
+type rawSource struct {
+	endpoints []*endpoint.Endpoint
+}
+
+// NewRawSource creates a new rawSource with the given config.
+func NewRawSource(endpoints []*endpoint.Endpoint) Source {
+	return &rawSource{
+		endpoints: endpoints,
+	}
+}
+
+// Endpoints returns endpoint objects for each txt record.
+func (sc *rawSource) Endpoints() ([]*endpoint.Endpoint, error) {
+	return sc.endpoints, nil
+}

--- a/source/raw_test.go
+++ b/source/raw_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"testing"
+
+	"github.com/kubernetes-incubator/external-dns/endpoint"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRawSource(t *testing.T) {
+	t.Run("Interface", testRawSourceImplementsSource)
+	t.Run("Endpoints", testRawEndpoints)
+}
+
+// testRawSourceImplementsSource tests that rawSource is a valid Source.
+func testRawSourceImplementsSource(t *testing.T) {
+	assert.Implements(t, (*Source)(nil), new(rawSource))
+}
+
+func testRawEndpoints(t *testing.T) {
+	for _, ti := range []struct {
+		title     string
+		endpoints []*endpoint.Endpoint
+		expected  []*endpoint.Endpoint
+	}{
+		{
+			title: "test raw endpoints are the same",
+			endpoints: []*endpoint.Endpoint{
+				{
+					DNSName: "example.org",
+					Target:  "8.8.8.8",
+				},
+				{
+					DNSName: "new.org",
+					Target:  "lb.com",
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "example.org",
+					Target:  "8.8.8.8",
+				},
+				{
+					DNSName: "new.org",
+					Target:  "lb.com",
+				},
+			},
+		},
+	} {
+		t.Run(ti.title, func(t *testing.T) {
+			rawSource := NewRawSource(ti.endpoints)
+
+			res, err := rawSource.Endpoints()
+			require.NoError(t, err)
+
+			validateEndpoints(t, res, ti.expected)
+		})
+	}
+}

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -488,6 +488,51 @@ func testServiceSourceEndpoints(t *testing.T) {
 			[]*endpoint.Endpoint{},
 			true,
 		},
+		{
+			"annotated services with AWS Route53 policy return an endpoint with an AWS Route53 policy",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeLoadBalancer,
+			"",
+			"",
+			map[string]string{},
+			map[string]string{
+				hostnameAnnotationKey:                "foo.example.org.",
+				weightScopeAnnotationKey:             "cluster",
+				awsRoute53WeightAnnotationKey:        "1",
+				awsRoute53SetIdentifierAnnotationKey: "identifier-1",
+			},
+			"",
+			[]string{"1.2.3.4"},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Target: "1.2.3.4", Policy: endpoint.Policy{
+					AWSRoute53: &endpoint.AWSRoute53Policy{Weight: 1,
+						SetIdentifier: "identifier-1"}},
+				},
+			},
+			false,
+		},
+		{
+			"annotated services with invalid AWS Route53 policy do not return an endpoint",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeLoadBalancer,
+			"",
+			"",
+			map[string]string{},
+			map[string]string{
+				hostnameAnnotationKey:                "foo.example.org.",
+				weightScopeAnnotationKey:             "cluster",
+				awsRoute53WeightAnnotationKey:        "-1",
+				awsRoute53SetIdentifierAnnotationKey: "identifier-1",
+			},
+			"",
+			[]string{"1.2.3.4"},
+			[]*endpoint.Endpoint{},
+			false,
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			// Create a Kubernetes testing client

--- a/source/shared_test.go
+++ b/source/shared_test.go
@@ -47,4 +47,12 @@ func validateEndpoint(t *testing.T, endpoint, expected *endpoint.Endpoint) {
 	if expected.RecordType != "" && endpoint.RecordType != expected.RecordType {
 		t.Errorf("expected %s, got %s", expected.RecordType, endpoint.RecordType)
 	}
+
+	if endpoint.Policy.HasAWSRoute53Policy() {
+		if endpoint.Policy.AWSRoute53.SetIdentifier != expected.Policy.AWSRoute53.SetIdentifier &&
+			endpoint.Policy.AWSRoute53.Weight != expected.Policy.AWSRoute53.Weight {
+			t.Errorf("expected %s, got %s", expected.Policy.AWSRoute53.SetIdentifier,
+				endpoint.Policy.AWSRoute53.SetIdentifier)
+		}
+	}
 }

--- a/source/source.go
+++ b/source/source.go
@@ -29,7 +29,13 @@ const (
 	hostnameAnnotationKey = "external-dns.alpha.kubernetes.io/hostname"
 	// The annotation used for defining the desired ingress target
 	targetAnnotationKey = "external-dns.alpha.kubernetes.io/target"
-	// The value of the controller annotation so that we feel resposible
+	// The annotation used for defining the desired weight scope for the record
+	weightScopeAnnotationKey = "external-dns.alpha.kubernetes.io/weight-scope"
+	// The annotation used for defining the desired weight for the record
+	awsRoute53WeightAnnotationKey = "external-dns.alpha.kubernetes.io/aws-route53-weight"
+	// The value of the suffix for the weighted policy id
+	awsRoute53SetIdentifierAnnotationKey = "external-dns.alpha.kubernetes.io/aws-route53-set-identifier"
+	// The value of the controller annotation so that we feel responsible
 	controllerAnnotationValue = "dns-controller"
 )
 


### PR DESCRIPTION
This PR is based on the proposal here: https://github.com/kubernetes-incubator/external-dns/pull/331. It assumes we're only doing the "cluster" portion now. Changes to the registry will be required to do the "global" part.

I have tested it and it is fully functional. I would appreciate feedback especially around the plan and the registry changes. I feel like there is a lot of logic there and wondering if you have ideas on how to make that part more straightforward. I was considering splitting that out even to its own package but thought I'd run it by here first. There's also bits of logic spread around with regards to using the AWS-specific record sets which I do not like, but I have not come up with any great ideas on how to get around that.

Also note that the changes to the inmemory zone are necessary because it's possible to have multiple records with the same dns name (and is necessary for weighting).