### PR TITLE
[Cloudflare] Custom record TTL

### DIFF
--- a/docs/tutorials/cloudflare.md
+++ b/docs/tutorials/cloudflare.md
@@ -146,6 +146,7 @@ metadata:
   name: nginx
   annotations:
     external-dns.alpha.kubernetes.io/hostname: example.com
+    external-dns.alpha.kubernetes.io/ttl: "120" #optional
 spec:
   selector:
     app: nginx
@@ -158,6 +159,9 @@ spec:
 
 Note the annotation on the service; use the same hostname as the Cloudflare DNS zone created above. The annotation may also be a subdomain
 of the DNS zone (e.g. 'www.example.com').
+
+By setting the TTL annotation on the service, you have to pass a valid TTL, which must be 120 or above.
+This annotation is optional, if you won't set it, it will be 1 (automatic) which is 300.
 
 ExternalDNS uses this annotation to determine what services should be registered with DNS.  Removing the annotation
 will cause ExternalDNS to remove the corresponding DNS records.

--- a/provider/cloudflare.go
+++ b/provider/cloudflare.go
@@ -285,8 +285,7 @@ func newCloudFlareChange(action string, endpoint *endpoint.Endpoint, proxied boo
 	if proxied && (cloudFlareTypeNotSupported[endpoint.RecordType] || strings.Contains(endpoint.DNSName, "*")) {
 		proxied = false
 	}
-	//// min value:120
-	if endpoint.RecordTTL.IsConfigured() && endpoint.RecordTTL >= 120 {
+	if endpoint.RecordTTL.IsConfigured() {
 		ttl = int(endpoint.RecordTTL)
 	}
 

--- a/provider/cloudflare_test.go
+++ b/provider/cloudflare_test.go
@@ -39,8 +39,8 @@ func (m *mockCloudFlareClient) CreateDNSRecord(zoneID string, rr cloudflare.DNSR
 func (m *mockCloudFlareClient) DNSRecords(zoneID string, rr cloudflare.DNSRecord) ([]cloudflare.DNSRecord, error) {
 	if zoneID == "1234567890" {
 		return []cloudflare.DNSRecord{
-				{ID: "1234567890", Name: "foobar.ext-dns-test.zalando.to.", Type: endpoint.RecordTypeA},
-				{ID: "1231231233", Name: "foo.bar.com"}},
+				{ID: "1234567890", Name: "foobar.ext-dns-test.zalando.to.", Type: endpoint.RecordTypeA, TTL: 120},
+				{ID: "1231231233", Name: "foo.bar.com", TTL: 1}},
 			nil
 	}
 	return nil, nil
@@ -336,8 +336,36 @@ func (m *mockCloudFlareUpdateRecordsFail) ListZones(zoneID ...string) ([]cloudfl
 }
 
 func TestNewCloudFlareChanges(t *testing.T) {
-	endpoints := []*endpoint.Endpoint{{DNSName: "new", Targets: endpoint.Targets{"target"}}}
-	newCloudFlareChanges(cloudFlareCreate, endpoints, true)
+	expect := []struct {
+		Name string
+		TTL  int
+	}{
+		{
+			"CustomRecordTTL",
+			120,
+		},
+		{
+			"DefaultRecordTTL",
+			1,
+		},
+		{
+			"InvalidRecordTTL",
+			1,
+		},
+	}
+	endpoints := []*endpoint.Endpoint{
+		{DNSName: "new", Targets: endpoint.Targets{"target"}, RecordTTL: 120},
+		{DNSName: "new2", Targets: endpoint.Targets{"target2"}},
+		{DNSName: "new3", Targets: endpoint.Targets{"target2"}, RecordTTL: 60},
+	}
+	changes := newCloudFlareChanges(cloudFlareCreate, endpoints, true)
+	for i, change := range changes {
+		assert.Equal(
+			t,
+			change.ResourceRecordSet.TTL,
+			expect[i].TTL,
+			expect[i].Name)
+	}
 }
 
 func TestNewCloudFlareChangeNoProxied(t *testing.T) {

--- a/provider/cloudflare_test.go
+++ b/provider/cloudflare_test.go
@@ -348,15 +348,10 @@ func TestNewCloudFlareChanges(t *testing.T) {
 			"DefaultRecordTTL",
 			1,
 		},
-		{
-			"InvalidRecordTTL",
-			1,
-		},
 	}
 	endpoints := []*endpoint.Endpoint{
 		{DNSName: "new", Targets: endpoint.Targets{"target"}, RecordTTL: 120},
 		{DNSName: "new2", Targets: endpoint.Targets{"target2"}},
-		{DNSName: "new3", Targets: endpoint.Targets{"target2"}, RecordTTL: 60},
 	}
 	changes := newCloudFlareChanges(cloudFlareCreate, endpoints, true)
 	for i, change := range changes {


### PR DESCRIPTION
Custom record TTL annotation should be noted by Cloudflare provider 

TTL min value is 120 everything below will take the default TTL which is 1 (automatic which means 300)