### PR TITLE
Retrive all DNSimple response pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+  - Bugfix: Retrive all DNSimple response pages (#468) @jbowes
   - Google: Improve logging to help trace misconfigurations (#388) @stealthybox
   - AWS: In addition to the one best public hosted zone, records will be added to all matching private hosted zones (#356) @coreypobrien
   - Every record managed by External DNS is now mapped to a kubernetes resource (service/ingress) @ideahitme

--- a/provider/dnsimple.go
+++ b/provider/dnsimple.go
@@ -124,20 +124,30 @@ func NewDnsimpleProvider(domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, d
 // Returns a list of filtered Zones
 func (p *dnsimpleProvider) Zones() (map[string]dnsimple.Zone, error) {
 	zones := make(map[string]dnsimple.Zone)
-	zonesResponse, err := p.client.ListZones(p.accountID, &dnsimple.ZoneListOptions{})
-	if err != nil {
-		return nil, err
-	}
-	for _, zone := range zonesResponse.Data {
-		if !p.domainFilter.Match(zone.Name) {
-			continue
+	page := 1
+	listOptions := &dnsimple.ZoneListOptions{}
+	for {
+		listOptions.Page = page
+		zonesResponse, err := p.client.ListZones(p.accountID, listOptions)
+		if err != nil {
+			return nil, err
+		}
+		for _, zone := range zonesResponse.Data {
+			if !p.domainFilter.Match(zone.Name) {
+				continue
+			}
+
+			if !p.zoneIDFilter.Match(strconv.Itoa(zone.ID)) {
+				continue
+			}
+
+			zones[strconv.Itoa(zone.ID)] = zone
 		}
 
-		if !p.zoneIDFilter.Match(strconv.Itoa(zone.ID)) {
-			continue
+		page++
+		if page > zonesResponse.Pagination.TotalPages {
+			break
 		}
-
-		zones[strconv.Itoa(zone.ID)] = zone
 	}
 	return zones, nil
 }
@@ -149,18 +159,27 @@ func (p *dnsimpleProvider) Records() (endpoints []*endpoint.Endpoint, _ error) {
 		return nil, err
 	}
 	for _, zone := range zones {
-		records, err := p.client.ListRecords(p.accountID, zone.Name, &dnsimple.ZoneRecordListOptions{})
-		if err != nil {
-			return nil, err
-		}
-		for _, record := range records.Data {
-			switch record.Type {
-			case "A", "CNAME", "TXT":
-				break
-			default:
-				continue
+		page := 1
+		listOptions := &dnsimple.ZoneRecordListOptions{}
+		for {
+			listOptions.Page = page
+			records, err := p.client.ListRecords(p.accountID, zone.Name, listOptions)
+			if err != nil {
+				return nil, err
 			}
-			endpoints = append(endpoints, endpoint.NewEndpoint(record.Name+"."+record.ZoneID, record.Content, record.Type))
+			for _, record := range records.Data {
+				switch record.Type {
+				case "A", "CNAME", "TXT":
+					break
+				default:
+					continue
+				}
+				endpoints = append(endpoints, endpoint.NewEndpoint(record.Name+"."+record.ZoneID, record.Content, record.Type))
+			}
+			page++
+			if page > records.Pagination.TotalPages {
+				break
+			}
 		}
 	}
 	return endpoints, nil
@@ -239,13 +258,24 @@ func (p *dnsimpleProvider) submitChanges(changes []*dnsimpleChange) error {
 
 // Returns the record ID for a given record name and zone
 func (p *dnsimpleProvider) GetRecordID(zone string, recordName string) (recordID int, err error) {
-	records, err := p.client.ListRecords(p.accountID, zone, &dnsimple.ZoneRecordListOptions{})
-	if err != nil {
-		return 0, err
-	}
-	for _, record := range records.Data {
-		if record.Name == recordName {
-			return record.ID, nil
+	page := 1
+	listOptions := &dnsimple.ZoneRecordListOptions{Name: recordName}
+	for {
+		listOptions.Page = page
+		records, err := p.client.ListRecords(p.accountID, zone, listOptions)
+		if err != nil {
+			return 0, err
+		}
+
+		for _, record := range records.Data {
+			if record.Name == recordName {
+				return record.ID, nil
+			}
+		}
+
+		page++
+		if page > records.Pagination.TotalPages {
+			break
 		}
 	}
 	return 0, fmt.Errorf("No record id found")


### PR DESCRIPTION
The DNSimple API is paginated. Retrive all pages when requesting zones
and records, so that none are skipped.

When querying for a single record, ask for it by name. That way, there
will be fewer pages to iterate through.