### PR TITLE
AWS: add support for AWS Network Load Balancers

### DIFF
--- a/provider/aws.go
+++ b/provider/aws.go
@@ -30,30 +30,47 @@ import (
 )
 
 const (
-	elbHostnameSuffix    = ".elb.amazonaws.com"
 	evaluateTargetHealth = true
 	recordTTL            = 300
 	maxChangeCount       = 4000
 )
 
 var (
-	// see: https://docs.aws.amazon.com/general/latest/gr/rande.html
+	// see: https://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region
 	canonicalHostedZones = map[string]string{
-		"us-east-1" + elbHostnameSuffix:      "Z35SXDOTRQ7X7K",
-		"us-east-2" + elbHostnameSuffix:      "Z3AADJGX6KTTL2",
-		"us-west-1" + elbHostnameSuffix:      "Z368ELLRRE2KJ0",
-		"us-west-2" + elbHostnameSuffix:      "Z1H1FL5HABSF5",
-		"ca-central-1" + elbHostnameSuffix:   "ZQSVJUPU6J1EY",
-		"ap-south-1" + elbHostnameSuffix:     "ZP97RAFLXTNZK",
-		"ap-northeast-2" + elbHostnameSuffix: "ZWKZPGTI48KDX",
-		"ap-southeast-1" + elbHostnameSuffix: "Z1LMS91P8CMLE5",
-		"ap-southeast-2" + elbHostnameSuffix: "Z1GM3OXH4ZPM65",
-		"ap-northeast-1" + elbHostnameSuffix: "Z14GRHDCWA56QT",
-		"eu-central-1" + elbHostnameSuffix:   "Z215JYRZR1TBD5",
-		"eu-west-1" + elbHostnameSuffix:      "Z32O12XQLNTSW2",
-		"eu-west-2" + elbHostnameSuffix:      "ZHURV8PSTC4K8",
-		"eu-west-3" + elbHostnameSuffix:      "Z3Q77PNBQS71R4",
-		"sa-east-1" + elbHostnameSuffix:      "Z2P70J7HTTTPLU",
+		// Application Load Balancers and Classic Load Balancers
+		"us-east-2.elb.amazonaws.com":      "Z3AADJGX6KTTL2",
+		"us-east-1.elb.amazonaws.com":      "Z35SXDOTRQ7X7K",
+		"us-west-1.elb.amazonaws.com":      "Z368ELLRRE2KJ0",
+		"us-west-2.elb.amazonaws.com":      "Z1H1FL5HABSF5",
+		"ca-central-1.elb.amazonaws.com":   "ZQSVJUPU6J1EY",
+		"ap-south-1.elb.amazonaws.com":     "ZP97RAFLXTNZK",
+		"ap-northeast-2.elb.amazonaws.com": "ZWKZPGTI48KDX",
+		"ap-northeast-3.elb.amazonaws.com": "Z5LXEXXYW11ES",
+		"ap-southeast-1.elb.amazonaws.com": "Z1LMS91P8CMLE5",
+		"ap-southeast-2.elb.amazonaws.com": "Z1GM3OXH4ZPM65",
+		"ap-northeast-1.elb.amazonaws.com": "Z14GRHDCWA56QT",
+		"eu-central-1.elb.amazonaws.com":   "Z215JYRZR1TBD5",
+		"eu-west-1.elb.amazonaws.com":      "Z32O12XQLNTSW2",
+		"eu-west-2.elb.amazonaws.com":      "ZHURV8PSTC4K8",
+		"eu-west-3.elb.amazonaws.com":      "Z3Q77PNBQS71R4",
+		"sa-east-1.elb.amazonaws.com":      "Z2P70J7HTTTPLU",
+		// Network Load Balancers
+		"elb.us-east-2.amazonaws.com":      "ZLMOA37VPKANP",
+		"elb.us-east-1.amazonaws.com":      "Z26RNL4JYFTOTI",
+		"elb.us-west-1.amazonaws.com":      "Z24FKFUX50B4VW",
+		"elb.us-west-2.amazonaws.com":      "Z18D5FSROUN65G",
+		"elb.ca-central-1.amazonaws.com":   "Z2EPGBW3API2WT",
+		"elb.ap-south-1.amazonaws.com":     "ZVDDRBQ08TROA",
+		"elb.ap-northeast-2.amazonaws.com": "ZIBE1TIR4HY56",
+		"elb.ap-southeast-1.amazonaws.com": "ZKVM4W9LS7TM",
+		"elb.ap-southeast-2.amazonaws.com": "ZCT6FZBF4DROD",
+		"elb.ap-northeast-1.amazonaws.com": "Z31USIVHYNEOWT",
+		"elb.eu-central-1.amazonaws.com":   "Z3F0SRJ5LGBH90",
+		"elb.eu-west-1.amazonaws.com":      "Z2IFOLAFXWLO4F",
+		"elb.eu-west-2.amazonaws.com":      "ZD4D7Y8KGAS4G",
+		"elb.eu-west-3.amazonaws.com":      "Z1CMS0P5QUZ6D5",
+		"elb.sa-east-1.amazonaws.com":      "ZTK26PT1VY4CU",
 	}
 )
 

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -697,13 +697,15 @@ func TestAWSCanonicalHostedZone(t *testing.T) {
 		hostname string
 		expected string
 	}{
-		{"foo.us-east-1.elb.amazonaws.com", "Z35SXDOTRQ7X7K"},
+		// Application Load Balancers and Classic Load Balancers
 		{"foo.us-east-2.elb.amazonaws.com", "Z3AADJGX6KTTL2"},
+		{"foo.us-east-1.elb.amazonaws.com", "Z35SXDOTRQ7X7K"},
 		{"foo.us-west-1.elb.amazonaws.com", "Z368ELLRRE2KJ0"},
 		{"foo.us-west-2.elb.amazonaws.com", "Z1H1FL5HABSF5"},
 		{"foo.ca-central-1.elb.amazonaws.com", "ZQSVJUPU6J1EY"},
 		{"foo.ap-south-1.elb.amazonaws.com", "ZP97RAFLXTNZK"},
 		{"foo.ap-northeast-2.elb.amazonaws.com", "ZWKZPGTI48KDX"},
+		{"foo.ap-northeast-3.elb.amazonaws.com", "Z5LXEXXYW11ES"},
 		{"foo.ap-southeast-1.elb.amazonaws.com", "Z1LMS91P8CMLE5"},
 		{"foo.ap-southeast-2.elb.amazonaws.com", "Z1GM3OXH4ZPM65"},
 		{"foo.ap-northeast-1.elb.amazonaws.com", "Z14GRHDCWA56QT"},
@@ -712,6 +714,23 @@ func TestAWSCanonicalHostedZone(t *testing.T) {
 		{"foo.eu-west-2.elb.amazonaws.com", "ZHURV8PSTC4K8"},
 		{"foo.eu-west-3.elb.amazonaws.com", "Z3Q77PNBQS71R4"},
 		{"foo.sa-east-1.elb.amazonaws.com", "Z2P70J7HTTTPLU"},
+		// Network Load Balancers
+		{"foo.elb.us-east-2.amazonaws.com", "ZLMOA37VPKANP"},
+		{"foo.elb.us-east-1.amazonaws.com", "Z26RNL4JYFTOTI"},
+		{"foo.elb.us-west-1.amazonaws.com", "Z24FKFUX50B4VW"},
+		{"foo.elb.us-west-2.amazonaws.com", "Z18D5FSROUN65G"},
+		{"foo.elb.ca-central-1.amazonaws.com", "Z2EPGBW3API2WT"},
+		{"foo.elb.ap-south-1.amazonaws.com", "ZVDDRBQ08TROA"},
+		{"foo.elb.ap-northeast-2.amazonaws.com", "ZIBE1TIR4HY56"},
+		{"foo.elb.ap-southeast-1.amazonaws.com", "ZKVM4W9LS7TM"},
+		{"foo.elb.ap-southeast-2.amazonaws.com", "ZCT6FZBF4DROD"},
+		{"foo.elb.ap-northeast-1.amazonaws.com", "Z31USIVHYNEOWT"},
+		{"foo.elb.eu-central-1.amazonaws.com", "Z3F0SRJ5LGBH90"},
+		{"foo.elb.eu-west-1.amazonaws.com", "Z2IFOLAFXWLO4F"},
+		{"foo.elb.eu-west-2.amazonaws.com", "ZD4D7Y8KGAS4G"},
+		{"foo.elb.eu-west-3.amazonaws.com", "Z1CMS0P5QUZ6D5"},
+		{"foo.elb.sa-east-1.amazonaws.com", "ZTK26PT1VY4CU"},
+		// No Load Balancer
 		{"foo.example.org", ""},
 	} {
 		zone := canonicalHostedZone(tc.hostname)


### PR DESCRIPTION
The Hosted Zone IDs for NLBs are different and their DNS names use a different format compared to ALBs and ELBs (look closely).

This adds the correct zone IDs for NLBs as well as adds some new zones that were added in the meantime for ALBs and ELBs.

see https://docs.aws.amazon.com/general/latest/gr/rande.html#elb_region