### PR TITLE
update RBAC rules in docs

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -63,7 +63,37 @@ In this case it's the ones shown above but your's will differ.
 ## Deploy ExternalDNS
 
 Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
-Then apply the following manifest file to deploy ExternalDNS.
+Then apply one of the following manifests file to deploy ExternalDNS.
+
+### Manifest (for clusters without RBAC enabled)
+```yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
+        args:
+        - --source=service
+        - --source=ingress
+        - --domain-filter=external-dns-test.my-org.com # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
+        - --provider=aws
+        - --policy=upsert-only # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
+        - --aws-zone-type=public # only look at public hosted zones (valid values are public, private or no value for both)
+        - --registry=txt
+        - --txt-owner-id=my-identifier
+```
+
+### Manifest (for clusters with RBAC enabled)
 
 ```yaml
 apiVersion: v1
@@ -76,22 +106,12 @@ kind: ClusterRole
 metadata:
   name: external-dns
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions"] 
+  resources: ["ingresses"] 
+  verbs: ["get","watch","list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -130,6 +150,8 @@ spec:
         - --registry=txt
         - --txt-owner-id=my-identifier
 ```
+
+
 
 ## Arguments
 

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -137,6 +137,7 @@ spec:
       labels:
         app: external-dns
     spec:
+      serviceAccountName: external-dns
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -124,6 +124,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: external-dns
+  namespace: default
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -66,6 +66,45 @@ Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
 Then apply the following manifest file to deploy ExternalDNS.
 
 ```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -98,8 +98,43 @@ A Service Principal with a minimum access level of contribute to the resource gr
 
 ## Deploy ExternalDNS
 
-Create a deployment file called `externaldns.yaml` with the following contents:
 
+Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
+Then apply one of the following manifests file to deploy ExternalDNS.
+
+### Manifest (for clusters without RBAC enabled)
+```yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
+        args:
+        - --source=service
+        - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
+        - --provider=azure
+        - --azure-resource-group=externaldns # (optional) use the DNS zones from the tutorial's resource group
+        volumeMounts:
+        - name: azure-config-file
+          mountPath: /etc/kubernetes
+          readOnly: true
+      volumes:
+      - name: azure-config-file
+        secret:
+          secretName: azure-config-file
+```
+
+### Manifest (for clusters with RBAC enabled)
 ```yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -111,22 +146,12 @@ kind: ClusterRole
 metadata:
   name: external-dns
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions"] 
+  resources: ["ingresses"] 
+  verbs: ["get","watch","list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -101,6 +101,45 @@ A Service Principal with a minimum access level of contribute to the resource gr
 Create a deployment file called `externaldns.yaml` with the following contents:
 
 ```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -164,6 +164,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: external-dns
+  namespace: default
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -177,6 +177,7 @@ spec:
       labels:
         app: external-dns
     spec:
+      serviceAccountName: external-dns
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -99,6 +99,7 @@ spec:
       labels:
         app: external-dns
     spec:
+      serviceAccountName: external-dns
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -86,6 +86,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: external-dns
+  namespace: default
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -25,6 +25,45 @@ The environment vars `CF_API_KEY` and `CF_API_EMAIL` will be needed to run Exter
 Create a deployment file called `externaldns.yaml` with the following contents:
 
 ```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -22,7 +22,40 @@ The environment vars `CF_API_KEY` and `CF_API_EMAIL` will be needed to run Exter
 
 ## Deploy ExternalDNS
 
-Create a deployment file called `externaldns.yaml` with the following contents:
+Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
+Then apply one of the following manifests file to deploy ExternalDNS.
+
+### Manifest (for clusters without RBAC enabled)
+
+```yaml
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
+        args:
+        - --source=service # ingress is also possible
+        - --domain-filter=example.com # (optional) limit to only example.com domains; change to match the zone created above.
+        - --provider=cloudflare
+        - --cloudflare-proxied # (optional) enable the proxy feature of Cloudflare (DDOS protection, CDN...)
+        env:
+        - name: CF_API_KEY
+          value: "YOUR_CLOUDFLARE_API_KEY"
+        - name: CF_API_EMAIL
+          value: "YOUR_CLOUDFLARE_EMAIL"
+```
+
+### Manifest (for clusters with RBAC enabled)
 
 ```yaml
 apiVersion: v1
@@ -35,22 +68,12 @@ kind: ClusterRole
 metadata:
   name: external-dns
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions"] 
+  resources: ["ingresses"] 
+  verbs: ["get","watch","list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -89,12 +112,6 @@ spec:
           value: "YOUR_CLOUDFLARE_API_KEY"
         - name: CF_API_EMAIL
           value: "YOUR_CLOUDFLARE_EMAIL"
-```
-
-Create the deployment for ExternalDNS:
-
-```
-$ kubectl create -f externaldns.yaml
 ```
 
 ## Deploying an Nginx Service

--- a/docs/tutorials/digitalocean.md
+++ b/docs/tutorials/digitalocean.md
@@ -79,6 +79,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: external-dns
+  namespace: default
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/docs/tutorials/digitalocean.md
+++ b/docs/tutorials/digitalocean.md
@@ -92,6 +92,7 @@ spec:
       labels:
         app: external-dns
     spec:
+      serviceAccountName: external-dns
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8

--- a/docs/tutorials/digitalocean.md
+++ b/docs/tutorials/digitalocean.md
@@ -23,6 +23,45 @@ The environment variable `DO_TOKEN` will be needed to run ExternalDNS with Digit
 Create a deployment file called `externaldns.yaml` with the following contents:
 
 ```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/docs/tutorials/gke.md
+++ b/docs/tutorials/gke.md
@@ -63,6 +63,45 @@ gcloud container clusters get-credentials "external-dns"
 Apply the following manifest file to deploy ExternalDNS.
 
 ```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/docs/tutorials/gke.md
+++ b/docs/tutorials/gke.md
@@ -76,6 +76,7 @@ spec:
       labels:
         app: external-dns
     spec:
+      serviceAccountName: external-dns
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8

--- a/docs/tutorials/gke.md
+++ b/docs/tutorials/gke.md
@@ -121,6 +121,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: external-dns
+  namespace: default
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/docs/tutorials/hostport.md
+++ b/docs/tutorials/hostport.md
@@ -67,6 +67,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: external-dns
+  namespace: default
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/docs/tutorials/hostport.md
+++ b/docs/tutorials/hostport.md
@@ -77,6 +77,7 @@ spec:
     type: Recreate
   template:
     spec:
+      serviceAccountName: external-dns
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8

--- a/docs/tutorials/hostport.md
+++ b/docs/tutorials/hostport.md
@@ -13,6 +13,45 @@ We will go through a small example of deploying a simple Kafka with use of a hea
 
 A simple deploy could look like this:
 ```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/docs/tutorials/infoblox.md
+++ b/docs/tutorials/infoblox.md
@@ -123,6 +123,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: external-dns
+  namespace: default
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/docs/tutorials/infoblox.md
+++ b/docs/tutorials/infoblox.md
@@ -136,6 +136,7 @@ spec:
       labels:
         app: external-dns
     spec:
+      serviceAccountName: external-dns
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8

--- a/docs/tutorials/infoblox.md
+++ b/docs/tutorials/infoblox.md
@@ -49,8 +49,46 @@ $ kubectl create secret generic external-dns \
 
 Create a deployment file called `externaldns.yaml` with the following contents:
 
-```
-$ cat > externaldns.yaml <<EOF
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -89,7 +127,6 @@ spec:
             secretKeyRef:
               name: external-dns
               key: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
-EOF
 ```
 
 Create the deployment for ExternalDNS:

--- a/docs/tutorials/nginx-ingress.md
+++ b/docs/tutorials/nginx-ingress.md
@@ -203,6 +203,45 @@ spec:
 Apply the following manifest file to deploy ExternalDNS.
 
 ```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/docs/tutorials/nginx-ingress.md
+++ b/docs/tutorials/nginx-ingress.md
@@ -241,6 +241,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: external-dns
+  namespace: default
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
This PR addresses #233. I have updated the example YAML's to have the appropriate RBAC permissions for K8s clusters running with RBAC (now enabled by default on new clusters.) 

