### PR TITLE
Add some filters for DNS name generation

### DIFF
--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -1,0 +1,87 @@
+## Filter-Scenarios and Filter Options
+
+The controller supports various options controlling the
+IP ranges for which DNS entries should be created or DNS
+domains that should be handled.
+
+### Option `--domain-filter`<domain name>
+
+This option may be given multiple times. It takes a single
+DNS argument representing the base domain of a hosted zone.
+By default, all hosted zones available for the given
+DNS provider and the given credentials are used for potential
+target DNS entries.With this optio the supported hosted zones
+can be explicitly selected. Despite its name this option
+does not filter domains but hosted zones.
+
+A typical scenario for the use of this option is for an
+account used by the DNS controller containing more than one
+hosted zones. If the actual instance should be limited to a
+dedicated set of hosted zones, this option ca be given
+to select the hosted zones, that should be used.
+
+### Option `--zone-id-filter`<zone id>
+
+This option may be given multiple times. It takes a single
+id argument for a hosted zone. 
+
+This option has a similar effect as the `--domain-filter`
+option. But instead of specifying the domain name of the
+hosted zone, the id of hosted zone is used.
+
+
+### Option `--basedomain-filter`<domain name>
+
+This option may be given multiple times. It takes a single
+domain name argument. It may be any domain, not only 
+base domain names for a hosted zone. It limits the
+DNS entry generation to sub domains of the given base domain
+set.
+
+A typical scenario for the use of this option are hosted
+zones shared among multiple kubernetes clusters, where every
+cluster gets its own base domain. Ingresses and services
+of one cluster should not use DNS entries interfering with
+names used for another cluster.
+
+This can be achieved by using this option with the base
+domain name used for the actual cluster.
+
+
+### Option `--cidr-ignore`<cidr>
+
+This option may be given multiple times. It takes a single
+CIDR argument. When collecting the IPs for which DNS entries
+should exist, all IPs in those ranges are ignored.
+
+A typical scenario for the use of this option is OpenStack.
+The cloud provider here adds multiple IPs for a service of
+type load-balancer, if it is configured to add a floating IP
+to the load-balancer. The floating IP as well as the
+IP of the load-balancer in the subnet it is deployed into
+is propagated as IP address. In this case typically only the
+floating IP should be used for the DNS entry, because the
+load balancer IP is on an internal subnet.
+
+Here this option is given with the IP of the internal
+load-balancer IP to omit DNS entries for those IPs.
+
+### Option `--dns-ignore`
+
+This option may be given multiple times. It takes a single
+DNS name argument. The DNS name might be a wildcard name.
+When collecting target DNS names all entries matching the
+given DNS names are ignored.
+
+A typical scenario for the use of this option is
+configuring an ingress service of type load-balancer
+(for example nginx) with a wildcard DNS entry. In such
+a case all subsequent DNS names are already mapped to the
+ingress service and it makes no sence to generate explicit
+DNS entries for ingresses matching this wildcard domain.
+
+Here this option is given with the wildcard DNS name used
+for the ingress service to avoid such explicit DNS entries.
+
+
+

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -61,6 +61,32 @@ func (t Targets) Less(i, j int) bool {
 	return t[i] < t[j]
 }
 
+// Has checks whether a Targets array
+// contains a dedicated target
+func (t Targets) Has(target string) bool {
+	for _, e := range t {
+		if e == target {
+			return true
+		}
+	}
+	return false
+}
+
+// Remove removes an entry from the array if it is present
+// and returns the resulting target array.
+func (t Targets) Remove(target string) Targets {
+	n := Targets{}
+	for _, e := range t {
+		if e != target {
+			n = append(n, e)
+		}
+	}
+	if len(t) == len(n) {
+		return t
+	}
+	return n
+}
+
 func (t Targets) Swap(i, j int) {
 	t[i], t[j] = t[j], t[i]
 }

