### PR TITLE
Multitarget

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -94,8 +94,9 @@ func TestRunOnce(t *testing.T) {
 			Target:  "1.2.3.4",
 		},
 		{
-			DNSName: "update-record",
-			Target:  "8.8.4.4",
+			DNSName:   "update-record",
+			Target:    "8.8.4.4",
+			RecordTTL: 100,
 		},
 	}, nil)
 
@@ -103,8 +104,9 @@ func TestRunOnce(t *testing.T) {
 	provider := newMockProvider(
 		[]*endpoint.Endpoint{
 			{
-				DNSName: "update-record",
-				Target:  "8.8.8.8",
+				DNSName:   "update-record",
+				Target:    "8.8.4.4",
+				RecordTTL: 50,
 			},
 			{
 				DNSName: "delete-record",
@@ -116,10 +118,10 @@ func TestRunOnce(t *testing.T) {
 				{DNSName: "create-record", Target: "1.2.3.4"},
 			},
 			UpdateNew: []*endpoint.Endpoint{
-				{DNSName: "update-record", Target: "8.8.4.4"},
+				{DNSName: "update-record", Target: "8.8.4.4", RecordTTL: 100},
 			},
 			UpdateOld: []*endpoint.Endpoint{
-				{DNSName: "update-record", Target: "8.8.8.8"},
+				{DNSName: "update-record", Target: "8.8.4.4", RecordTTL: 50},
 			},
 			Delete: []*endpoint.Endpoint{
 				{DNSName: "delete-record", Target: "4.3.2.1"},

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -73,7 +73,7 @@ func (p *Plan) Calculate() *Plan {
 		}
 
 		changes.UpdateOld = append(changes.UpdateOld, current)
-		desired.MergeLabels(current.Labels)     // inherit the labels from the dns provider, including Owner ID
+		desired.MergeLabels(current.Labels)     // inherit the labels from the dns provider
 		desired.RecordType = current.RecordType // inherit the type from the dns provider
 
 		changes.UpdateNew = append(changes.UpdateNew, desired)

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -65,24 +65,16 @@ func (p *Plan) Calculate() *Plan {
 			continue
 		}
 
-		targetChanged := targetChanged(desired, current)
 		shouldUpdateTTL := shouldUpdateTTL(desired, current)
 
-		if !targetChanged && !shouldUpdateTTL {
+		if !shouldUpdateTTL {
 			log.Debugf("Skipping endpoint %v because nothing has changed", desired)
 			continue
 		}
 
 		changes.UpdateOld = append(changes.UpdateOld, current)
-		desired.MergeLabels(current.Labels) // inherit the labels from the dns provider, including Owner ID
-
-		if targetChanged {
-			desired.RecordType = current.RecordType // inherit the type from the dns provider
-		}
-
-		if !shouldUpdateTTL {
-			desired.RecordTTL = current.RecordTTL
-		}
+		desired.MergeLabels(current.Labels)     // inherit the labels from the dns provider, including Owner ID
+		desired.RecordType = current.RecordType // inherit the type from the dns provider
 
 		changes.UpdateNew = append(changes.UpdateNew, desired)
 	}
@@ -109,10 +101,6 @@ func (p *Plan) Calculate() *Plan {
 	return plan
 }
 
-func targetChanged(desired, current *endpoint.Endpoint) bool {
-	return desired.Target != current.Target
-}
-
 func shouldUpdateTTL(desired, current *endpoint.Endpoint) bool {
 	if !desired.RecordTTL.IsConfigured() {
 		return false
@@ -123,7 +111,7 @@ func shouldUpdateTTL(desired, current *endpoint.Endpoint) bool {
 // recordExists checks whether a record can be found in a list of records.
 func recordExists(needle *endpoint.Endpoint, haystack []*endpoint.Endpoint) (*endpoint.Endpoint, bool) {
 	for _, record := range haystack {
-		if record.DNSName == needle.DNSName {
+		if record.DNSName == needle.DNSName && record.Target == needle.Target {
 			return record, true
 		}
 	}

--- a/provider/cloudflare.go
+++ b/provider/cloudflare.go
@@ -251,7 +251,7 @@ func (p *CloudFlareProvider) changesByZone(zones []cloudflare.Zone, changeSet []
 
 func (p *CloudFlareProvider) getRecordID(records []cloudflare.DNSRecord, record cloudflare.DNSRecord) string {
 	for _, zoneRecord := range records {
-		if zoneRecord.Name == record.Name && zoneRecord.Type == record.Type {
+		if zoneRecord.Name == record.Name && zoneRecord.Type == record.Type && zoneRecord.Content == record.Content {
 			return zoneRecord.ID
 		}
 	}

--- a/provider/inmemory_test.go
+++ b/provider/inmemory_test.go
@@ -280,10 +280,10 @@ func testInMemoryValidateChangeBatch(t *testing.T) {
 			},
 			"foo.bar.org": []*inMemoryRecord{
 				{
-					Name:   "foo.bar.org",
-					Target: "5.5.5.5",
-					Type:   endpoint.RecordTypeA,
-					RecordTTL:  50,
+					Name:      "foo.bar.org",
+					Target:    "5.5.5.5",
+					Type:      endpoint.RecordTypeA,
+					RecordTTL: 50,
 				},
 			},
 		},
@@ -616,9 +616,9 @@ func getInitData() map[string]zone {
 			},
 			"foo.bar.org": []*inMemoryRecord{
 				{
-					Name:   "foo.bar.org",
-					Target: "5.5.5.5",
-					Type:   endpoint.RecordTypeA,
+					Name:      "foo.bar.org",
+					Target:    "5.5.5.5",
+					Type:      endpoint.RecordTypeA,
 					RecordTTL: 50,
 				},
 			},
@@ -782,10 +782,10 @@ func testInMemoryApplyChanges(t *testing.T) {
 					},
 					"foo.bar.org": []*inMemoryRecord{
 						{
-							Name:   "foo.bar.org",
-							Target: "5.5.5.5",
-							Type:   endpoint.RecordTypeA,
-							RecordTTL:  100,
+							Name:      "foo.bar.org",
+							Target:    "5.5.5.5",
+							Type:      endpoint.RecordTypeA,
+							RecordTTL: 100,
 						},
 					},
 					"foo.bar.new.org": []*inMemoryRecord{

--- a/registry/noop_test.go
+++ b/registry/noop_test.go
@@ -71,20 +71,29 @@ func testNoopApplyChanges(t *testing.T) {
 	providerRecords := []*endpoint.Endpoint{
 		{
 			DNSName:    "example.org",
-			Target:     "old-lb.com",
+			Target:     "example-lb.com",
 			RecordType: endpoint.RecordTypeCNAME,
+			RecordTTL:  50,
 		},
 	}
 	expectedUpdate := []*endpoint.Endpoint{
 		{
 			DNSName:    "example.org",
-			Target:     "new-example-lb.com",
+			Target:     "example-lb.com",
 			RecordType: endpoint.RecordTypeCNAME,
+			RecordTTL:  150,
+		},
+		{
+			DNSName:    "example.org",
+			Target:     "example-lb-2.com",
+			RecordType: endpoint.RecordTypeCNAME,
+			RecordTTL:  50,
 		},
 		{
 			DNSName:    "new-record.org",
 			Target:     "new-lb.org",
 			RecordType: endpoint.RecordTypeCNAME,
+			RecordTTL:  42,
 		},
 	}
 
@@ -98,8 +107,9 @@ func testNoopApplyChanges(t *testing.T) {
 		Create: []*endpoint.Endpoint{
 			{
 				DNSName:    "example.org",
-				Target:     "lb.com",
+				Target:     "example-lb.com",
 				RecordType: endpoint.RecordTypeCNAME,
+				RecordTTL:  100,
 			},
 		},
 	})
@@ -109,23 +119,32 @@ func testNoopApplyChanges(t *testing.T) {
 	require.NoError(t, r.ApplyChanges(&plan.Changes{
 		Create: []*endpoint.Endpoint{
 			{
+				DNSName:    "example.org",
+				Target:     "example-lb-2.com",
+				RecordType: endpoint.RecordTypeCNAME,
+				RecordTTL:  50,
+			},
+			{
 				DNSName:    "new-record.org",
 				Target:     "new-lb.org",
 				RecordType: endpoint.RecordTypeCNAME,
+				RecordTTL:  42,
 			},
 		},
 		UpdateNew: []*endpoint.Endpoint{
 			{
 				DNSName:    "example.org",
-				Target:     "new-example-lb.com",
+				Target:     "example-lb.com",
 				RecordType: endpoint.RecordTypeCNAME,
+				RecordTTL:  150,
 			},
 		},
 		UpdateOld: []*endpoint.Endpoint{
 			{
 				DNSName:    "example.org",
-				Target:     "old-lb.com",
+				Target:     "example-lb.com",
 				RecordType: endpoint.RecordTypeCNAME,
+				RecordTTL:  50,
 			},
 		},
 	}))

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -19,7 +19,6 @@ package registry
 import (
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 	"github.com/kubernetes-incubator/external-dns/plan"
-	log "github.com/sirupsen/logrus"
 )
 
 // Registry is an interface which should enables ownership concept in external-dns
@@ -29,17 +28,4 @@ import (
 type Registry interface {
 	Records() ([]*endpoint.Endpoint, error)
 	ApplyChanges(changes *plan.Changes) error
-}
-
-//TODO(ideahitme): consider moving this to Plan
-func filterOwnedRecords(ownerID string, eps []*endpoint.Endpoint) []*endpoint.Endpoint {
-	filtered := []*endpoint.Endpoint{}
-	for _, ep := range eps {
-		if endpointOwner, ok := ep.Labels[endpoint.OwnerLabelKey]; !ok || endpointOwner != ownerID {
-			log.Debugf(`Skipping endpoint %v because owner id does not match, found: "%s", required: "%s"`, ep, endpointOwner, ownerID)
-			continue
-		}
-		filtered = append(filtered, ep)
-	}
-	return filtered
 }

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -119,7 +119,7 @@ func (im *TXTRegistry) ApplyChanges(changes *plan.Changes) error {
 	for _, r := range changes.Create {
 		rOwner := im.ownerMap[r.DNSName]
 
-		if rOwner == "" || rOwner == im.ownerID {
+		if rOwner == im.ownerID || im.recCount[r.DNSName] == 0 { // only change anything if we own r.DNSName or it doesn't exist yet
 			filteredChanges.Create = append(filteredChanges.Create, r)
 
 			im.ownerMap[r.DNSName] = im.ownerID

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -88,7 +88,9 @@ func (im *TXTRegistry) Records() ([]*endpoint.Endpoint, error) {
 		}
 
 		endpointDNSName := im.mapper.toEndpointName(record.DNSName)
-		im.ownerMap[endpointDNSName] = ownerID
+		if endpointDNSName != "" {
+			im.ownerMap[endpointDNSName] = ownerID
+		}
 	}
 
 	log.Debugf("after scanning: ownerMap: %s, recCount: %s", im.ownerMap, im.recCount)

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -190,6 +190,13 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 func testTXTRegistryApplyChanges(t *testing.T) {
 	t.Run("With Prefix", testTXTRegistryApplyChangesWithPrefix)
 	t.Run("No prefix", testTXTRegistryApplyChangesNoPrefix)
+	t.Run("Multitarget create", testTXTRegistryMultitargetCreate)
+	t.Run("Multitarget add", testTXTRegistryMultitargetAdd)
+	t.Run("Multitarget delete", testTXTRegistryMultitargetDelete)
+	t.Run("Multitarget delete all", testTXTRegistryMultitargetDeleteAll)
+	t.Run("Multitarget try to add to non-owned cluster", testTXTRegistryMultitargetAddForeign)
+	t.Run("Multitarget create, update and delete", testTXTRegistryMultitargetCreateDeleteUpdate)
+	t.Run("Multitarget change target via delete and create", testTXTRegistryMultitargetDeleteAndCreate)
 }
 
 func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
@@ -213,37 +220,39 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			endpoint.NewEndpoint("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", ""),
-		},
-		Delete: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME),
-		},
-		UpdateNew: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multiadd.test-zone.example.org", "backend1.lb.com", ""),
+			endpoint.NewEndpoint("multiadd.test-zone.example.org", "backend2.lb.com", ""),
 			endpoint.NewEndpoint("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME),
 		},
-		UpdateOld: []*endpoint.Endpoint{
+		Delete: []*endpoint.Endpoint{
 			endpoint.NewEndpoint("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME),
 		},
+		UpdateNew: []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{},
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			endpoint.NewEndpoint("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", ""),
 			endpoint.NewEndpoint("txt.new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("multiadd.test-zone.example.org", "backend1.lb.com", ""),
+			endpoint.NewEndpoint("multiadd.test-zone.example.org", "backend2.lb.com", ""),
+			endpoint.NewEndpoint("txt.multiadd.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME),
 		},
 		Delete: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME),
 			endpoint.NewEndpoint("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME),
 			endpoint.NewEndpoint("txt.foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
 		},
-		UpdateNew: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME),
-		},
-		UpdateOld: []*endpoint.Endpoint{
-			endpoint.NewEndpoint("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME),
-		},
+		UpdateNew: []*endpoint.Endpoint{},
+		UpdateOld: []*endpoint.Endpoint{},
 	}
 	expectedOwnerMap := map[string]string{
 		"bar.test-zone.example.org":          "owner",
 		"tar.test-zone.example.org":          "owner",
 		"new-record-1.test-zone.example.org": "owner",
+		"multiadd.test-zone.example.org":     "owner",
 	}
 	p.OnApplyChanges = func(got *plan.Changes) {
 		mExpected := map[string][]*endpoint.Endpoint{
@@ -286,6 +295,8 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
 			endpoint.NewEndpoint("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", ""),
+			endpoint.NewEndpoint("multiadd.test-zone.example.org", "backend1.lb.com", ""),
+			endpoint.NewEndpoint("multiadd.test-zone.example.org", "backend2.lb.com", ""),
 		},
 		Delete: []*endpoint.Endpoint{
 			endpoint.NewEndpoint("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME),
@@ -301,6 +312,9 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 		Create: []*endpoint.Endpoint{
 			endpoint.NewEndpoint("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", ""),
 			endpoint.NewEndpoint("new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("multiadd.test-zone.example.org", "backend1.lb.com", ""),
+			endpoint.NewEndpoint("multiadd.test-zone.example.org", "backend2.lb.com", ""),
+			endpoint.NewEndpoint("multiadd.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
 		},
 		Delete: []*endpoint.Endpoint{
 			endpoint.NewEndpoint("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME),
@@ -313,6 +327,7 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 		"txt.bar.test-zone.example.org":      "owner",
 		"txt.tar.test-zone.example.org":      "owner",
 		"new-record-1.test-zone.example.org": "owner",
+		"multiadd.test-zone.example.org":     "owner",
 	}
 	p.OnApplyChanges = func(got *plan.Changes) {
 		mExpected := map[string][]*endpoint.Endpoint{
@@ -332,4 +347,363 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 	err := r.ApplyChanges(changes)
 	require.NoError(t, err)
 	assert.Equal(t, expectedOwnerMap, r.ownerMap)
+}
+
+func testTXTRegistryMultitargetCreate(t *testing.T) {
+	p := provider.NewInMemoryProvider()
+	p.CreateZone(testZone)
+
+	r, _ := NewTXTRegistry(p, "", "owner")
+
+	changes := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+		},
+	}
+	expected := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+		},
+	}
+	p.OnApplyChanges = func(got *plan.Changes) {
+		mExpected := map[string][]*endpoint.Endpoint{
+			"Create":    expected.Create,
+			"UpdateNew": expected.UpdateNew,
+			"UpdateOld": expected.UpdateOld,
+			"Delete":    expected.Delete,
+		}
+		mGot := map[string][]*endpoint.Endpoint{
+			"Create":    got.Create,
+			"UpdateNew": got.UpdateNew,
+			"UpdateOld": got.UpdateOld,
+			"Delete":    got.Delete,
+		}
+		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
+	}
+	err := r.ApplyChanges(changes)
+	require.NoError(t, err)
+}
+
+func testTXTRegistryMultitargetAdd(t *testing.T) {
+	p := provider.NewInMemoryProvider()
+	p.CreateZone(testZone)
+	p.ApplyChanges(&plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+		},
+	})
+	r, _ := NewTXTRegistry(p, "", "owner")
+
+	changes := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "3.3.3.3", endpoint.RecordTypeA),
+		},
+	}
+	expected := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "3.3.3.3", endpoint.RecordTypeA),
+		},
+	}
+	p.OnApplyChanges = func(got *plan.Changes) {
+		mExpected := map[string][]*endpoint.Endpoint{
+			"Create":    expected.Create,
+			"UpdateNew": expected.UpdateNew,
+			"UpdateOld": expected.UpdateOld,
+			"Delete":    expected.Delete,
+		}
+		mGot := map[string][]*endpoint.Endpoint{
+			"Create":    got.Create,
+			"UpdateNew": got.UpdateNew,
+			"UpdateOld": got.UpdateOld,
+			"Delete":    got.Delete,
+		}
+		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
+	}
+
+	err := r.ApplyChanges(changes)
+	require.NoError(t, err)
+
+	finalRecords, err := r.Records()
+	require.NoError(t, err)
+	assert.True(t, testutils.SameEndpoints(finalRecords, []*endpoint.Endpoint{
+		endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+		endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+		endpoint.NewEndpoint("multitarget.test-zone.example.org", "3.3.3.3", endpoint.RecordTypeA),
+	}))
+}
+
+func testTXTRegistryMultitargetDelete(t *testing.T) {
+	p := provider.NewInMemoryProvider()
+	p.CreateZone(testZone)
+	p.ApplyChanges(&plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "3.3.3.3", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+		},
+	})
+	r, _ := NewTXTRegistry(p, "", "owner")
+
+	changes := &plan.Changes{
+		Delete: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+		},
+	}
+	expected := &plan.Changes{
+		Delete: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+		},
+	}
+	p.OnApplyChanges = func(got *plan.Changes) {
+		mExpected := map[string][]*endpoint.Endpoint{
+			"Create":    expected.Create,
+			"UpdateNew": expected.UpdateNew,
+			"UpdateOld": expected.UpdateOld,
+			"Delete":    expected.Delete,
+		}
+		mGot := map[string][]*endpoint.Endpoint{
+			"Create":    got.Create,
+			"UpdateNew": got.UpdateNew,
+			"UpdateOld": got.UpdateOld,
+			"Delete":    got.Delete,
+		}
+		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
+	}
+
+	err := r.ApplyChanges(changes)
+	require.NoError(t, err)
+
+	finalRecords, err := r.Records()
+	require.NoError(t, err)
+	assert.True(t, testutils.SameEndpoints(finalRecords, []*endpoint.Endpoint{
+		endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+		endpoint.NewEndpoint("multitarget.test-zone.example.org", "3.3.3.3", endpoint.RecordTypeA),
+	}))
+}
+
+func testTXTRegistryMultitargetDeleteAll(t *testing.T) {
+	p := provider.NewInMemoryProvider()
+	p.CreateZone(testZone)
+	p.ApplyChanges(&plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+		},
+	})
+	r, _ := NewTXTRegistry(p, "", "owner")
+
+	changes := &plan.Changes{
+		Delete: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+		},
+	}
+	expected := &plan.Changes{
+		Delete: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+		},
+	}
+	p.OnApplyChanges = func(got *plan.Changes) {
+		mExpected := map[string][]*endpoint.Endpoint{
+			"Create":    expected.Create,
+			"UpdateNew": expected.UpdateNew,
+			"UpdateOld": expected.UpdateOld,
+			"Delete":    expected.Delete,
+		}
+		mGot := map[string][]*endpoint.Endpoint{
+			"Create":    got.Create,
+			"UpdateNew": got.UpdateNew,
+			"UpdateOld": got.UpdateOld,
+			"Delete":    got.Delete,
+		}
+		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
+	}
+
+	err := r.ApplyChanges(changes)
+	require.NoError(t, err)
+
+	finalRecords, err := r.Records()
+	require.NoError(t, err)
+	assert.True(t, testutils.SameEndpoints(finalRecords, []*endpoint.Endpoint{}))
+}
+
+func testTXTRegistryMultitargetAddForeign(t *testing.T) {
+	p := provider.NewInMemoryProvider()
+	p.CreateZone(testZone)
+	p.ApplyChanges(&plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=notme\"", endpoint.RecordTypeTXT),
+		},
+	})
+	r, _ := NewTXTRegistry(p, "", "owner")
+
+	changes := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "3.3.3.3", endpoint.RecordTypeA),
+		},
+	}
+	expected := &plan.Changes{
+		Create: []*endpoint.Endpoint{},
+	}
+	p.OnApplyChanges = func(got *plan.Changes) {
+		mExpected := map[string][]*endpoint.Endpoint{
+			"Create":    expected.Create,
+			"UpdateNew": expected.UpdateNew,
+			"UpdateOld": expected.UpdateOld,
+			"Delete":    expected.Delete,
+		}
+		mGot := map[string][]*endpoint.Endpoint{
+			"Create":    got.Create,
+			"UpdateNew": got.UpdateNew,
+			"UpdateOld": got.UpdateOld,
+			"Delete":    got.Delete,
+		}
+		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
+	}
+
+	err := r.ApplyChanges(changes)
+	require.NoError(t, err)
+
+	finalRecords, err := r.Records()
+	require.NoError(t, err)
+	assert.True(t, testutils.SameEndpoints(finalRecords, []*endpoint.Endpoint{
+		endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+		endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+	}))
+}
+
+func testTXTRegistryMultitargetCreateDeleteUpdate(t *testing.T) {
+	p := provider.NewInMemoryProvider()
+	p.CreateZone(testZone)
+	p.ApplyChanges(&plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+			endpoint.NewEndpointWithTTL("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA, 50),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("target2.test-zone.example.org", "9.9.9.9", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("target2.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+		},
+	})
+	r, _ := NewTXTRegistry(p, "", "owner")
+
+	changes := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "3.3.3.3", endpoint.RecordTypeA),
+		},
+		UpdateOld: []*endpoint.Endpoint{
+			endpoint.NewEndpointWithTTL("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA, 50),
+		},
+		UpdateNew: []*endpoint.Endpoint{
+			endpoint.NewEndpointWithTTL("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA, 100),
+		},
+		Delete: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("target2.test-zone.example.org", "9.9.9.9", endpoint.RecordTypeA),
+		},
+	}
+	expected := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "3.3.3.3", endpoint.RecordTypeA),
+		},
+		UpdateOld: []*endpoint.Endpoint{
+			endpoint.NewEndpointWithTTL("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA, 50),
+		},
+		UpdateNew: []*endpoint.Endpoint{
+			endpoint.NewEndpointWithTTL("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA, 100),
+		},
+		Delete: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("target2.test-zone.example.org", "9.9.9.9", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("target2.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+		},
+	}
+	p.OnApplyChanges = func(got *plan.Changes) {
+		mExpected := map[string][]*endpoint.Endpoint{
+			"Create":    expected.Create,
+			"UpdateNew": expected.UpdateNew,
+			"UpdateOld": expected.UpdateOld,
+			"Delete":    expected.Delete,
+		}
+		mGot := map[string][]*endpoint.Endpoint{
+			"Create":    got.Create,
+			"UpdateNew": got.UpdateNew,
+			"UpdateOld": got.UpdateOld,
+			"Delete":    got.Delete,
+		}
+		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
+	}
+
+	err := r.ApplyChanges(changes)
+	require.NoError(t, err)
+
+	finalRecords, err := r.Records()
+	require.NoError(t, err)
+	assert.True(t, testutils.SameEndpoints(finalRecords, []*endpoint.Endpoint{
+		endpoint.NewEndpointWithTTL("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA, 100),
+		endpoint.NewEndpoint("multitarget.test-zone.example.org", "3.3.3.3", endpoint.RecordTypeA),
+	}))
+}
+
+func testTXTRegistryMultitargetDeleteAndCreate(t *testing.T) {
+	p := provider.NewInMemoryProvider()
+	p.CreateZone(testZone)
+	p.ApplyChanges(&plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+		},
+	})
+	r, _ := NewTXTRegistry(p, "", "owner")
+
+	changes := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+		},
+		Delete: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+		},
+	}
+	expected := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+		},
+		Delete: []*endpoint.Endpoint{
+			endpoint.NewEndpoint("multitarget.test-zone.example.org", "1.1.1.1", endpoint.RecordTypeA),
+		},
+	}
+	p.OnApplyChanges = func(got *plan.Changes) {
+		mExpected := map[string][]*endpoint.Endpoint{
+			"Create":    expected.Create,
+			"UpdateNew": expected.UpdateNew,
+			"UpdateOld": expected.UpdateOld,
+			"Delete":    expected.Delete,
+		}
+		mGot := map[string][]*endpoint.Endpoint{
+			"Create":    got.Create,
+			"UpdateNew": got.UpdateNew,
+			"UpdateOld": got.UpdateOld,
+			"Delete":    got.Delete,
+		}
+		assert.True(t, testutils.SamePlanChanges(mGot, mExpected))
+	}
+
+	err := r.ApplyChanges(changes)
+	require.NoError(t, err)
+
+	finalRecords, err := r.Records()
+	require.NoError(t, err)
+	assert.True(t, testutils.SameEndpoints(finalRecords, []*endpoint.Endpoint{
+		endpoint.NewEndpoint("multitarget.test-zone.example.org", "2.2.2.2", endpoint.RecordTypeA),
+	}))
 }

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -68,15 +68,15 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 	p.CreateZone(testZone)
 	p.ApplyChanges(&plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			endpoint.NewEndpoint("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -84,55 +84,44 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			DNSName:    "foo.test-zone.example.org",
 			Target:     "foo.loadbalancer.com",
 			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
 		},
 		{
 			DNSName:    "bar.test-zone.example.org",
 			Target:     "my-domain.com",
 			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-			},
 		},
 		{
 			DNSName:    "txt.bar.test-zone.example.org",
 			Target:     "baz.test-zone.example.org",
 			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
 		},
 		{
 			DNSName:    "qux.test-zone.example.org",
 			Target:     "random",
 			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
 		},
 		{
 			DNSName:    "tar.test-zone.example.org",
 			Target:     "tar.loadbalancer.com",
 			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner-2",
-			},
 		},
 		{
 			DNSName:    "foobar.test-zone.example.org",
 			Target:     "foobar.loadbalancer.com",
 			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
 		},
