### PR TITLE
Google Provider Add Ttl from annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+  - Google: Support configuring TTL by annotation: `external-dns.alpha.kubernetes.io/ttl`. (#389) @stealthybox
+
 ## v0.4.8 - 2017-11-09
 
   - AWS: Added change batch limiting to a maximum of 4000 Route53 updates in one API call.  Changes exceeding the limit will be dropped but all related changes by hostname are preserved within the limit. (#368) @bitvector2

--- a/docs/ttl.md
+++ b/docs/ttl.md
@@ -24,7 +24,23 @@ Providers
 - [ ] Azure
 - [ ] Cloudflare
 - [ ] DigitalOcean
-- [ ] Google
+- [x] Google
 - [ ] InMemory
 
 PRs welcome!
+
+Notes
+=====
+When the `external-dns.alpha.kubernetes.io/ttl` annotation is not provided, the Ttl will default to 0 seconds and `enpoint.TTL.isConfigured()` will be false.
+
+### AWS Provider
+The AWS Provider overrides the value to 300s when the Ttl is 0. 
+This value is a constant in the provider code.
+
+### Google Provider
+Previously with the Google Provider, Ttl's were hard-coded to 300s.
+For safety, the Google Provider overrides the value to 300s when the Ttl is 0. 
+This value is a constant in the provider code.
+
+For the moment, it is impossible to use a Ttl value of 0 with the AWS and Google Providers.
+This behavior may change in the future.

--- a/provider/google.go
+++ b/provider/google.go
@@ -33,6 +33,10 @@ import (
 	"github.com/kubernetes-incubator/external-dns/plan"
 )
 
+const (
+	googleRecordTTL = 300
+)
+
 type managedZonesCreateCallInterface interface {
 	Do(opts ...googleapi.CallOption) (*dns.ManagedZone, error)
 }
@@ -319,10 +323,16 @@ func newRecord(ep *endpoint.Endpoint) *dns.ResourceRecordSet {
 		target = ensureTrailingDot(target)
 	}
 
+	// no annotation results in a Ttl of 0, default to 300 for backwards-compatability
+	var ttl int64 = googleRecordTTL
+	if ep.RecordTTL.IsConfigured() {
+		ttl = int64(ep.RecordTTL)
+	}
+
 	return &dns.ResourceRecordSet{
 		Name:    ensureTrailingDot(ep.DNSName),
 		Rrdatas: []string{target},
-		Ttl:     300,
+		Ttl:     ttl,
 		Type:    ep.RecordType,
 	}
 }


### PR DESCRIPTION
Use `int64(ep.RecordTTL)` in `newRecord()`
Fallback to hardcoded 300s for backwards-compat
Add `TestNewRecords()`
Add notes in *ttl.md*