### PR TITLE
Correctly detect zones if names overlap with subdomain

### DIFF
--- a/provider/zonefinder.go
+++ b/provider/zonefinder.go
@@ -26,7 +26,7 @@ func (z zoneIDName) Add(zoneID, zoneName string) {
 
 func (z zoneIDName) FindZone(hostname string) (suitableZoneID, suitableZoneName string) {
 	for zoneID, zoneName := range z {
-		if strings.HasSuffix(hostname, zoneName) {
+		if hostname == zoneName || strings.HasSuffix(hostname, "."+zoneName) {
 			if suitableZoneName == "" || len(zoneName) > len(suitableZoneName) {
 				suitableZoneID = zoneID
 				suitableZoneName = zoneName

--- a/provider/zonefinder_test.go
+++ b/provider/zonefinder_test.go
@@ -33,15 +33,28 @@ func TestZoneIDName(t *testing.T) {
 		"654321": "foo.qux.baz",
 	}, z)
 
+	// simple entry in a domain
 	zoneID, zoneName := z.FindZone("name.qux.baz")
 	assert.Equal(t, "qux.baz", zoneName)
 	assert.Equal(t, "123456", zoneID)
 
+	// simple entry in a domain's subdomain.
 	zoneID, zoneName = z.FindZone("name.foo.qux.baz")
 	assert.Equal(t, "foo.qux.baz", zoneName)
 	assert.Equal(t, "654321", zoneID)
 
+	// no possible zone for entry
 	zoneID, zoneName = z.FindZone("name.qux.foo")
 	assert.Equal(t, "", zoneName)
 	assert.Equal(t, "", zoneID)
+
+	// entry's suffix matches a subdomain but doesn't belong there
+	zoneID, zoneName = z.FindZone("name-foo.qux.baz")
+	assert.Equal(t, "qux.baz", zoneName)
+	assert.Equal(t, "123456", zoneID)
+
+	// entry is an exact match of the domain (e.g. azure provider)
+	zoneID, zoneName = z.FindZone("foo.qux.baz")
+	assert.Equal(t, "foo.qux.baz", zoneName)
+	assert.Equal(t, "654321", zoneID)
 }


### PR DESCRIPTION
Fix for https://github.com/kubernetes-incubator/external-dns/issues/446

As suggested by @dhawal55 including a preceding dot in the zone suffix match avoids a wrongly detected zone.

The suffix match used to be true when the strings where exact matches as well which the Azure provider depends on, hence the additional check in the if statement. Added some tests with comments as well.

/cc @dhawal55 @gustav-b @ideahitme 