### PR TITLE
Switch to go v1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ os:
 language: go
 
 go:
-- 1.8
 - 1.9
 - tip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # builder image
-FROM golang:1.8 as builder
+FROM golang:1.9 as builder
 
 WORKDIR /go/src/github.com/kubernetes-incubator/external-dns
 COPY . .


### PR DESCRIPTION
Removes 1.8 from travis and builds the image using 1.9