+	}
+
+	// white-box testing: check tracked ownerIDs
+	expectedOwnerMap := map[string]string{
+		"bar.test-zone.example.org": "owner",
+		"tar.test-zone.example.org": "owner-2",
 	}
 
 	r, _ := NewTXTRegistry(p, "txt.", "owner")
 	records, _ := r.Records()
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+	assert.Equal(t, expectedOwnerMap, r.ownerMap)
 }
 
 func testTXTRegistryRecordsNoPrefix(t *testing.T) {
@@ -140,15 +129,15 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 	p.CreateZone(testZone)
 	p.ApplyChanges(&plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			endpoint.NewEndpoint("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
 		},
 	})
 	expectedRecords := []*endpoint.Endpoint{
@@ -156,56 +145,46 @@ func testTXTRegistryRecordsNoPrefix(t *testing.T) {
 			DNSName:    "foo.test-zone.example.org",
 			Target:     "foo.loadbalancer.com",
 			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
 		},
 		{
 			DNSName:    "bar.test-zone.example.org",
 			Target:     "my-domain.com",
 			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
 		},
 		{
 			DNSName:    "txt.bar.test-zone.example.org",
 			Target:     "baz.test-zone.example.org",
 			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-			},
 		},
 		{
 			DNSName:    "qux.test-zone.example.org",
 			Target:     "random",
 			RecordType: endpoint.RecordTypeTXT,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
 		},
 		{
 			DNSName:    "tar.test-zone.example.org",
 			Target:     "tar.loadbalancer.com",
 			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "",
-			},
 		},
 		{
 			DNSName:    "foobar.test-zone.example.org",
 			Target:     "foobar.loadbalancer.com",
 			RecordType: endpoint.RecordTypeCNAME,
-			Labels: map[string]string{
-				endpoint.OwnerLabelKey: "owner",
-			},
 		},
