### PR TITLE
Add support for NodePort services

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -29,6 +29,8 @@ const (
 	RecordTypeCNAME = "CNAME"
 	// RecordTypeTXT is a RecordType enum value
 	RecordTypeTXT = "TXT"
+	// RecordTypeSRV is a RecordType enum value
+	RecordTypeSRV = "SRV"
 )
 
 // TTL is a structure defining the TTL of a DNS record

--- a/provider/recordfilter.go
+++ b/provider/recordfilter.go
@@ -17,10 +17,10 @@ limitations under the License.
 package provider
 
 // supportedRecordType returns true only for supported record types.
-// Currently only A, CNAME and TXT record types are supported.
+// Currently A, CNAME, SRV, and TXT record types are supported.
 func supportedRecordType(recordType string) bool {
 	switch recordType {
-	case "A", "CNAME", "TXT":
+	case "A", "CNAME", "SRV", "TXT":
 		return true
 	default:
 		return false

--- a/source/service.go
+++ b/source/service.go
@@ -90,9 +90,19 @@ func (sc *serviceSource) Endpoints() ([]*endpoint.Endpoint, error) {
 		return nil, err
 	}
 
+	// get the ip addresses of all the nodes and cache them for this run
 	nodes, err := sc.client.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
+	}
+	var nodeTargets endpoint.Targets
+
+	for _, node := range nodes.Items {
+		for _, address := range node.Status.Addresses {
+			if address.Type == v1.NodeExternalIP {
+				nodeTargets = append(nodeTargets, address.Address)
+			}
+		}
 	}
 
 	endpoints := []*endpoint.Endpoint{}
@@ -106,7 +116,7 @@ func (sc *serviceSource) Endpoints() ([]*endpoint.Endpoint, error) {
 			continue
 		}
 
-		svcEndpoints := sc.endpoints(&svc, nodes)
+		svcEndpoints := sc.endpoints(&svc, nodeTargets)
 
 		// process legacy annotations if no endpoints were returned and compatibility mode is enabled.
 		if len(svcEndpoints) == 0 && sc.compatibility != "" {
@@ -115,7 +125,7 @@ func (sc *serviceSource) Endpoints() ([]*endpoint.Endpoint, error) {
 
 		// apply template if none of the above is found
 		if (sc.combineFQDNAnnotation || len(svcEndpoints) == 0) && sc.fqdnTemplate != nil {
-			sEndpoints, err := sc.endpointsFromTemplate(&svc, nodes)
+			sEndpoints, err := sc.endpointsFromTemplate(&svc, nodeTargets)
 			if err != nil {
 				return nil, err
 			}
@@ -175,7 +185,7 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 	return endpoints
 }
 
-func (sc *serviceSource) endpointsFromTemplate(svc *v1.Service, nodes *v1.NodeList) ([]*endpoint.Endpoint, error) {
+func (sc *serviceSource) endpointsFromTemplate(svc *v1.Service, nodeTargets endpoint.Targets) ([]*endpoint.Endpoint, error) {
 	var endpoints []*endpoint.Endpoint
 
 	// Process the whole template string
@@ -187,19 +197,19 @@ func (sc *serviceSource) endpointsFromTemplate(svc *v1.Service, nodes *v1.NodeLi
 
 	hostnameList := strings.Split(strings.Replace(buf.String(), " ", "", -1), ",")
 	for _, hostname := range hostnameList {
-		endpoints = append(endpoints, sc.generateEndpoints(svc, hostname, nodes)...)
+		endpoints = append(endpoints, sc.generateEndpoints(svc, hostname, nodeTargets)...)
 	}
 
 	return endpoints, nil
 }
 
 // endpointsFromService extracts the endpoints from a service object
-func (sc *serviceSource) endpoints(svc *v1.Service, nodes *v1.NodeList) []*endpoint.Endpoint {
+func (sc *serviceSource) endpoints(svc *v1.Service, nodeTargets endpoint.Targets) []*endpoint.Endpoint {
 	var endpoints []*endpoint.Endpoint
 
 	hostnameList := getHostnamesFromAnnotations(svc.Annotations)
 	for _, hostname := range hostnameList {
-		endpoints = append(endpoints, sc.generateEndpoints(svc, hostname, nodes)...)
+		endpoints = append(endpoints, sc.generateEndpoints(svc, hostname, nodeTargets)...)
 	}
 
 	return endpoints
@@ -242,7 +252,7 @@ func (sc *serviceSource) setResourceLabel(service v1.Service, endpoints []*endpo
 	}
 }
 
-func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, nodes *v1.NodeList) []*endpoint.Endpoint {
+func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, nodeTargets endpoint.Targets) []*endpoint.Endpoint {
 	hostname = strings.TrimSuffix(hostname, ".")
 	ttl, err := getTTLFromAnnotations(svc.Annotations)
 	if err != nil {
@@ -279,7 +289,9 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string, nod
 			endpoints = append(endpoints, sc.extractHeadlessEndpoints(svc, hostname, ttl)...)
 		}
 	case v1.ServiceTypeNodePort:
-		targets = sc.extractNodeTargets(nodes)
+		// add the nodeTargets and extract an SRV endpoint
+		targets = append(targets, nodeTargets...)
+		endpoints = append(endpoints, sc.extractNodePortEndpoints(svc, nodeTargets, hostname, ttl)...)
 	}
 
 	for _, t := range targets {
@@ -324,16 +336,38 @@ func extractLoadBalancerTargets(svc *v1.Service) endpoint.Targets {
 	return targets
 }
 
-func (sc *serviceSource) extractNodeTargets(nodes *v1.NodeList) endpoint.Targets {
-	var targets endpoint.Targets
+func (sc *serviceSource) extractNodePortEndpoints(svc *v1.Service, nodeTargets endpoint.Targets, hostname string, ttl endpoint.TTL) []*endpoint.Endpoint {
+	var endpoints []*endpoint.Endpoint
 
-	for _, node := range nodes.Items {
-		for _, address := range node.Status.Addresses {
-			if address.Type == v1.NodeExternalIP {
-				targets = append(targets, address.Address)
+	for _, port := range svc.Spec.Ports {
+		if port.NodePort > 0 {
+			// build a target with a priority of 0, pointing the given port on the given host
+			target := fmt.Sprintf("0 %d %s", port.NodePort, hostname)
+
+			// figure out the portname
+			portName := port.Name
+			if portName == "" {
+				portName = fmt.Sprintf("%d", port.NodePort)
 			}
+
+			// figure out the protocol
+			protocol := strings.ToLower(string(port.Protocol))
+			if protocol == "" {
+				protocol = "tcp"
+			}
+
+			recordName := fmt.Sprintf("_%s._%s.%s", portName, protocol, hostname)
+
+			var ep *endpoint.Endpoint
+			if ttl.IsConfigured() {
+				ep = endpoint.NewEndpointWithTTL(recordName, endpoint.RecordTypeSRV, ttl, target)
+			} else {
+				ep = endpoint.NewEndpoint(recordName, endpoint.RecordTypeSRV, target)
+			}
+
+			endpoints = append(endpoints, ep)
 		}
 	}
 
-	return targets
+	return endpoints
 }

--- a/source/service.go
+++ b/source/service.go
@@ -361,8 +361,8 @@ func (sc *serviceSource) extractNodePortEndpoints(svc *v1.Service, nodeTargets e
 
 	for _, port := range svc.Spec.Ports {
 		if port.NodePort > 0 {
-			// build a target with a priority of 0, pointing the given port on the given host
-			target := fmt.Sprintf("0 %d %s", port.NodePort, hostname)
+			// build a target with a priority of 0, weight of 0, and pointing the given port on the given host
+			target := fmt.Sprintf("0 50 %d %s", port.NodePort, hostname)
 
 			// figure out the portname
 			portName := port.Name

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1055,7 +1055,7 @@ func TestNodePortServices(t *testing.T) {
 			},
 			nil,
 			[]*endpoint.Endpoint{
-				{DNSName: "_30192._tcp.foo.example.org", Targets: endpoint.Targets{"0 30192 foo.example.org"}, RecordType: endpoint.RecordTypeSRV},
+				{DNSName: "_30192._tcp.foo.example.org", Targets: endpoint.Targets{"0 50 30192 foo.example.org"}, RecordType: endpoint.RecordTypeSRV},
 				{DNSName: "foo.example.org", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}, RecordType: endpoint.RecordTypeA},
 			},
 			false,
@@ -1094,7 +1094,7 @@ func TestNodePortServices(t *testing.T) {
 			map[string]string{},
 			nil,
 			[]*endpoint.Endpoint{
-				{DNSName: "_30192._tcp.foo.bar.example.com", Targets: endpoint.Targets{"0 30192 foo.bar.example.com"}, RecordType: endpoint.RecordTypeSRV},
+				{DNSName: "_30192._tcp.foo.bar.example.com", Targets: endpoint.Targets{"0 50 30192 foo.bar.example.com"}, RecordType: endpoint.RecordTypeSRV},
 				{DNSName: "foo.bar.example.com", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}, RecordType: endpoint.RecordTypeA},
 			},
 			false,
@@ -1135,7 +1135,7 @@ func TestNodePortServices(t *testing.T) {
 			},
 			nil,
 			[]*endpoint.Endpoint{
-				{DNSName: "_30192._tcp.foo.example.org", Targets: endpoint.Targets{"0 30192 foo.example.org"}, RecordType: endpoint.RecordTypeSRV},
+				{DNSName: "_30192._tcp.foo.example.org", Targets: endpoint.Targets{"0 50 30192 foo.example.org"}, RecordType: endpoint.RecordTypeSRV},
 				{DNSName: "foo.example.org", Targets: endpoint.Targets{"10.0.1.1", "10.0.1.2"}, RecordType: endpoint.RecordTypeA},
 			},
 			false,

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1111,7 +1111,7 @@ func TestNodePortServices(t *testing.T) {
 				Spec: v1.ServiceSpec{
 					Type: tc.svcType,
 					Ports: []v1.ServicePort{
-						v1.ServicePort{
+						{
 							NodePort: 30192,
 						},
 					},

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1055,12 +1055,13 @@ func TestNodePortServices(t *testing.T) {
 			},
 			nil,
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.example.org", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}},
+				{DNSName: "_30192._tcp.foo.example.org", Targets: endpoint.Targets{"0 30192 foo.example.org"}, RecordType: endpoint.RecordTypeSRV},
+				{DNSName: "foo.example.org", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}, RecordType: endpoint.RecordTypeA},
 			},
 			false,
 		},
 		{
-			"non-annotated ClusterIp services with set fqdnTemplate return an endpoint with target IP",
+			"non-annotated NodePort services with set fqdnTemplate return an endpoint with target IP",
 			"",
 			"",
 			"testing",
@@ -1072,7 +1073,8 @@ func TestNodePortServices(t *testing.T) {
 			map[string]string{},
 			nil,
 			[]*endpoint.Endpoint{
-				{DNSName: "foo.bar.example.com", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}},
+				{DNSName: "_30192._tcp.foo.bar.example.com", Targets: endpoint.Targets{"0 30192 foo.bar.example.com"}, RecordType: endpoint.RecordTypeSRV},
+				{DNSName: "foo.bar.example.com", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}, RecordType: endpoint.RecordTypeA},
 			},
 			false,
 		},
@@ -1108,6 +1110,11 @@ func TestNodePortServices(t *testing.T) {
 			service := &v1.Service{
 				Spec: v1.ServiceSpec{
 					Type: tc.svcType,
+					Ports: []v1.ServicePort{
+						v1.ServicePort{
+							NodePort: 30192,
+						},
+					},
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:   tc.svcNamespace,

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -1053,7 +1053,7 @@ func TestNodePortServices(t *testing.T) {
 			map[string]string{
 				hostnameAnnotationKey: "foo.example.org.",
 			},
-			[]string{},
+			nil,
 			[]*endpoint.Endpoint{
 				{DNSName: "foo.example.org", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}},
 			},
@@ -1070,7 +1070,7 @@ func TestNodePortServices(t *testing.T) {
 			"{{.Name}}.bar.example.com",
 			map[string]string{},
 			map[string]string{},
-			[]string{},
+			nil,
 			[]*endpoint.Endpoint{
 				{DNSName: "foo.bar.example.com", Targets: endpoint.Targets{"54.10.11.1", "54.10.11.2"}},
 			},
@@ -1105,15 +1105,6 @@ func TestNodePortServices(t *testing.T) {
 			}
 
 			// Create a service to test against
-			ingresses := []v1.LoadBalancerIngress{}
-			for _, lb := range tc.lbs {
-				if net.ParseIP(lb) != nil {
-					ingresses = append(ingresses, v1.LoadBalancerIngress{IP: lb})
-				} else {
-					ingresses = append(ingresses, v1.LoadBalancerIngress{Hostname: lb})
-				}
-			}
-
 			service := &v1.Service{
 				Spec: v1.ServiceSpec{
 					Type: tc.svcType,
@@ -1123,11 +1114,6 @@ func TestNodePortServices(t *testing.T) {
 					Name:        tc.svcName,
 					Labels:      tc.labels,
 					Annotations: tc.annotations,
-				},
-				Status: v1.ServiceStatus{
-					LoadBalancer: v1.LoadBalancerStatus{
-						Ingress: ingresses,
-					},
 				},
 			}
 


### PR DESCRIPTION
Initial work towards support for NodePort services for https://github.com/kubernetes-incubator/external-dns/issues/191.

I'm a little lost on how to get some fake nodes into the testing harness so any help would be appreciated.  I also haven't been able to test this yet as my dev cluster is in bad shape at the moment.

Any input would be greatly appreciated.  I went with a poll on update due to the rest of the application not using the event stream.  This poll is done once and passed through the update process.