### PR TITLE
update docs to use latest release v0.4.8

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -156,7 +156,7 @@ $ docker run \
   -e EXTERNAL_DNS_SOURCE=$'service\ningress' \
   -e EXTERNAL_DNS_PROVIDER=google \
   -e EXTERNAL_DNS_DOMAIN_FILTER=$'foo.com\nbar.com' \
-  registry.opensource.zalan.do/teapot/external-dns:v0.4.2
+  registry.opensource.zalan.do/teapot/external-dns:v0.4.8
 time="2017-08-08T14:10:26Z" level=info msg="config: &{Master: KubeConfig: Sources:[service ingress] Namespace: ...
 ```
 

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.2
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -115,7 +115,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.2
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
         args:
         - --source=service
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.2
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/digitalocean.md
+++ b/docs/tutorials/digitalocean.md
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.2
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
         args:
         - --source=service # ingress is also possible
         - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.

--- a/docs/tutorials/gke.md
+++ b/docs/tutorials/gke.md
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.2
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
         args:
         - --source=service
         - --source=ingress

--- a/docs/tutorials/infoblox.md
+++ b/docs/tutorials/infoblox.md
@@ -65,7 +65,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.6
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
         args:
         - --source=service
         - --domain-filter=example.com       # (optional) limit to only example.com domains.

--- a/docs/tutorials/nginx-ingress.md
+++ b/docs/tutorials/nginx-ingress.md
@@ -217,7 +217,7 @@ spec:
     spec:
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.2
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
         args:
         - --source=ingress
         - --domain-filter=external-dns-test.gcp.zalan.do


### PR DESCRIPTION
Use the latest release [v0.4.8](https://github.com/kubernetes-incubator/external-dns/releases/tag/v0.4.8) in all docs.