--- a/main.go
+++ b/main.go
@@ -86,7 +86,8 @@ func main() {
 
 	// Combine multiple sources into a single, deduplicated source.
 	log.Infof("found %d cidr filters %+v", len(cfg.CidrIgnore), cfg.CidrIgnore)
-	endpointsSource := source.NewDedupSource(source.NewFilterSource(source.CIDRs(cfg.CidrIgnore), source.NewMultiSource(sources)))
+	log.Infof("found %d dns filters %+v", len(cfg.DNSIgnore), cfg.DNSIgnore)
+	endpointsSource := source.NewDedupSource(source.NewFilterSource(source.CIDRs(cfg.CidrIgnore), cfg.DNSIgnore, source.NewMultiSource(sources)))
 
 	domainFilter := provider.NewDomainFilter(cfg.DomainFilter)
 	zoneIDFilter := provider.NewZoneIDFilter(cfg.ZoneIDFilter)

--- a/main.go
+++ b/main.go
@@ -84,10 +84,12 @@ func main() {
 		log.Fatal(err)
 	}
 
+	baseDomainFilter := provider.NewDomainFilter(cfg.BaseDomainFilter)
+
 	// Combine multiple sources into a single, deduplicated source.
 	log.Infof("found %d cidr filters %+v", len(cfg.CidrIgnore), cfg.CidrIgnore)
 	log.Infof("found %d dns filters %+v", len(cfg.DNSIgnore), cfg.DNSIgnore)
-	endpointsSource := source.NewDedupSource(source.NewFilterSource(source.CIDRs(cfg.CidrIgnore), cfg.DNSIgnore, source.NewMultiSource(sources)))
+	endpointsSource := source.NewDedupSource(source.NewFilterSource(baseDomainFilter, source.CIDRs(cfg.CidrIgnore), cfg.DNSIgnore, source.NewMultiSource(sources)))
 
 	domainFilter := provider.NewDomainFilter(cfg.DomainFilter)
 	zoneIDFilter := provider.NewZoneIDFilter(cfg.ZoneIDFilter)

--- a/main.go
+++ b/main.go
@@ -85,7 +85,8 @@ func main() {
 	}
 
 	// Combine multiple sources into a single, deduplicated source.
-	endpointsSource := source.NewDedupSource(source.NewMultiSource(sources))
+	log.Infof("found %d cidr filters %+v", len(cfg.CidrIgnore), cfg.CidrIgnore)
+	endpointsSource := source.NewDedupSource(source.NewFilterSource(source.CIDRs(cfg.CidrIgnore), source.NewMultiSource(sources)))
 
 	domainFilter := provider.NewDomainFilter(cfg.DomainFilter)
 	zoneIDFilter := provider.NewZoneIDFilter(cfg.ZoneIDFilter)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -49,6 +49,7 @@ type Config struct {
 	GoogleProject            string
 	DomainFilter             []string
 	ZoneIDFilter             []string
+	BaseDomainFilter         []string
 	CidrIgnore               []string
 	DNSIgnore                []string
 	AWSZoneType              string
@@ -94,6 +95,7 @@ var defaultConfig = &Config{
 	Provider:                 "",
 	GoogleProject:            "",
 	DomainFilter:             []string{},
+	BaseDomainFilter:         nil,
 	CidrIgnore:               nil,
 	DNSIgnore:                nil,
 	AWSZoneType:              "",
@@ -172,8 +174,9 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("provider", "The DNS provider where the DNS records will be created (required, options: aws, google, azure, cloudflare, digitalocean, dnsimple, infoblox, dyn, designate, inmemory, pdns)").Required().PlaceHolder("provider").EnumVar(&cfg.Provider, "aws", "google", "azure", "cloudflare", "digitalocean", "dnsimple", "infoblox", "dyn", "desginate", "inmemory", "pdns")
 	app.Flag("domain-filter", "Limit possible target zones by a domain suffix; specify multiple times for multiple domains (optional)").Default("").StringsVar(&cfg.DomainFilter)
 	app.Flag("zone-id-filter", "Filter target zones by hosted zone id; specify multiple times for multiple zones (optional)").Default("").StringsVar(&cfg.ZoneIDFilter)
-	app.Flag("cidr-ignore", "Limit DNS entries excluding IP addresses in given ranges").StringsVar(&cfg.CidrIgnore)
-	app.Flag("dns-ignore", "Limit DNS entries excluding given DNS (wirldcard) names").StringsVar(&cfg.DNSIgnore)
+	app.Flag("basedomain-filter", "Limit possible DNS entries by a domain suffix; specify multiple times for multiple domains (optional)").StringsVar(&cfg.BaseDomainFilter)
+	app.Flag("cidr-ignore", "Limit DNS entries excluding IP addresses in given ranges; specify multiple times for multiple CIDRs (optional)").StringsVar(&cfg.CidrIgnore)
+	app.Flag("dns-ignore", "Limit DNS entries excluding given DNS (or wildcard DNS) names; specify multiple times for multiple DNS names (optional)").StringsVar(&cfg.DNSIgnore)
 	app.Flag("google-project", "When using the Google provider, current project is auto-detected, when running on GCP. Specify other project with this. Must be specified when running outside GCP.").Default(defaultConfig.GoogleProject).StringVar(&cfg.GoogleProject)
 	app.Flag("aws-zone-type", "When using the AWS provider, filter for zones of this type (optional, options: public, private)").Default(defaultConfig.AWSZoneType).EnumVar(&cfg.AWSZoneType, "", "public", "private")
 	app.Flag("aws-assume-role", "When using the AWS provider, assume this IAM role. Useful for hosted zones in another AWS account. Specify the full ARN, e.g. `arn:aws:iam::123455567:role/external-dns` (optional)").Default(defaultConfig.AWSAssumeRole).StringVar(&cfg.AWSAssumeRole)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -49,6 +49,7 @@ type Config struct {
 	GoogleProject            string
 	DomainFilter             []string
 	ZoneIDFilter             []string
+	CidrIgnore               []string
 	AWSZoneType              string
 	AWSAssumeRole            string
 	AzureConfigFile          string
@@ -92,6 +93,7 @@ var defaultConfig = &Config{
 	Provider:                 "",
 	GoogleProject:            "",
 	DomainFilter:             []string{},
+	CidrIgnore:               nil,
 	AWSZoneType:              "",
 	AWSAssumeRole:            "",
 	AzureConfigFile:          "/etc/kubernetes/azure.json",
@@ -168,6 +170,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("provider", "The DNS provider where the DNS records will be created (required, options: aws, google, azure, cloudflare, digitalocean, dnsimple, infoblox, dyn, designate, inmemory, pdns)").Required().PlaceHolder("provider").EnumVar(&cfg.Provider, "aws", "google", "azure", "cloudflare", "digitalocean", "dnsimple", "infoblox", "dyn", "desginate", "inmemory", "pdns")
 	app.Flag("domain-filter", "Limit possible target zones by a domain suffix; specify multiple times for multiple domains (optional)").Default("").StringsVar(&cfg.DomainFilter)
 	app.Flag("zone-id-filter", "Filter target zones by hosted zone id; specify multiple times for multiple zones (optional)").Default("").StringsVar(&cfg.ZoneIDFilter)
+	app.Flag("cidr-ignore", "Limit DNS entries excluding IP addresses in given ranges").StringsVar(&cfg.CidrIgnore)
 	app.Flag("google-project", "When using the Google provider, current project is auto-detected, when running on GCP. Specify other project with this. Must be specified when running outside GCP.").Default(defaultConfig.GoogleProject).StringVar(&cfg.GoogleProject)
 	app.Flag("aws-zone-type", "When using the AWS provider, filter for zones of this type (optional, options: public, private)").Default(defaultConfig.AWSZoneType).EnumVar(&cfg.AWSZoneType, "", "public", "private")
 	app.Flag("aws-assume-role", "When using the AWS provider, assume this IAM role. Useful for hosted zones in another AWS account. Specify the full ARN, e.g. `arn:aws:iam::123455567:role/external-dns` (optional)").Default(defaultConfig.AWSAssumeRole).StringVar(&cfg.AWSAssumeRole)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -50,6 +50,7 @@ type Config struct {
 	DomainFilter             []string
 	ZoneIDFilter             []string
 	CidrIgnore               []string
+	DNSIgnore                []string
 	AWSZoneType              string
 	AWSAssumeRole            string
 	AzureConfigFile          string
@@ -94,6 +95,7 @@ var defaultConfig = &Config{
 	GoogleProject:            "",
 	DomainFilter:             []string{},
 	CidrIgnore:               nil,
+	DNSIgnore:                nil,
 	AWSZoneType:              "",
 	AWSAssumeRole:            "",
 	AzureConfigFile:          "/etc/kubernetes/azure.json",
@@ -171,6 +173,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("domain-filter", "Limit possible target zones by a domain suffix; specify multiple times for multiple domains (optional)").Default("").StringsVar(&cfg.DomainFilter)
 	app.Flag("zone-id-filter", "Filter target zones by hosted zone id; specify multiple times for multiple zones (optional)").Default("").StringsVar(&cfg.ZoneIDFilter)
 	app.Flag("cidr-ignore", "Limit DNS entries excluding IP addresses in given ranges").StringsVar(&cfg.CidrIgnore)
+	app.Flag("dns-ignore", "Limit DNS entries excluding given DNS (wirldcard) names").StringsVar(&cfg.DNSIgnore)
 	app.Flag("google-project", "When using the Google provider, current project is auto-detected, when running on GCP. Specify other project with this. Must be specified when running outside GCP.").Default(defaultConfig.GoogleProject).StringVar(&cfg.GoogleProject)
 	app.Flag("aws-zone-type", "When using the AWS provider, filter for zones of this type (optional, options: public, private)").Default(defaultConfig.AWSZoneType).EnumVar(&cfg.AWSZoneType, "", "public", "private")
 	app.Flag("aws-assume-role", "When using the AWS provider, assume this IAM role. Useful for hosted zones in another AWS account. Specify the full ARN, e.g. `arn:aws:iam::123455567:role/external-dns` (optional)").Default(defaultConfig.AWSAssumeRole).StringVar(&cfg.AWSAssumeRole)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -77,6 +77,7 @@ type Config struct {
 	Interval                 time.Duration
 	Once                     bool
 	DryRun                   bool
+	Cleanup                  bool
 	LogFormat                string
 	MetricsAddress           string
 	LogLevel                 string
@@ -119,6 +120,7 @@ var defaultConfig = &Config{
 	Interval:                 time.Minute,
 	Once:                     false,
 	DryRun:                   false,
+	Cleanup:                  false,
 	LogFormat:                "text",
 	MetricsAddress:           ":7979",
 	LogLevel:                 logrus.InfoLevel.String(),
@@ -210,6 +212,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("interval", "The interval between two consecutive synchronizations in duration format (default: 1m)").Default(defaultConfig.Interval.String()).DurationVar(&cfg.Interval)
 	app.Flag("once", "When enabled, exits the synchronization loop after the first iteration (default: disabled)").BoolVar(&cfg.Once)
 	app.Flag("dry-run", "When enabled, prints DNS record changes rather than actually performing them (default: disabled)").BoolVar(&cfg.DryRun)
+	app.Flag("cleanup", "When enabled, deletes DNS records formerly created  (default: disabled); implies --once").BoolVar(&cfg.Cleanup)
 
 	// Miscellaneous flags
 	app.Flag("log-format", "The format in which log messages are printed (default: text, options: text, json)").Default(defaultConfig.LogFormat).EnumVar(&cfg.LogFormat, "text", "json")

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -82,7 +82,7 @@ func (im *TXTRegistry) Records() ([]*endpoint.Endpoint, error) {
 		}
 		endpointDNSName := im.mapper.toEndpointName(record.DNSName)
 		labelMap[endpointDNSName] = labels
-    log.Debugf("found %s TXT: %s -> %v",endpointDNSName, record.Target, labels)
+		log.Debugf("found %s TXT: %v -> %v", endpointDNSName, record.Targets, labels)
 	}
 
 	for _, ep := range endpoints {
@@ -165,11 +165,11 @@ func newPrefixNameMapper(prefix string) prefixNameMapper {
 // This happens lways if the entry prefix is set.
 func (pr prefixNameMapper) toEndpointName(txtDNSName string) string {
 	if strings.HasPrefix(txtDNSName, pr.prefix) {
-		n:=strings.TrimPrefix(txtDNSName, pr.prefix)
-    if strings.HasPrefix(n, "\\052.") {
-      return "*"+strings.TrimPrefix(n, "\\052")
-    }
-    return n
+		n := strings.TrimPrefix(txtDNSName, pr.prefix)
+		if strings.HasPrefix(n, "\\052.") {
+			return "*" + strings.TrimPrefix(n, "\\052")
+		}
+		return n
 	}
 	return ""
 }

--- a/source/filter_source.go
+++ b/source/filter_source.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"net"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/kubernetes-incubator/external-dns/endpoint"
+)
+
+func CIDRs(raw []string) []*net.IPNet {
+	cidrs := make([]*net.IPNet, len(raw))
+	for i, f := range raw {
+		_, cidr, err := net.ParseCIDR(f)
+		if err != nil {
+			log.Fatalf("failed to parse cidr '%s': %v", f, err)
+		}
+		cidrs[i] = cidr
+	}
+	return cidrs
+}
+
+func FilterSources(cidrs []*net.IPNet, sources ...Source) []Source {
+	result := make([]Source, len(sources))
+	for i, s := range sources {
+		result[i] = NewFilterSource(cidrs, s)
+	}
+	return result
+}
+
+// filterSource is a Source that removes duplicate endpoints from its wrapped source.
+type filterSource struct {
+	ignoreCIDRs []*net.IPNet
+	source      Source
+}
+
+// NewFilterSource creates a new FilterSource wrapping the provided Source.
+func NewFilterSource(cidrs []*net.IPNet, source Source) Source {
+	return &filterSource{ignoreCIDRs: cidrs, source: source}
+}
+
+// Endpoints collects endpoints from its wrapped source and returns them without filtered IPs.
+func (ms *filterSource) Endpoints() ([]*endpoint.Endpoint, error) {
+	result := []*endpoint.Endpoint{}
+
+	endpoints, err := ms.source.Endpoints()
+	if err != nil {
+		return nil, err
+	}
+
+EPS:
+	for _, ep := range endpoints {
+		if ep.RecordType == endpoint.RecordTypeA {
+			for _, t := range ep.Targets {
+				ip := net.ParseIP(t)
+				if ip != nil {
+					for _, cidr := range ms.ignoreCIDRs {
+						if cidr.Contains(ip) {
+							ep.Targets = ep.Targets.Remove(t)
+							if len(ep.Targets) == 0 {
+								log.Debugf("Removing endpoint %s omitted because of CIDR %s", ep, cidr)
+								continue EPS
+							} else {
+								log.Debugf("Removing target %s from endpoint %s because of CIDR %s", t, ep, cidr)
+							}
+						}
+					}
+				}
+			}
+		}
+
+		result = append(result, ep)
+	}
+
+	return result, nil
+}

--- a/source/filter_source_test.go
+++ b/source/filter_source_test.go
@@ -28,11 +28,12 @@ import (
 var _ Source = &filterSource{}
 
 func TestFilter(t *testing.T) {
-	t.Run("Endpoints", testFilterEndpoints)
+	t.Run("Filter Cidr Endpoints", testFilterCidrEndpoints)
+	t.Run("Filter DNS Names", testFilterDNSNames)
 }
 
-// testFilterEndpoints tests that filtered IPs from the wrapped source are removed.
-func testFilterEndpoints(t *testing.T) {
+// testFilterCidrEndpoints tests that filtered IPs from the wrapped source are removed.
+func testFilterCidrEndpoints(t *testing.T) {
 	for _, tc := range []struct {
 		title     string
 		endpoints []*endpoint.Endpoint
@@ -70,10 +71,20 @@ func testFilterEndpoints(t *testing.T) {
 			},
 		},
 		{
-			"two endpoints with same dnsname and same target return one endpoint",
+			"two endpoints with same dnsname and ignored target return one endpoint",
 			[]*endpoint.Endpoint{
 				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
 				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("192.168.100.10"), RecordType: endpoint.RecordTypeA},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+		},
+		{
+			"two endpoints with different dnsname and ignored target return one endpoint",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "bar.example.org", Targets: endpoint.NewTargets("192.168.100.10"), RecordType: endpoint.RecordTypeA},
 			},
 			[]*endpoint.Endpoint{
 				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
@@ -86,7 +97,98 @@ func testFilterEndpoints(t *testing.T) {
 
 			// Create our object under test and get the endpoints.
 			_, cidr, _ := net.ParseCIDR("192.168.100.0/24")
-			source := NewFilterSource([]*net.IPNet{cidr}, mockSource)
+			source := NewFilterSource([]*net.IPNet{cidr}, nil, mockSource)
+
+			endpoints, err := source.Endpoints()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Validate returned endpoints against desired endpoints.
+			validateEndpoints(t, endpoints, tc.expected)
+
+			// Validate that the mock source was called.
+			mockSource.AssertExpectations(t)
+		})
+	}
+}
+
+// testFilterDNS tests that filtered DNS names are removed.
+func testFilterDNSNames(t *testing.T) {
+	for _, tc := range []struct {
+		title     string
+		endpoints []*endpoint.Endpoint
+		expected  []*endpoint.Endpoint
+	}{
+		{
+			"one endpoint returns one endpoint",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+		},
+		{
+			"two different endpoints return two endpoints",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "bar.example.org", Targets: endpoint.NewTargets("4.5.6.7"), RecordType: endpoint.RecordTypeA},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "bar.example.org", Targets: endpoint.NewTargets("4.5.6.7"), RecordType: endpoint.RecordTypeA},
+			},
+		},
+		{
+			"endpoints with ignored dnsname are removed",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.bar.example.com", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+		},
+		{
+			"endpoints with dnsname ignored by wildcard are removed",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.com", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+		},
+		{
+			"endpoints with dnsname with more levels than wildcard are not removed",
+			[]*endpoint.Endpoint{
+				{DNSName: "bar.foo.example.com", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "bar.foo.example.com", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+		},
+		{
+			"endpoints with matching wildcard are not removed",
+			[]*endpoint.Endpoint{
+				{DNSName: "*.example.com", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "*.example.com", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			mockSource := new(testutils.MockSource)
+			mockSource.On("Endpoints").Return(tc.endpoints, nil)
+
+			// Create our object under test and get the endpoints.
+			source := NewFilterSource(nil, []string{"*.example.com", "foo.bar.example.com"}, mockSource)
 
 			endpoints, err := source.Endpoints()
 			if err != nil {

--- a/source/filter_source_test.go
+++ b/source/filter_source_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 	"github.com/kubernetes-incubator/external-dns/internal/testutils"
+	"github.com/kubernetes-incubator/external-dns/provider"
 )
 
 // Validates that filterSource is a Source
@@ -97,7 +98,7 @@ func testFilterCidrEndpoints(t *testing.T) {
 
 			// Create our object under test and get the endpoints.
 			_, cidr, _ := net.ParseCIDR("192.168.100.0/24")
-			source := NewFilterSource([]*net.IPNet{cidr}, nil, mockSource)
+			source := NewFilterSource(provider.NewDomainFilter([]string{}), []*net.IPNet{cidr}, nil, mockSource)
 
 			endpoints, err := source.Endpoints()
 			if err != nil {
@@ -188,7 +189,56 @@ func testFilterDNSNames(t *testing.T) {
 			mockSource.On("Endpoints").Return(tc.endpoints, nil)
 
 			// Create our object under test and get the endpoints.
-			source := NewFilterSource(nil, []string{"*.example.com", "foo.bar.example.com"}, mockSource)
+			source := NewFilterSource(provider.NewDomainFilter([]string{}), nil, []string{"*.example.com", "foo.bar.example.com"}, mockSource)
+
+			endpoints, err := source.Endpoints()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Validate returned endpoints against desired endpoints.
+			validateEndpoints(t, endpoints, tc.expected)
+
+			// Validate that the mock source was called.
+			mockSource.AssertExpectations(t)
+		})
+	}
+}
+
+// testFilterBaseDomain tests that filtered DNS names are removed.
+func testFilterBaseDomain(t *testing.T) {
+	for _, tc := range []struct {
+		title     string
+		endpoints []*endpoint.Endpoint
+		expected  []*endpoint.Endpoint
+	}{
+		{
+			"matching endpoint returns one endpoint",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.cluster.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.cluster.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+		},
+		{
+			"endpoints with ignored non matching dnsname are removed",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.bar.example.com", Targets: endpoint.NewTargets("1.2.3.6"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.5"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "foo.cluster.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.cluster.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			mockSource := new(testutils.MockSource)
+			mockSource.On("Endpoints").Return(tc.endpoints, nil)
+
+			// Create our object under test and get the endpoints.
+			source := NewFilterSource(provider.NewDomainFilter([]string{"cluster.example.org"}), nil, []string{"*.example.com", "foo.bar.example.com"}, mockSource)
 
 			endpoints, err := source.Endpoints()
 			if err != nil {

--- a/source/filter_source_test.go
+++ b/source/filter_source_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"net"
+	"testing"
+
+	"github.com/kubernetes-incubator/external-dns/endpoint"
+	"github.com/kubernetes-incubator/external-dns/internal/testutils"
+)
+
+// Validates that filterSource is a Source
+var _ Source = &filterSource{}
+
+func TestFilter(t *testing.T) {
+	t.Run("Endpoints", testFilterEndpoints)
+}
+
+// testFilterEndpoints tests that filtered IPs from the wrapped source are removed.
+func testFilterEndpoints(t *testing.T) {
+	for _, tc := range []struct {
+		title     string
+		endpoints []*endpoint.Endpoint
+		expected  []*endpoint.Endpoint
+	}{
+		{
+			"one endpoint returns one endpoint",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+		},
+		{
+			"two different endpoints return two endpoints",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "bar.example.org", Targets: endpoint.NewTargets("4.5.6.7"), RecordType: endpoint.RecordTypeA},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "bar.example.org", Targets: endpoint.NewTargets("4.5.6.7"), RecordType: endpoint.RecordTypeA},
+			},
+		},
+		{
+			"non A-records ignores",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("192.168.100.10"), RecordType: endpoint.RecordTypeCNAME},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("192.168.100.10"), RecordType: endpoint.RecordTypeCNAME},
+			},
+		},
+		{
+			"two endpoints with same dnsname and same target return one endpoint",
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("192.168.100.10"), RecordType: endpoint.RecordTypeA},
+			},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.example.org", Targets: endpoint.NewTargets("1.2.3.4"), RecordType: endpoint.RecordTypeA},
+			},
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			mockSource := new(testutils.MockSource)
+			mockSource.On("Endpoints").Return(tc.endpoints, nil)
+
+			// Create our object under test and get the endpoints.
+			_, cidr, _ := net.ParseCIDR("192.168.100.0/24")
+			source := NewFilterSource([]*net.IPNet{cidr}, mockSource)
+
+			endpoints, err := source.Endpoints()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Validate returned endpoints against desired endpoints.
+			validateEndpoints(t, endpoints, tc.expected)
+
+			// Validate that the mock source was called.
+			mockSource.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
We want to use the external-dns controller in an on-premise Openstack environment using AWS route53 (later designate) as DNS provider. (see https://github.com/gardener/kubify)

This causes several problems fixed by this pull request:
- The Openstack Cloud Provider adds several endpoints to a service if the loadbalancer is created in a local subnet and gets an (external) floating IP. The dns controller then tries to create several DNS entries with different target IPs. The pull request adds a CIDR ignore filter to speciify CIDRs for which no DNS entries should be created. The controller is then called with the local subnet CIDR to filter.
- The controller basically supports the creation of wildcard entries. But the TXT entries are not recognized anymore when configuring a txt prefix. Because wildcards are only allowed at the beginning of an entry it is replaced by \052 when a prefix is added. The second commit fixes this problem.
- When using wildcard entries for an ingress loadbalancer it makes no sense to add dedicated DNS entries for every service whose hostname matches this pattern. Therefore the third commit adds a DNS filter, to specify DNS names (optionally with wildcard) for which no DNS entry should be generated. 
- A useful scenario (we would require) is to restrict the DNS names handled by the controller to a dedicated base domain assigned for the cluster (for example: mycluster.acme.com), just reusing a common hosted zone shared with other clusters or clients.  Therefore it would be nice to be able to specify a `domain-filter` for the DNS names valid for this cluster. Unfortunately this name is now already used for the hosted zone filter. Here only zones for a base domain being a (sub)domain of the values specified for the domain filter are taken into account for the DNS provider. Therefore the option `basedomain-filter` has been used to add a real domain filter for DNS entries.
- With the new option `--cleanup` it is possible to remove all DNS entries managed according to the actual argument settings. This option implies `--once`. It should be called after the controller has been stopped. Otherwise the entries might reappear, before the controller is finished later on. Access to kubernetes is not required, so it can even be called after a kubernetes cluster has been destroyed.
