### PR TITLE
use ticker

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -66,14 +66,14 @@ func (c *Controller) RunOnce() error {
 
 // Run runs RunOnce in a loop with a delay until stopChan receives a value.
 func (c *Controller) Run(stopChan <-chan struct{}) {
+	ticker := time.NewTicker(c.Interval)
 	for {
 		err := c.RunOnce()
 		if err != nil {
 			log.Error(err)
 		}
-
 		select {
-		case <-time.After(c.Interval):
+		case <-ticker.C:
 		case <-stopChan:
 			log.Info("Terminating main controller loop")
 			return

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -67,6 +67,7 @@ func (c *Controller) RunOnce() error {
 // Run runs RunOnce in a loop with a delay until stopChan receives a value.
 func (c *Controller) Run(stopChan <-chan struct{}) {
 	ticker := time.NewTicker(c.Interval)
+	defer ticker.Stop()
 	for {
 		err := c.RunOnce()
 		if err != nil {


### PR DESCRIPTION
Rather than create a new `timer.After()` instance for each loop, this uses a single ticker to accomplish the same goal.