### PR TITLE
Print matched dns zones (only gcp, aws)

### DIFF
--- a/provider/aws.go
+++ b/provider/aws.go
@@ -131,6 +131,10 @@ func (p *AWSProvider) Zones() (map[string]*route53.HostedZone, error) {
 		return nil, err
 	}
 
+	for _, zone := range zones {
+		log.Debugf("Considering zone: %s (domain: %s)", aws.StringValue(zone.Id), aws.StringValue(zone.Name))
+	}
+
 	return zones, nil
 }
 

--- a/provider/google.go
+++ b/provider/google.go
@@ -159,6 +159,10 @@ func (p *GoogleProvider) Zones() (map[string]*dns.ManagedZone, error) {
 		return nil, err
 	}
 
+	for _, zone := range zones {
+		log.Debugf("Considering zone: %s (domain: %s)", zone.Name, zone.DnsName)
+	}
+
 	return zones, nil
 }
 


### PR DESCRIPTION
This prints the dns zones the provider considers for placing dns records. It hopefully helps us to quickly figure out why ExternalDNS refuses to place records, e.g. due to wrong IAM configuration, wrong domain filter or bugs in the zone detection.

```console
time="2017-11-28T11:27:24+01:00" level=debug msg="Considering zone: /hostedzone/Z3...P7 (domain: zone-1.teapot.zalan.do.)"
time="2017-11-28T11:27:24+01:00" level=debug msg="Considering zone: /hostedzone/ZH...5OE (domain: zone-4.teapot.zalan.do.)"
```

/cc @ideahitme 