### PR TITLE
Adding required `name` values

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -106,6 +106,7 @@ spec:
   type: LoadBalancer
   ports:
   - port: 80
+    name: http
     targetPort: 80
   selector:
     app: nginx
@@ -127,6 +128,7 @@ spec:
         name: nginx
         ports:
         - containerPort: 80
+          name: http
 ```
 
 After roughly two minutes check that a corresponding DNS record for your service was created.


### PR DESCRIPTION
Added a name value to make Kubernetes 1.8.5 work.

Had this error before:
```
The Service "nginx" is invalid:
* spec.ports[0].name: Required value
```