### PR TITLE
Don't log passwords on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+  - Don't log sensitive data on start (#463) @jvassev
   - Google: Improve logging to help trace misconfigurations (#388) @stealthybox
   - AWS: In addition to the one best public hosted zone, records will be added to all matching private hosted zones (#356) @coreypobrien
   - Every record managed by External DNS is now mapped to a kubernetes resource (service/ingress) @ideahitme

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 	if err := cfg.ParseFlags(os.Args[1:]); err != nil {
 		log.Fatalf("flag parsing error: %v", err)
 	}
-	log.Infof("config: %+v", cfg)
+	log.Infof("config: %s", cfg)
 
 	if err := validation.ValidateConfig(cfg); err != nil {
 		log.Fatalf("config validation failed: %v", err)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -17,11 +17,16 @@ limitations under the License.
 package externaldns
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/alecthomas/kingpin"
 	"github.com/sirupsen/logrus"
+)
+
+const (
+	passwordMask = "******"
 )
 
 var (
@@ -107,6 +112,19 @@ var defaultConfig = &Config{
 // NewConfig returns new Config object
 func NewConfig() *Config {
 	return &Config{}
+}
+
+func (cfg *Config) String() string {
+	// prevent logging of sensitive information
+	temp := *cfg
+	if temp.DynPassword != "" {
+		temp.DynPassword = passwordMask
+	}
+	if temp.InfobloxWapiPassword != "" {
+		temp.InfobloxWapiPassword = passwordMask
+	}
+
+	return fmt.Sprintf("%+v", temp)
 }
 
 // allLogLevelsAsStrings returns all logrus levels as a list of strings


### PR DESCRIPTION
The two passwords configurable as flags (for infoblox and dyn) are
masked now and not logged.