### PR TITLE
Allow newlines for Hostnames annotation

### DIFF
--- a/source/compatibility.go
+++ b/source/compatibility.go
@@ -17,6 +17,7 @@ limitations under the License.
 package source
 
 import (
+	"regexp"
 	"strings"
 
 	"k8s.io/client-go/pkg/api/v1"
@@ -81,8 +82,9 @@ func legacyEndpointsFromMoleculeService(svc *v1.Service) []*endpoint.Endpoint {
 	if !exists {
 		return nil
 	}
+	re := regexp.MustCompile(`\s`)
 
-	hostnameList := strings.Split(strings.Replace(hostnameAnnotation, " ", "", -1), ",")
+	hostnameList := strings.Split(re.ReplaceAllString(hostnameAnnotation, ""), ",")
 
 	for _, hostname := range hostnameList {
 		// Create a corresponding endpoint for each configured external entrypoint.

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -19,6 +19,7 @@ package source
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"text/template"
@@ -134,7 +135,8 @@ func getTargetsFromTargetAnnotation(ing *v1beta1.Ingress) endpoint.Targets {
 	targetAnnotation, exists := ing.Annotations[targetAnnotationKey]
 	if exists {
 		// splits the hostname annotation and removes the trailing periods
-		targetsList := strings.Split(strings.Replace(targetAnnotation, " ", "", -1), ",")
+		re := regexp.MustCompile(`\s`)
+		targetsList := strings.Split(re.ReplaceAllString(targetAnnotation, ""), ",")
 		for _, targetHostname := range targetsList {
 			targetHostname = strings.TrimSuffix(targetHostname, ".")
 			targets = append(targets, targetHostname)
@@ -166,7 +168,8 @@ func (sc *ingressSource) endpointsFromTemplate(ing *v1beta1.Ingress) ([]*endpoin
 
 	var endpoints []*endpoint.Endpoint
 	// splits the FQDN template and removes the trailing periods
-	hostnameList := strings.Split(strings.Replace(hostnames, " ", "", -1), ",")
+	re := regexp.MustCompile(`\s`)
+	hostnameList := strings.Split(re.ReplaceAllString(hostnames, ""), ",")
 	for _, hostname := range hostnameList {
 		hostname = strings.TrimSuffix(hostname, ".")
 		endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl)...)

--- a/source/service.go
+++ b/source/service.go
@@ -19,6 +19,7 @@ package source
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"text/template"
@@ -178,8 +179,9 @@ func (sc *serviceSource) endpointsFromTemplate(svc *v1.Service) ([]*endpoint.End
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply template on service %s: %v", svc.String(), err)
 	}
+	re := regexp.MustCompile(`\s`)
 
-	hostnameList := strings.Split(strings.Replace(buf.String(), " ", "", -1), ",")
+	hostnameList := strings.Split(re.ReplaceAllString(buf.String(), ""), ",")
 	for _, hostname := range hostnameList {
 		endpoints = append(endpoints, sc.generateEndpoints(svc, hostname)...)
 	}

--- a/source/source.go
+++ b/source/source.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"regexp"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 )
@@ -70,8 +71,9 @@ func getHostnamesFromAnnotations(annotations map[string]string) []string {
 	if !exists {
 		return nil
 	}
+	re := regexp.MustCompile(`\s`)
 
-	return strings.Split(strings.Replace(hostnameAnnotation, " ", "", -1), ",")
+	return strings.Split(re.ReplaceAllString(hostnameAnnotation, ""), ",")
 }
 
 // suitableType returns the DNS resource record type suitable for the target.

--- a/source/source.go
+++ b/source/source.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
-	"regexp"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 )

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -92,3 +92,37 @@ func TestSuitableType(t *testing.T) {
 		}
 	}
 }
+
+func TestGetHostnamesFromAnnotations(t *testing.T) {
+	for _, tc := range []struct {
+		title             string
+		annotations       map[string]string
+		expectedHostnames []string
+	}{
+		{
+			title:             "Hostnames annotation not present",
+			annotations:       map[string]string{"foo": "bar"},
+			expectedHostnames: nil,
+		},
+		{
+			title:             "Split Hostnames by comma",
+			annotations:       map[string]string{hostnameAnnotationKey: "foo.example.com.,bar.example.com."},
+			expectedHostnames: []string{"foo.example.com.", "bar.example.com."},
+		},
+		{
+			title:             "Replace all whitespaces",
+			annotations:       map[string]string{hostnameAnnotationKey: " foo.example.com. ,   bar.example.com.  "},
+			expectedHostnames: []string{"foo.example.com.", "bar.example.com."},
+		},
+		{
+			title:             "Replace newlines",
+			annotations:       map[string]string{hostnameAnnotationKey: "\nfoo.example.com.\r\n,\nbar.example.com."},
+			expectedHostnames: []string{"foo.example.com.", "bar.example.com."},
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			hostnames := getHostnamesFromAnnotations(tc.annotations)
+			assert.Equal(t, tc.expectedHostnames, hostnames)
+		})
+	}
+}


### PR DESCRIPTION
Makes possible to use newlines inside of hostnames annotation to have well-formatted config

```
    external-dns.alpha.kubernetes.io/hostname: |
      foo.example.com.,
      bar.example.com.
```
