### PR TITLE
add support for hostname annotation in ingress resource

### DIFF
--- a/source/ingress.go
+++ b/source/ingress.go
@@ -233,12 +233,9 @@ func endpointsFromIngress(ing *v1beta1.Ingress) []*endpoint.Endpoint {
 		endpoints = append(endpoints, endpointsForHostname(rule.Host, targets, ttl)...)
 	}
 
-	if ing.Annotations[hostnameAnnotationKey] != "" {
-		hostnames := strings.Split(ing.Annotations[hostnameAnnotationKey], ",")
-		for _, hostname := range hostnames {
-			hostname = strings.TrimSpace(hostname)
-			endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl)...)
-		}
+	hostnameList := getHostnamesFromAnnotations(ing.Annotations)
+	for _, hostname := range hostnameList {
+		endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl)...)
 	}
 
 	return endpoints

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -232,6 +232,15 @@ func endpointsFromIngress(ing *v1beta1.Ingress) []*endpoint.Endpoint {
 		}
 		endpoints = append(endpoints, endpointsForHostname(rule.Host, targets, ttl)...)
 	}
+
+	if ing.Annotations[hostnameAnnotationKey] != "" {
+		hostnames := strings.Split(ing.Annotations[hostnameAnnotationKey], ",")
+		for _, hostname := range hostnames {
+			hostname = strings.TrimSpace(hostname)
+			endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl)...)
+		}
+	}
+
 	return endpoints
 }
 

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -616,6 +616,93 @@ func testIngressEndpoints(t *testing.T) {
 			},
 		},
 		{
+			title:           "ingress rules with hostname annotation",
+			targetNamespace: "",
+			ingressItems: []fakeIngress{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						hostnameAnnotationKey: "dns-through-hostname.com",
+					},
+					dnsnames: []string{"example.org"},
+					ips:      []string{"1.2.3.4"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "dns-through-hostname.com",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+			},
+		},
+		{
+			title:           "ingress rules with hostname annotation having multiple hostnames",
+			targetNamespace: "",
+			ingressItems: []fakeIngress{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						hostnameAnnotationKey: "dns-through-hostname.com, another-dns-through-hostname.com",
+					},
+					dnsnames: []string{"example.org"},
+					ips:      []string{"1.2.3.4"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "dns-through-hostname.com",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "another-dns-through-hostname.com",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+			},
+		},
+		{
+			title:           "ingress rules with hostname and target annotation",
+			targetNamespace: "",
+			ingressItems: []fakeIngress{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						hostnameAnnotationKey: "dns-through-hostname.com",
+						targetAnnotationKey:   "ingress-target.com",
+					},
+					dnsnames: []string{"example.org"},
+					ips:      []string{},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"ingress-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+				{
+					DNSName:    "dns-through-hostname.com",
+					Targets:    endpoint.Targets{"ingress-target.com"},
+					RecordType: endpoint.RecordTypeCNAME,
+				},
+			},
+		},
+		{
 			title:           "ingress rules with annotation and custom TTL",
 			targetNamespace: "",
 			ingressItems: []fakeIngress{

--- a/source/service.go
+++ b/source/service.go
@@ -191,13 +191,7 @@ func (sc *serviceSource) endpointsFromTemplate(svc *v1.Service) ([]*endpoint.End
 func (sc *serviceSource) endpoints(svc *v1.Service) []*endpoint.Endpoint {
 	var endpoints []*endpoint.Endpoint
 
-	// Get the desired hostname of the service from the annotation.
-	hostnameAnnotation, exists := svc.Annotations[hostnameAnnotationKey]
-	if !exists {
-		return nil
-	}
-
-	hostnameList := strings.Split(strings.Replace(hostnameAnnotation, " ", "", -1), ",")
+	hostnameList := getHostnamesFromAnnotations(svc.Annotations)
 	for _, hostname := range hostnameList {
 		endpoints = append(endpoints, sc.generateEndpoints(svc, hostname)...)
 	}

--- a/source/source.go
+++ b/source/source.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 )
@@ -62,6 +63,15 @@ func getTTLFromAnnotations(annotations map[string]string) (endpoint.TTL, error) 
 		return ttlNotConfigured, fmt.Errorf("TTL value must be between [%d, %d]", ttlMinimum, ttlMaximum)
 	}
 	return endpoint.TTL(ttlValue), nil
+}
+
+func getHostnamesFromAnnotations(annotations map[string]string) []string {
+	hostnameAnnotation, exists := annotations[hostnameAnnotationKey]
+	if !exists {
+		return nil
+	}
+
+	return strings.Split(strings.Replace(hostnameAnnotation, " ", "", -1), ",")
 }
 
 // suitableType returns the DNS resource record type suitable for the target.


### PR DESCRIPTION
This PR fixes #402 

We ran into similar issue where we had ingress rule hostname set to 'website.company.com' whereas the externaldns name we wanted was 'website.extdomain.company.com'

and website.company.com is a static cname to website.extdomain.company.com

