### PR TITLE
add paris region

### DIFF
--- a/provider/aws.go
+++ b/provider/aws.go
@@ -52,6 +52,7 @@ var (
 		"eu-central-1" + elbHostnameSuffix:   "Z215JYRZR1TBD5",
 		"eu-west-1" + elbHostnameSuffix:      "Z32O12XQLNTSW2",
 		"eu-west-2" + elbHostnameSuffix:      "ZHURV8PSTC4K8",
+		"eu-west-3" + elbHostnameSuffix:      "Z3Q77PNBQS71R4",
 		"sa-east-1" + elbHostnameSuffix:      "Z2P70J7HTTTPLU",
 	}
 )

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -710,6 +710,7 @@ func TestAWSCanonicalHostedZone(t *testing.T) {
 		{"foo.eu-central-1.elb.amazonaws.com", "Z215JYRZR1TBD5"},
 		{"foo.eu-west-1.elb.amazonaws.com", "Z32O12XQLNTSW2"},
 		{"foo.eu-west-2.elb.amazonaws.com", "ZHURV8PSTC4K8"},
+		{"foo.eu-west-3.elb.amazonaws.com", "Z3Q77PNBQS71R4"},
 		{"foo.sa-east-1.elb.amazonaws.com", "Z2P70J7HTTTPLU"},
 		{"foo.example.org", ""},
 	} {


### PR DESCRIPTION
Addresses #447 by adding the new AWS Paris region to the list of `canonicalHostedZones`.