+	}
+
+	// white-box testing: check tracked ownerIDs
+	expectedOwnerMap := map[string]string{
+		"txt.bar.test-zone.example.org": "owner",
+		"txt.tar.test-zone.example.org": "owner-2",
+		"foobar.test-zone.example.org":  "owner",
 	}
 
 	r, _ := NewTXTRegistry(p, "", "owner")
 	records, _ := r.Records()
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+	assert.Equal(t, expectedOwnerMap, r.ownerMap)
 }
 
 func testTXTRegistryApplyChanges(t *testing.T) {
@@ -218,48 +197,53 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 	p.CreateZone(testZone)
 	p.ApplyChanges(&plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			endpoint.NewEndpoint("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("txt.foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
 		},
 	})
 	r, _ := NewTXTRegistry(p, "txt.", "owner")
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", "", ""),
+			endpoint.NewEndpoint("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", ""),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			endpoint.NewEndpoint("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME),
 		},
 		UpdateOld: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			endpoint.NewEndpoint("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME),
 		},
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", "", ""),
-			newEndpointWithOwner("txt.new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			endpoint.NewEndpoint("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", ""),
+			endpoint.NewEndpoint("txt.new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwner("txt.foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("txt.foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			endpoint.NewEndpoint("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME),
 		},
 		UpdateOld: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			endpoint.NewEndpoint("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME),
 		},
+	}
+	expectedOwnerMap := map[string]string{
+		"bar.test-zone.example.org":          "owner",
+		"tar.test-zone.example.org":          "owner",
+		"new-record-1.test-zone.example.org": "owner",
 	}
 	p.OnApplyChanges = func(got *plan.Changes) {
 		mExpected := map[string][]*endpoint.Endpoint{
@@ -278,6 +262,7 @@ func testTXTRegistryApplyChangesWithPrefix(t *testing.T) {
 	}
 	err := r.ApplyChanges(changes)
 	require.NoError(t, err)
+	assert.Equal(t, expectedOwnerMap, r.ownerMap)
 }
 
 func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
@@ -285,44 +270,49 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 	p.CreateZone(testZone)
 	p.ApplyChanges(&plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			endpoint.NewEndpoint("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
 		},
 	})
 	r, _ := NewTXTRegistry(p, "", "owner")
 
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", "", ""),
+			endpoint.NewEndpoint("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", ""),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME),
 		},
 		UpdateNew: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner-2"),
