### PR TITLE
Fix typo for serviceAccountName in RBAC example

### DIFF
--- a/docs/tutorials/gke.md
+++ b/docs/tutorials/gke.md
@@ -76,7 +76,6 @@ spec:
       labels:
         app: external-dns
     spec:
-      serviceAccountName: external-dns
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8
@@ -135,6 +134,7 @@ spec:
       labels:
         app: external-dns
     spec:
+      serviceAccountName: external-dns
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8


### PR DESCRIPTION
serviceAccountName was transposed onto the non-RBAC example