### PR TITLE
fix nil ptr dereference in inmemroy provider

### DIFF
--- a/provider/inmemory.go
+++ b/provider/inmemory.go
@@ -143,18 +143,30 @@ func (im *InMemoryProvider) ApplyChanges(changes *plan.Changes) error {
 
 	for _, ep := range changes.Create {
 		zoneID := im.filter.EndpointZoneID(ep, zones)
+		if zoneID == "" {
+			continue
+		}
 		perZoneChanges[zoneID].Create = append(perZoneChanges[zoneID].Create, ep)
 	}
 	for _, ep := range changes.UpdateNew {
 		zoneID := im.filter.EndpointZoneID(ep, zones)
+		if zoneID == "" {
+			continue
+		}
 		perZoneChanges[zoneID].UpdateNew = append(perZoneChanges[zoneID].UpdateNew, ep)
 	}
 	for _, ep := range changes.UpdateOld {
 		zoneID := im.filter.EndpointZoneID(ep, zones)
+		if zoneID == "" {
+			continue
+		}
 		perZoneChanges[zoneID].UpdateOld = append(perZoneChanges[zoneID].UpdateOld, ep)
 	}
 	for _, ep := range changes.Delete {
 		zoneID := im.filter.EndpointZoneID(ep, zones)
+		if zoneID == "" {
+			continue
+		}
 		perZoneChanges[zoneID].Delete = append(perZoneChanges[zoneID].Delete, ep)
 	}
 

--- a/provider/inmemory_test.go
+++ b/provider/inmemory_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provider
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
@@ -798,7 +799,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, ti.expectedZonesState, c.zones)
+				assert.True(t, reflect.DeepEqual(ti.expectedZonesState, c.zones), "not equal data")
 			}
 		})
 	}

--- a/provider/inmemory_test.go
+++ b/provider/inmemory_test.go
@@ -563,6 +563,21 @@ func testInMemoryApplyChanges(t *testing.T) {
 		expectedZonesState map[string]zone
 	}{
 		{
+			title:       "unmatched zoneID, should be ignored in the apply step",
+			expectError: false,
+			zone:        "org",
+			changes: &plan.Changes{
+				Create: []*endpoint.Endpoint{{
+					DNSName:    "example.com",
+					Target:     "8.8.8.8",
+					RecordType: endpoint.RecordTypeA,
+				}},
+				UpdateNew: []*endpoint.Endpoint{},
+				UpdateOld: []*endpoint.Endpoint{},
+				Delete:    []*endpoint.Endpoint{},
+			},
+		},
+		{
 			title:       "expect error",
 			expectError: true,
 			zone:        "org",

--- a/provider/inmemory_test.go
+++ b/provider/inmemory_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package provider
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
@@ -601,13 +600,11 @@ func testInMemoryApplyChanges(t *testing.T) {
 		expectError        bool
 		init               map[string]zone
 		changes            *plan.Changes
-		zone               string
 		expectedZonesState map[string]zone
 	}{
 		{
 			title:       "unmatched zone, should be ignored in the apply step",
 			expectError: false,
-			zone:        "de",
 			changes: &plan.Changes{
 				Create: []*endpoint.Endpoint{{
 					DNSName:    "example.de",
@@ -623,7 +620,6 @@ func testInMemoryApplyChanges(t *testing.T) {
 		{
 			title:       "expect error",
 			expectError: true,
-			zone:        "org",
 			changes: &plan.Changes{
 				Create: []*endpoint.Endpoint{},
 				UpdateNew: []*endpoint.Endpoint{
@@ -646,7 +642,6 @@ func testInMemoryApplyChanges(t *testing.T) {
 		{
 			title:       "zones, update, right zone, valid batch - delete",
 			expectError: false,
-			zone:        "org",
 			changes: &plan.Changes{
 				Create:    []*endpoint.Endpoint{},
 				UpdateNew: []*endpoint.Endpoint{},
@@ -698,7 +693,6 @@ func testInMemoryApplyChanges(t *testing.T) {
 		{
 			title:       "zones, update, right zone, valid batch - update, create, delete",
 			expectError: false,
-			zone:        "org",
 			changes: &plan.Changes{
 				Create: []*endpoint.Endpoint{
 					{
@@ -783,7 +777,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				assert.True(t, reflect.DeepEqual(ti.expectedZonesState, c.zones), "not equal data")
+				assert.Equal(t, ti.expectedZonesState, c.zones)
 			}
 		})
 	}

--- a/provider/inmemory_test.go
+++ b/provider/inmemory_test.go
@@ -553,8 +553,8 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 	}
 }
 
-func testInMemoryApplyChanges(t *testing.T) {
-	init := map[string]zone{
+func getInitData() map[string]zone {
+	return map[string]zone{
 		"org": {
 			"example.org": []*inMemoryRecord{
 				{
@@ -592,7 +592,9 @@ func testInMemoryApplyChanges(t *testing.T) {
 			},
 		},
 	}
+}
 
+func testInMemoryApplyChanges(t *testing.T) {
 	for _, ti := range []struct {
 		title              string
 		expectError        bool
@@ -615,7 +617,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 				UpdateOld: []*endpoint.Endpoint{},
 				Delete:    []*endpoint.Endpoint{},
 			},
-			expectedZonesState: init,
+			expectedZonesState: getInitData(),
 		},
 		{
 			title:       "unmatched zoneID, should be ignored in the apply step",
@@ -631,7 +633,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 				UpdateOld: []*endpoint.Endpoint{},
 				Delete:    []*endpoint.Endpoint{},
 			},
-			expectedZonesState: init,
+			expectedZonesState: getInitData(),
 		},
 		{
 			title:       "expect error",
@@ -788,7 +790,7 @@ func testInMemoryApplyChanges(t *testing.T) {
 
 			im := NewInMemoryProvider()
 			c := &inMemoryClient{}
-			c.zones = init
+			c.zones = getInitData()
 			im.client = c
 
 			err := im.ApplyChanges(ti.changes)

--- a/provider/inmemory_test.go
+++ b/provider/inmemory_test.go
@@ -621,22 +621,6 @@ func testInMemoryApplyChanges(t *testing.T) {
 			expectedZonesState: getInitData(),
 		},
 		{
-			title:       "unmatched zoneID, should be ignored in the apply step",
-			expectError: false,
-			zone:        "org",
-			changes: &plan.Changes{
-				Create: []*endpoint.Endpoint{{
-					DNSName:    "example.com",
-					Target:     "8.8.8.8",
-					RecordType: endpoint.RecordTypeA,
-				}},
-				UpdateNew: []*endpoint.Endpoint{},
-				UpdateOld: []*endpoint.Endpoint{},
-				Delete:    []*endpoint.Endpoint{},
-			},
-			expectedZonesState: getInitData(),
-		},
-		{
 			title:       "expect error",
 			expectError: true,
 			zone:        "org",


### PR DESCRIPTION
 if zoneid does not match, we get empty string from im.filter.EndpointZoneID(ep, zones)