### PR TITLE
Fixed Bug in PowerDNS provider and added testcases

### DIFF
--- a/provider/pdns.go
+++ b/provider/pdns.go
@@ -235,7 +235,7 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 	for _, zone := range zones {
 		zone.Rrsets = []pgo.RrSet{}
 		for i := 0; i < len(endpoints); {
-			ep := endpoints[0]
+			ep := endpoints[i]
 			dnsname := ensureTrailingDot(ep.DNSName)
 			if strings.HasSuffix(dnsname, zone.Name) {
 				// The assumption here is that there will only ever be one target


### PR DESCRIPTION
* Fixed PowerDNS provider bug affecting endpoint conversion to
  zone in a particular case
* Added a regressive test case, covered an additional case

PowerDNS provider bug: In the function `ConvertEndpointsToZones`, the endpoints are sorted lexicographically increasing (and by record type in case of match). The zones are sorted by decreasing order of length. There's a loop through of zones under which the code loops through endpoints. In the case the first endpoint does not match with the first zone, the complete zone won't get populated with any endpoints. This small change fixes that. 