+			endpoint.NewEndpoint("tar.test-zone.example.org", "new-tar.loadbalancer.com", endpoint.RecordTypeCNAME),
 		},
 		UpdateOld: []*endpoint.Endpoint{
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner-2"),
+			endpoint.NewEndpoint("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME),
 		},
 	}
 	expected := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", "", ""),
-			newEndpointWithOwner("new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			endpoint.NewEndpoint("new-record-1.test-zone.example.org", "new-loadbalancer-1.lb.com", ""),
+			endpoint.NewEndpoint("new-record-1.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
 		},
 		Delete: []*endpoint.Endpoint{
-			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, "owner"),
-			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME),
+			endpoint.NewEndpoint("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT),
 		},
 		UpdateNew: []*endpoint.Endpoint{},
 		UpdateOld: []*endpoint.Endpoint{},
+	}
+	expectedOwnerMap := map[string]string{
+		"txt.bar.test-zone.example.org":      "owner",
+		"txt.tar.test-zone.example.org":      "owner",
+		"new-record-1.test-zone.example.org": "owner",
 	}
 	p.OnApplyChanges = func(got *plan.Changes) {
 		mExpected := map[string][]*endpoint.Endpoint{
@@ -341,16 +331,5 @@ func testTXTRegistryApplyChangesNoPrefix(t *testing.T) {
 	}
 	err := r.ApplyChanges(changes)
 	require.NoError(t, err)
-}
-
-/**
-
-helper methods
-
-*/
-
-func newEndpointWithOwner(dnsName, target, recordType, ownerID string) *endpoint.Endpoint {
-	e := endpoint.NewEndpoint(dnsName, target, recordType)
-	e.Labels[endpoint.OwnerLabelKey] = ownerID
-	return e
+	assert.Equal(t, expectedOwnerMap, r.ownerMap)
 }


### PR DESCRIPTION
This PR enables having multiple targets per domain name. I'm aware of PR 243, but this one works by having one `Endpoint` structure per (name, target) rather than extending `Endpoint.Target` to be an array and having one `Endpoint` per name. This means that the existing providers should work without changes, EXCEPT if they're written explicitly with the assumption of one endpoint per name in mind. We're using the Cloudflare provider; I had to modify one line (2d45bc2e19dd455f52925831c171c8506f423eb9) to make it work. I also modified the inmemory provider accordingly and added multi-target tests to for TXTRegistry, Controller and Plan.

I modified `TXTRegistry` to perform the ownerID tracking internally by caching some state in member variables between `Records()` and `ApplyValues()`, rather than using the Endpoints' `.Labels["owner"]` for that (storing per-name ownerIDs in per-target Endpoints would've been redundant and would've complicated things). This means that the labels are no longer used for anything now and might be removed unless we need them for something else in the future.

Everything works, AFAICS. We use the CF provider as I said, haven't really tested the others.

(update 11/08/17: inmemory provider multi-target capability, more tests) 