### PR TITLE
Add a flag that allows FQDN and Annotations to combine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+  - Add a flag that allows FQDN template and annotations to combine (#513) @helgi
   - Fix: Use PodIP instead of HostIP for headless Services (#498) @nrobert13
   - Support a comma separated list for the FQDN template (#512) @helgi
   - Google Provider: Add auto-detection of Google Project when running on GCP (#492) @drzero42

--- a/main.go
+++ b/main.go
@@ -67,11 +67,12 @@ func main() {
 
 	// Create a source.Config from the flags passed by the user.
 	sourceCfg := &source.Config{
-		Namespace:        cfg.Namespace,
-		AnnotationFilter: cfg.AnnotationFilter,
-		FQDNTemplate:     cfg.FQDNTemplate,
-		Compatibility:    cfg.Compatibility,
-		PublishInternal:  cfg.PublishInternal,
+		Namespace:                cfg.Namespace,
+		AnnotationFilter:         cfg.AnnotationFilter,
+		FQDNTemplate:             cfg.FQDNTemplate,
+		CombineFQDNAndAnnotation: cfg.CombineFQDNAndAnnotation,
+		Compatibility:            cfg.Compatibility,
+		PublishInternal:          cfg.PublishInternal,
 	}
 
 	// Lookup all the selected sources by names and pass them the desired configuration.

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -36,78 +36,80 @@ var (
 
 // Config is a project-wide configuration
 type Config struct {
-	Master               string
-	KubeConfig           string
-	Sources              []string
-	Namespace            string
-	AnnotationFilter     string
-	FQDNTemplate         string
-	Compatibility        string
-	PublishInternal      bool
-	Provider             string
-	GoogleProject        string
-	DomainFilter         []string
-	ZoneIDFilter         []string
-	AWSZoneType          string
-	AzureConfigFile      string
-	AzureResourceGroup   string
-	CloudflareProxied    bool
-	InfobloxGridHost     string
-	InfobloxWapiPort     int
-	InfobloxWapiUsername string
-	InfobloxWapiPassword string
-	InfobloxWapiVersion  string
-	InfobloxSSLVerify    bool
-	DynCustomerName      string
-	DynUsername          string
-	DynPassword          string
-	DynMinTTLSeconds     int
-	InMemoryZones        []string
-	Policy               string
-	Registry             string
-	TXTOwnerID           string
-	TXTPrefix            string
-	Interval             time.Duration
-	Once                 bool
-	DryRun               bool
-	LogFormat            string
-	MetricsAddress       string
-	LogLevel             string
+	Master                   string
+	KubeConfig               string
+	Sources                  []string
+	Namespace                string
+	AnnotationFilter         string
+	FQDNTemplate             string
+	CombineFQDNAndAnnotation bool
+	Compatibility            string
+	PublishInternal          bool
+	Provider                 string
+	GoogleProject            string
+	DomainFilter             []string
+	ZoneIDFilter             []string
+	AWSZoneType              string
+	AzureConfigFile          string
+	AzureResourceGroup       string
+	CloudflareProxied        bool
+	InfobloxGridHost         string
+	InfobloxWapiPort         int
+	InfobloxWapiUsername     string
+	InfobloxWapiPassword     string
+	InfobloxWapiVersion      string
+	InfobloxSSLVerify        bool
+	DynCustomerName          string
+	DynUsername              string
+	DynPassword              string
+	DynMinTTLSeconds         int
+	InMemoryZones            []string
+	Policy                   string
+	Registry                 string
+	TXTOwnerID               string
+	TXTPrefix                string
+	Interval                 time.Duration
+	Once                     bool
+	DryRun                   bool
+	LogFormat                string
+	MetricsAddress           string
+	LogLevel                 string
 }
 
 var defaultConfig = &Config{
-	Master:               "",
-	KubeConfig:           "",
-	Sources:              nil,
-	Namespace:            "",
-	AnnotationFilter:     "",
-	FQDNTemplate:         "",
-	Compatibility:        "",
-	PublishInternal:      false,
-	Provider:             "",
-	GoogleProject:        "",
-	DomainFilter:         []string{},
-	AWSZoneType:          "",
-	AzureConfigFile:      "/etc/kubernetes/azure.json",
-	AzureResourceGroup:   "",
-	CloudflareProxied:    false,
-	InfobloxGridHost:     "",
-	InfobloxWapiPort:     443,
-	InfobloxWapiUsername: "admin",
-	InfobloxWapiPassword: "",
-	InfobloxWapiVersion:  "2.3.1",
-	InfobloxSSLVerify:    true,
-	InMemoryZones:        []string{},
-	Policy:               "sync",
-	Registry:             "txt",
-	TXTOwnerID:           "default",
-	TXTPrefix:            "",
-	Interval:             time.Minute,
-	Once:                 false,
-	DryRun:               false,
-	LogFormat:            "text",
-	MetricsAddress:       ":7979",
-	LogLevel:             logrus.InfoLevel.String(),
+	Master:                   "",
+	KubeConfig:               "",
+	Sources:                  nil,
+	Namespace:                "",
+	AnnotationFilter:         "",
+	FQDNTemplate:             "",
+	CombineFQDNAndAnnotation: false,
+	Compatibility:            "",
+	PublishInternal:          false,
+	Provider:                 "",
+	GoogleProject:            "",
+	DomainFilter:             []string{},
+	AWSZoneType:              "",
+	AzureConfigFile:          "/etc/kubernetes/azure.json",
+	AzureResourceGroup:       "",
+	CloudflareProxied:        false,
+	InfobloxGridHost:         "",
+	InfobloxWapiPort:         443,
+	InfobloxWapiUsername:     "admin",
+	InfobloxWapiPassword:     "",
+	InfobloxWapiVersion:      "2.3.1",
+	InfobloxSSLVerify:        true,
+	InMemoryZones:            []string{},
+	Policy:                   "sync",
+	Registry:                 "txt",
+	TXTOwnerID:               "default",
+	TXTPrefix:                "",
+	Interval:                 time.Minute,
+	Once:                     false,
+	DryRun:                   false,
+	LogFormat:                "text",
+	MetricsAddress:           ":7979",
+	LogLevel:                 logrus.InfoLevel.String(),
 }
 
 // NewConfig returns new Config object
@@ -152,6 +154,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("namespace", "Limit sources of endpoints to a specific namespace (default: all namespaces)").Default(defaultConfig.Namespace).StringVar(&cfg.Namespace)
 	app.Flag("annotation-filter", "Filter sources managed by external-dns via annotation using label selector semantics (default: all sources)").Default(defaultConfig.AnnotationFilter).StringVar(&cfg.AnnotationFilter)
 	app.Flag("fqdn-template", "A templated string that's used to generate DNS names from sources that don't define a hostname themselves, or to add a hostname suffix when paired with the fake source (optional). Accepts comma separated list for multiple global FQDN.").Default(defaultConfig.FQDNTemplate).StringVar(&cfg.FQDNTemplate)
+	app.Flag("combine-fqdn-annotation", "Combine FQDN template and Annotations instead of overwriting").BoolVar(&cfg.CombineFQDNAndAnnotation)
 	app.Flag("compatibility", "Process annotation semantics from legacy implementations (optional, options: mate, molecule)").Default(defaultConfig.Compatibility).EnumVar(&cfg.Compatibility, "", "mate", "molecule")
 	app.Flag("publish-internal-services", "Allow external-dns to publish DNS records for ClusterIP services (optional)").BoolVar(&cfg.PublishInternal)
 

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -49,6 +49,7 @@ func (suite *IngressSuite) SetupTest() {
 		"",
 		"",
 		"{{.Name}}",
+		false,
 	)
 	suite.NoError(err, "should initialize ingress source")
 
@@ -78,10 +79,11 @@ func TestIngress(t *testing.T) {
 
 func TestNewIngressSource(t *testing.T) {
 	for _, ti := range []struct {
-		title            string
-		annotationFilter string
-		fqdnTemplate     string
-		expectError      bool
+		title                    string
+		annotationFilter         string
+		fqdnTemplate             string
+		combineFQDNAndAnnotation bool
+		expectError              bool
 	}{
 		{
 			title:        "invalid template",
@@ -98,6 +100,17 @@ func TestNewIngressSource(t *testing.T) {
 			fqdnTemplate: "{{.Name}}-{{.Namespace}}.ext-dns.test.com",
 		},
 		{
+			title:        "valid template",
+			expectError:  false,
+			fqdnTemplate: "{{.Name}}-{{.Namespace}}.ext-dns.test.com, {{.Name}}-{{.Namespace}}.ext-dna.test.com",
+		},
+		{
+			title:                    "valid template",
+			expectError:              false,
+			fqdnTemplate:             "{{.Name}}-{{.Namespace}}.ext-dns.test.com, {{.Name}}-{{.Namespace}}.ext-dna.test.com",
+			combineFQDNAndAnnotation: true,
+		},
+		{
 			title:            "non-empty annotation filter label",
 			expectError:      false,
 			annotationFilter: "kubernetes.io/ingress.class=nginx",
@@ -109,6 +122,7 @@ func TestNewIngressSource(t *testing.T) {
 				"",
 				ti.annotationFilter,
 				ti.fqdnTemplate,
+				ti.combineFQDNAndAnnotation,
 			)
 			if ti.expectError {
 				assert.Error(t, err)
@@ -204,13 +218,14 @@ func testEndpointsFromIngress(t *testing.T) {
 func testIngressEndpoints(t *testing.T) {
 	namespace := "testing"
 	for _, ti := range []struct {
-		title            string
-		targetNamespace  string
-		annotationFilter string
-		ingressItems     []fakeIngress
-		expected         []*endpoint.Endpoint
-		expectError      bool
-		fqdnTemplate     string
+		title                    string
+		targetNamespace          string
+		annotationFilter         string
+		ingressItems             []fakeIngress
+		expected                 []*endpoint.Endpoint
+		expectError              bool
+		fqdnTemplate             string
+		combineFQDNAndAnnotation bool
 	}{
 		{
 			title:           "no ingress",
@@ -500,6 +515,57 @@ func testIngressEndpoints(t *testing.T) {
 			fqdnTemplate: "{{.Name}}.ext-dns.test.com, {{.Name}}.ext-dna.test.com",
 		},
 		{
+			title:           "multiple FQDN template hostnames",
+			targetNamespace: "",
+			ingressItems: []fakeIngress{
+				{
+					name:        "fake1",
+					namespace:   namespace,
+					annotations: map[string]string{},
+					dnsnames:    []string{},
+					ips:         []string{"8.8.8.8"},
+				},
+				{
+					name:      "fake2",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "ingress-target.com",
+					},
+					dnsnames: []string{"example.org"},
+					ips:      []string{},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "fake1.ext-dns.test.com",
+					Targets:    endpoint.Targets{"8.8.8.8"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "fake1.ext-dna.test.com",
+					Targets:    endpoint.Targets{"8.8.8.8"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"ingress-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+				{
+					DNSName:    "fake2.ext-dns.test.com",
+					Targets:    endpoint.Targets{"ingress-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+				{
+					DNSName:    "fake2.ext-dna.test.com",
+					Targets:    endpoint.Targets{"ingress-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+			},
+			fqdnTemplate:             "{{.Name}}.ext-dns.test.com, {{.Name}}.ext-dna.test.com",
+			combineFQDNAndAnnotation: true,
+		},
+		{
 			title:           "ingress rules with annotation",
 			targetNamespace: "",
 			ingressItems: []fakeIngress{
@@ -653,6 +719,7 @@ func testIngressEndpoints(t *testing.T) {
 				ti.targetNamespace,
 				ti.annotationFilter,
 				ti.fqdnTemplate,
+				ti.combineFQDNAndAnnotation,
 			)
 			for _, ingress := range ingresses {
 				_, err := fakeClient.Extensions().Ingresses(ingress.Namespace).Create(ingress)

--- a/source/store.go
+++ b/source/store.go
@@ -35,11 +35,12 @@ var ErrSourceNotFound = errors.New("source not found")
 
 // Config holds shared configuration options for all Sources.
 type Config struct {
-	Namespace        string
-	AnnotationFilter string
-	FQDNTemplate     string
-	Compatibility    string
-	PublishInternal  bool
+	Namespace                string
+	AnnotationFilter         string
+	FQDNTemplate             string
+	CombineFQDNAndAnnotation bool
+	Compatibility            string
+	PublishInternal          bool
 }
 
 // ClientGenerator provides clients
@@ -87,13 +88,13 @@ func BuildWithConfig(source string, p ClientGenerator, cfg *Config) (Source, err
 		if err != nil {
 			return nil, err
 		}
-		return NewServiceSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.Compatibility, cfg.PublishInternal)
+		return NewServiceSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal)
 	case "ingress":
 		client, err := p.KubeClient()
 		if err != nil {
 			return nil, err
 		}
-		return NewIngressSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate)
+		return NewIngressSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation)
 	case "fake":
 		return NewFakeSource(cfg.FQDNTemplate)
 	}


### PR DESCRIPTION
The old behaviour is kept by default, a new flag is introduced to combine instead of overwriting

Fixes #218

Depends on #512 