### PR TITLE
digitalocean: Fix handling of domain record names

### DIFF
--- a/provider/digital_ocean.go
+++ b/provider/digital_ocean.go
@@ -106,7 +106,15 @@ func (p *DigitalOceanProvider) Records() ([]*endpoint.Endpoint, error) {
 
 		for _, r := range records {
 			if supportedRecordType(r.Type) {
-				endpoints = append(endpoints, endpoint.NewEndpoint(r.Name, r.Data, r.Type))
+				name := r.Name + "." + zone.Name
+
+				// root name is identified by @ and should be
+				// translated to zone name for the endpoint entry.
+				if r.Name == "@" {
+					name = zone.Name
+				}
+
+				endpoints = append(endpoints, endpoint.NewEndpoint(name, r.Data, r.Type))
 			}
 		}
 	}
@@ -197,13 +205,21 @@ func (p *DigitalOceanProvider) submitChanges(changes []*DigitalOceanChange) erro
 			if p.DryRun {
 				continue
 			}
-			changeName := strings.TrimSuffix(change.ResourceRecordSet.Name, "."+zoneName)
+
+			change.ResourceRecordSet.Name = strings.TrimSuffix(change.ResourceRecordSet.Name, "."+zoneName)
+
+			// record at the root should be defined as @ instead of
+			// the full domain name
+			if change.ResourceRecordSet.Name == zoneName {
+				change.ResourceRecordSet.Name = "@"
+			}
+
 			switch change.Action {
 			case DigitalOceanCreate:
 				_, _, err = p.Client.CreateRecord(context.TODO(), zoneName,
 					&godo.DomainRecordEditRequest{
 						Data: change.ResourceRecordSet.Data,
-						Name: changeName,
+						Name: change.ResourceRecordSet.Name,
 						Type: change.ResourceRecordSet.Type,
 					})
 				if err != nil {
@@ -220,7 +236,7 @@ func (p *DigitalOceanProvider) submitChanges(changes []*DigitalOceanChange) erro
 				_, _, err = p.Client.EditRecord(context.TODO(), zoneName, recordID,
 					&godo.DomainRecordEditRequest{
 						Data: change.ResourceRecordSet.Data,
-						Name: changeName,
+						Name: change.ResourceRecordSet.Name,
 						Type: change.ResourceRecordSet.Type,
 					})
 				if err != nil {


### PR DESCRIPTION
The DomainRecord response from the Digital Ocean API does not contain
the zone as part of the name and thus we must append the zone name when
converting it to an endpoint for the plan calculation.

Furthermore the root domain is identified by `@` and must be converted
to the zone name for the endpoint, and converted back to `@` when the
record is submitted to the DO API.

https://developers.digitalocean.com/documentation/v2/#retrieve-an-existing-domain-record

Fix #487
Fix #503 