### PR TITLE
Improve multi-target handling for aws provider

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -126,9 +126,16 @@ func NewEndpoint(dnsName, target, recordType string) *Endpoint {
 
 // NewEndpointWithTTL initialization method to be used to create an endpoint with a TTL struct
 func NewEndpointWithTTL(dnsName, target, recordType string, ttl TTL) *Endpoint {
+	return NewMultiTargetEndpointWithTTL(dnsName, Targets{target}, recordType, ttl)
+}
+
+func NewMultiTargetEndpointWithTTL(dnsName string, targets Targets, recordType string, ttl TTL) *Endpoint {
+	for i, v := range targets {
+		targets[i] = strings.TrimSuffix(v, ".")
+	}
 	return &Endpoint{
 		DNSName:    strings.TrimSuffix(dnsName, "."),
-		Targets:    Targets{strings.TrimSuffix(target, ".")},
+		Targets:    targets,
 		RecordType: recordType,
 		Labels:     NewLabels(),
 		RecordTTL:  ttl,

--- a/source/service.go
+++ b/source/service.go
@@ -263,6 +263,7 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string) []*
 		if sc.publishInternal {
 			targets = append(targets, extractServiceIps(svc)...)
 		}
+		targets = append(targets, extractExternalIps(svc)...)
 		if svc.Spec.ClusterIP == v1.ClusterIPNone {
 			endpoints = append(endpoints, sc.extractHeadlessEndpoints(svc, hostname)...)
 		}
@@ -306,6 +307,16 @@ func extractLoadBalancerTargets(svc *v1.Service) endpoint.Targets {
 		if lb.Hostname != "" {
 			targets = append(targets, lb.Hostname)
 		}
+	}
+
+	return targets
+}
+
+func extractExternalIps(svc *v1.Service) endpoint.Targets {
+	var targets = make(endpoint.Targets, len(svc.Spec.ExternalIPs))
+
+	for i, ip := range svc.Spec.ExternalIPs {
+		targets[i] = ip
 	}
 
 	return targets


### PR DESCRIPTION
This commit makes the aws provider support multi-target endpoints, as well as updates the service source to supply multi-target endpoints when an ExternalIPs field is listed for the service.