### PR TITLE
Graceful handling of misconfigure password for dyn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+  - Graceful handling of misconfigure password for dyn provider (#470) @jvassev
   - Don't log sensitive data on start (#463) @jvassev
   - Google: Improve logging to help trace misconfigurations (#388) @stealthybox
   - AWS: In addition to the one best public hosted zone, records will be added to all matching private hosted zones (#356) @coreypobrien

--- a/main.go
+++ b/main.go
@@ -121,13 +121,14 @@ func main() {
 	case "dyn":
 		p, err = provider.NewDynProvider(
 			provider.DynConfig{
-				DomainFilter: domainFilter,
-				ZoneIDFilter: zoneIDFilter,
-				DryRun:       cfg.DryRun,
-				CustomerName: cfg.DynCustomerName,
-				Username:     cfg.DynUsername,
-				Password:     cfg.DynPassword,
-				AppVersion:   externaldns.Version,
+				DomainFilter:  domainFilter,
+				ZoneIDFilter:  zoneIDFilter,
+				DryRun:        cfg.DryRun,
+				CustomerName:  cfg.DynCustomerName,
+				Username:      cfg.DynUsername,
+				Password:      cfg.DynPassword,
+				MinTTLSeconds: cfg.DynMinTTLSeconds,
+				AppVersion:    externaldns.Version,
 			},
 		)
 	case "inmemory":

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -61,6 +61,7 @@ type Config struct {
 	DynCustomerName      string
 	DynUsername          string
 	DynPassword          string
+	DynMinTTLSeconds     int
 	InMemoryZones        []string
 	Policy               string
 	Registry             string
@@ -172,6 +173,8 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("dyn-customer-name", "When using the Dyn provider, specify the Customer Name").Default("").StringVar(&cfg.DynCustomerName)
 	app.Flag("dyn-username", "When using the Dyn provider, specify the Username").Default("").StringVar(&cfg.DynUsername)
 	app.Flag("dyn-password", "When using the Dyn provider, specify the pasword").Default("").StringVar(&cfg.DynPassword)
+	app.Flag("dyn-min-ttl", "Minimal TTL (in seconds) for records. This value will be used if the provided TTL for a service/ingress is lower than this.").IntVar(&cfg.DynMinTTLSeconds)
+
 	app.Flag("inmemory-zone", "Provide a list of pre-configured zones for the inmemory provider; specify multiple times for multiple zones (optional)").Default("").StringsVar(&cfg.InMemoryZones)
 
 	// Flags related to policies

--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -18,6 +18,7 @@ package externaldns
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -221,4 +222,16 @@ func restoreEnv(t *testing.T, originalEnv map[string]string) {
 	for k, v := range originalEnv {
 		require.NoError(t, os.Setenv(k, v))
 	}
+}
+
+func TestPasswordsNotLogged(t *testing.T) {
+	cfg := Config{
+		DynPassword:          "dyn-pass",
+		InfobloxWapiPassword: "infoblox-pass",
+	}
+
+	s := cfg.String()
+
+	assert.False(t, strings.Contains(s, "dyn-pass"))
+	assert.False(t, strings.Contains(s, "infoblox-pass"))
 }

--- a/pkg/apis/externaldns/validation/validation.go
+++ b/pkg/apis/externaldns/validation/validation.go
@@ -52,5 +52,18 @@ func ValidateConfig(cfg *externaldns.Config) error {
 			return errors.New("no Infoblox WAPI password specified")
 		}
 	}
+
+	if cfg.Provider == "dyn" {
+		if cfg.DynUsername == "" {
+			return errors.New("no Dyn username specified")
+		}
+		if cfg.DynCustomerName == "" {
+			return errors.New("no Dyn customer name specified")
+		}
+
+		if cfg.DynMinTTLSeconds < 0 {
+			return errors.New("TTL specified for Dyn is negative")
+		}
+	}
 	return nil
 }

--- a/pkg/apis/externaldns/validation/validation_test.go
+++ b/pkg/apis/externaldns/validation/validation_test.go
@@ -63,3 +63,56 @@ func newValidConfig(t *testing.T) *externaldns.Config {
 
 	return cfg
 }
+
+func addRequiredFieldsForDyn(cfg *externaldns.Config) {
+	cfg.LogFormat = "json"
+	cfg.Sources = []string{"ingress"}
+	cfg.Provider = "dyn"
+}
+
+func TestValidateBadDynConfig(t *testing.T) {
+	badConfigs := []*externaldns.Config{
+		{},
+		{
+			// only username
+			DynUsername: "test",
+		},
+		{
+			// only customer name
+			DynCustomerName: "test",
+		},
+		{
+			// negative timeout
+			DynUsername:      "test",
+			DynCustomerName:  "test",
+			DynMinTTLSeconds: -1,
+		},
+	}
+
+	for _, cfg := range badConfigs {
+		addRequiredFieldsForDyn(cfg)
+		err := ValidateConfig(cfg)
+		assert.NotNil(t, err, "Configuration %+v should NOT have passed validation", cfg)
+	}
+}
+
+func TestValidateGoodDynConfig(t *testing.T) {
+	goodConfigs := []*externaldns.Config{
+		{
+			DynUsername:      "test",
+			DynCustomerName:  "test",
+			DynMinTTLSeconds: 600,
+		},
+		{
+			DynUsername:      "test",
+			DynCustomerName:  "test",
+			DynMinTTLSeconds: 0,
+		},
+	}
+
+	for _, cfg := range goodConfigs {
+		addRequiredFieldsForDyn(cfg)
+		err := ValidateConfig(cfg)
+		assert.Nil(t, err, "Configuration should be valid, got this error instead", err)
+	}
+}

--- a/provider/dyn_test.go
+++ b/provider/dyn_test.go
@@ -255,10 +255,13 @@ func TestDyn_filterAndFixLinks(t *testing.T) {
 }
 
 func TestDyn_fixMissingTTL(t *testing.T) {
-	assert.Equal(t, fmt.Sprintf("%v", dynDefaultTTL), fixMissingTTL(endpoint.TTL(0)))
+	assert.Equal(t, fmt.Sprintf("%v", dynDefaultTTL), fixMissingTTL(endpoint.TTL(0), 0))
 
 	// nothing to fix
-	assert.Equal(t, "111", fixMissingTTL(endpoint.TTL(111)))
+	assert.Equal(t, "111", fixMissingTTL(endpoint.TTL(111), 25))
+
+	// apply min TTL
+	assert.Equal(t, "1992", fixMissingTTL(endpoint.TTL(111), 1992))
 }
 
 func TestDyn_cachePut(t *testing.T) {


### PR DESCRIPTION
If a bad password is given for provider "dyn" then the next
login attempt is at least 30minutes apart. This prevents an
account from being suspended.

Add validation of flags for dyn provider.

Also add --dyn-min-ttl option which sets the lower limit
of a record's TTL. Ignored if 0 (the default).

Removed a stale fmt.Println() statement.