### PR TITLE
Adds `serviceAccountName` field to pod spec

### DIFF
--- a/docs/tutorials/nginx-ingress.md
+++ b/docs/tutorials/nginx-ingress.md
@@ -255,6 +255,7 @@ spec:
       labels:
         app: external-dns
     spec:
+      serviceAccountName: external-dns
       containers:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:v0.4.8


### PR DESCRIPTION
The nginx-ingress guide lists RBAC roles & bindings, but doesn't tie the Deployment to the specific ServiceAccount.

Links the Deployment to the ServiceAccount.