### PR TITLE
Always build against latest stable version of golang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 language: go
 
 go:
-- 1.9
+- 1.x
 - tip
 
 matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # builder image
-FROM golang:1.9 as builder
+FROM golang as builder
 
 WORKDIR /go/src/github.com/kubernetes-incubator/external-dns
 COPY . .


### PR DESCRIPTION
I believe we should always build against the latest stable version of golang instead of lacking behind when we forget to update the version.