### PR TITLE
Support IPv6

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -25,6 +25,8 @@ import (
 const (
 	// RecordTypeA is a RecordType enum value
 	RecordTypeA = "A"
+	// RecordTypeAAAA is a RecordType enum value
+	RecordTypeAAAA = "AAAA"
 	// RecordTypeCNAME is a RecordType enum value
 	RecordTypeCNAME = "CNAME"
 	// RecordTypeTXT is a RecordType enum value
@@ -117,6 +119,8 @@ type Endpoint struct {
 	RecordTTL TTL
 	// Labels stores labels defined for the Endpoint
 	Labels Labels
+	// IPv6 for the AAAA records
+	IPv6 bool
 }
 
 // NewEndpoint initialization method to be used to create an endpoint
@@ -130,14 +134,19 @@ func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) 
 	for idx, target := range targets {
 		cleanTargets[idx] = strings.TrimSuffix(target, ".")
 	}
-
-	return &Endpoint{
+	ep := &Endpoint{
 		DNSName:    strings.TrimSuffix(dnsName, "."),
 		Targets:    cleanTargets,
 		RecordType: recordType,
 		Labels:     NewLabels(),
 		RecordTTL:  ttl,
 	}
+	if recordType == RecordTypeAAAA {
+		ep.IPv6 = true
+	} else {
+		ep.IPv6 = false
+	}
+	return ep
 }
 
 func (e *Endpoint) String() string {

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -33,6 +33,11 @@ func TestNewEndpoint(t *testing.T) {
 	if w.DNSName != "example.org" || w.Targets[0] != "load-balancer.com" || w.RecordType != "" {
 		t.Error("endpoint is not initialized correctly")
 	}
+
+	r := NewEndpoint("example.org.", "AAAA", "load-balancer.com.")
+	if r.DNSName != "example.org" || r.Targets[0] != "load-balancer.com" || r.RecordType != "AAAA" {
+		t.Error("endpoint is not initialized correctly")
+	}
 }
 
 func TestTargetsSame(t *testing.T) {

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -95,7 +95,7 @@ func (r *Route53APIStub) ChangeResourceRecordSets(input *route53.ChangeResourceR
 	}
 
 	for _, change := range input.ChangeBatch.Changes {
-		if aws.StringValue(change.ResourceRecordSet.Type) == route53.RRTypeA {
+		if aws.StringValue(change.ResourceRecordSet.Type) == route53.RRTypeA || aws.StringValue(change.ResourceRecordSet.Type) == route53.RRTypeAaaa {
 			for _, rrs := range change.ResourceRecordSet.ResourceRecords {
 				if net.ParseIP(aws.StringValue(rrs.Value)) == nil {
 					return nil, fmt.Errorf("A records must point to IPs")
@@ -211,6 +211,7 @@ func TestAWSRecords(t *testing.T) {
 		endpoint.NewEndpoint("list-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com"),
 		endpoint.NewEndpoint("*.wildcard-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com"),
 		endpoint.NewEndpointWithTTL("list-test-multiple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8", "8.8.4.4"),
+		endpoint.NewEndpointWithTTL("list-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8339"),
 	})
 
 	records, err := provider.Records()
@@ -223,6 +224,7 @@ func TestAWSRecords(t *testing.T) {
 		endpoint.NewEndpoint("list-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com"),
 		endpoint.NewEndpoint("*.wildcard-test-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com"),
 		endpoint.NewEndpointWithTTL("list-test-multiple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8", "8.8.4.4"),
+		endpoint.NewEndpointWithTTL("list-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8339"),
 	})
 }
 
@@ -236,6 +238,7 @@ func TestAWSCreateRecords(t *testing.T) {
 		endpoint.NewEndpointWithTTL("create-test-cname-custom-ttl.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, customTTL, "172.17.0.1"),
 		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
 		endpoint.NewEndpoint("create-test-multiple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
+		endpoint.NewEndpointWithTTL("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8329"),
 	}
 
 	require.NoError(t, provider.CreateRecords(records))
@@ -249,6 +252,7 @@ func TestAWSCreateRecords(t *testing.T) {
 		endpoint.NewEndpointWithTTL("create-test-cname-custom-ttl.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, customTTL, "172.17.0.1"),
 		endpoint.NewEndpointWithTTL("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "foo.elb.amazonaws.com"),
 		endpoint.NewEndpointWithTTL("create-test-multiple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8", "8.8.4.4"),
+		endpoint.NewEndpointWithTTL("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8329"),
 	})
 }
 
@@ -258,6 +262,7 @@ func TestAWSUpdateRecords(t *testing.T) {
 		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.4.4"),
 		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "foo.elb.amazonaws.com"),
 		endpoint.NewEndpointWithTTL("create-test-multiple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8", "8.8.4.4"),
+		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8340"),
 	})
 
 	currentRecords := []*endpoint.Endpoint{
@@ -265,12 +270,14 @@ func TestAWSUpdateRecords(t *testing.T) {
 		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.4.4"),
 		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
 		endpoint.NewEndpoint("create-test-multiple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
+		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8340"),
 	}
 	updatedRecords := []*endpoint.Endpoint{
 		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
 		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "4.3.2.1"),
 		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
 		endpoint.NewEndpoint("create-test-multiple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
+		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8339"),
 	}
 
 	require.NoError(t, provider.UpdateRecords(updatedRecords, currentRecords))
@@ -283,6 +290,7 @@ func TestAWSUpdateRecords(t *testing.T) {
 		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "4.3.2.1"),
 		endpoint.NewEndpointWithTTL("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "bar.elb.amazonaws.com"),
 		endpoint.NewEndpointWithTTL("create-test-multiple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "4.3.2.1"),
+		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8339"),
 	})
 }
 
@@ -294,6 +302,7 @@ func TestAWSDeleteRecords(t *testing.T) {
 		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com"),
 		endpoint.NewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.eu-central-1.elb.amazonaws.com"),
 		endpoint.NewEndpointWithTTL("delete-test-multiple.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8", "8.8.4.4"),
+		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8339"),
 	}
 
 	provider := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), false, originalEndpoints)
@@ -319,6 +328,8 @@ func TestAWSApplyChanges(t *testing.T) {
 		endpoint.NewEndpointWithTTL("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "qux.elb.amazonaws.com"),
 		endpoint.NewEndpointWithTTL("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8", "8.8.4.4"),
 		endpoint.NewEndpointWithTTL("delete-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "4.3.2.1"),
+		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8339"),
+		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8340"),
 	})
 
 	createRecords := []*endpoint.Endpoint{
@@ -327,6 +338,7 @@ func TestAWSApplyChanges(t *testing.T) {
 		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
 		endpoint.NewEndpoint("create-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
 		endpoint.NewEndpoint("create-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
+		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "FE80::0202:B3FF:FE1E:8339"),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
@@ -335,6 +347,7 @@ func TestAWSApplyChanges(t *testing.T) {
 		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
 		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
 		endpoint.NewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "FE80::0202:B3FF:FE1E:8339"),
 	}
 	updatedRecords := []*endpoint.Endpoint{
 		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
@@ -342,6 +355,7 @@ func TestAWSApplyChanges(t *testing.T) {
 		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
 		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
 		endpoint.NewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "FE80::0202:B3FF:FE1E:8340"),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
@@ -350,6 +364,7 @@ func TestAWSApplyChanges(t *testing.T) {
 		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
 		endpoint.NewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
 		endpoint.NewEndpoint("delete-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
+		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "FE80::0202:B3FF:FE1E:8340"),
 	}
 
 	changes := &plan.Changes{
@@ -375,6 +390,8 @@ func TestAWSApplyChanges(t *testing.T) {
 		endpoint.NewEndpointWithTTL("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "baz.elb.amazonaws.com"),
 		endpoint.NewEndpointWithTTL("create-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8", "8.8.4.4"),
 		endpoint.NewEndpointWithTTL("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "4.3.2.1"),
+		endpoint.NewEndpointWithTTL("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8339"),
+		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8340"),
 	})
 }
 
@@ -390,6 +407,8 @@ func TestAWSApplyChangesDryRun(t *testing.T) {
 		endpoint.NewEndpointWithTTL("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "qux.elb.amazonaws.com"),
 		endpoint.NewEndpointWithTTL("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "8.8.8.8", "8.8.4.4"),
 		endpoint.NewEndpointWithTTL("delete-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "4.3.2.1"),
+		endpoint.NewEndpointWithTTL("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8339"),
+		endpoint.NewEndpointWithTTL("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, endpoint.TTL(recordTTL), "FE80::0202:B3FF:FE1E:8340"),
 	}
 
 	provider := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), true, originalEndpoints)
@@ -400,6 +419,7 @@ func TestAWSApplyChangesDryRun(t *testing.T) {
 		endpoint.NewEndpoint("create-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
 		endpoint.NewEndpoint("create-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "foo.elb.amazonaws.com"),
 		endpoint.NewEndpoint("create-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
+		endpoint.NewEndpoint("create-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "FE80::0202:B3FF:FE1E:8339"),
 	}
 
 	currentRecords := []*endpoint.Endpoint{
@@ -408,6 +428,7 @@ func TestAWSApplyChangesDryRun(t *testing.T) {
 		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
 		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "bar.elb.amazonaws.com"),
 		endpoint.NewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "8.8.8.8", "8.8.4.4"),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "FE80::0202:B3FF:FE1E:8339"),
 	}
 	updatedRecords := []*endpoint.Endpoint{
 		endpoint.NewEndpoint("update-test.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4"),
@@ -415,6 +436,7 @@ func TestAWSApplyChangesDryRun(t *testing.T) {
 		endpoint.NewEndpoint("update-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
 		endpoint.NewEndpoint("update-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "baz.elb.amazonaws.com"),
 		endpoint.NewEndpoint("update-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
+		endpoint.NewEndpoint("update-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "FE80::0202:B3FF:FE1E:8340"),
 	}
 
 	deleteRecords := []*endpoint.Endpoint{
@@ -423,6 +445,7 @@ func TestAWSApplyChangesDryRun(t *testing.T) {
 		endpoint.NewEndpoint("delete-test-cname.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
 		endpoint.NewEndpoint("delete-test-cname-alias.zone-1.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeCNAME, "qux.elb.amazonaws.com"),
 		endpoint.NewEndpoint("delete-test-multiple.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeA, "1.2.3.4", "4.3.2.1"),
+		endpoint.NewEndpoint("delete-test.zone-2.ext-dns-test-2.teapot.zalan.do", endpoint.RecordTypeAAAA, "FE80::0202:B3FF:FE1E:8340"),
 	}
 
 	changes := &plan.Changes{
@@ -678,7 +701,8 @@ func TestAWSCreateRecordsWithALIAS(t *testing.T) {
 	provider := newAWSProvider(t, NewDomainFilter([]string{"ext-dns-test-2.teapot.zalan.do."}), NewZoneIDFilter([]string{}), NewZoneTypeFilter(""), false, []*endpoint.Endpoint{})
 
 	records := []*endpoint.Endpoint{
-		{DNSName: "create-test.zone-1.ext-dns-test-2.teapot.zalan.do", Targets: endpoint.Targets{"foo.eu-central-1.elb.amazonaws.com"}, RecordType: endpoint.RecordTypeCNAME},
+		{DNSName: "create-test.zone-1.ext-dns-test-2.teapot.zalan.do", Targets: endpoint.Targets{"foo.eu-central-1.elb.amazonaws.com"}, RecordType: endpoint.RecordTypeCNAME, IPv6: false},
+		{DNSName: "create-test.zone-1.ext-dns-test-2.teapot.zalan.do", Targets: endpoint.Targets{"foo.eu-central-1.elb.amazonaws.com"}, RecordType: endpoint.RecordTypeCNAME, IPv6: true},
 	}
 
 	require.NoError(t, provider.CreateRecords(records))
@@ -695,6 +719,15 @@ func TestAWSCreateRecordsWithALIAS(t *testing.T) {
 			Name: aws.String("create-test.zone-1.ext-dns-test-2.teapot.zalan.do."),
 			Type: aws.String(endpoint.RecordTypeA),
 		},
+		{
+			AliasTarget: &route53.AliasTarget{
+				DNSName:              aws.String("foo.eu-central-1.elb.amazonaws.com."),
+				EvaluateTargetHealth: aws.Bool(true),
+				HostedZoneId:         aws.String("Z215JYRZR1TBD5"),
+			},
+			Name: aws.String("create-test.zone-1.ext-dns-test-2.teapot.zalan.do."),
+			Type: aws.String(endpoint.RecordTypeAAAA),
+		},
 	})
 }
 
@@ -702,14 +735,17 @@ func TestAWSisLoadBalancer(t *testing.T) {
 	for _, tc := range []struct {
 		target     string
 		recordType string
+		ipv6       bool
 		expected   bool
 	}{
-		{"bar.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeCNAME, true},
-		{"foo.example.org", endpoint.RecordTypeCNAME, false},
+		{"bar.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeCNAME, false, true},
+		{"bar-2.eu-central-1.elb.amazonaws.com", endpoint.RecordTypeCNAME, true, true},
+		{"foo.example.org", endpoint.RecordTypeCNAME, false, false},
 	} {
 		ep := &endpoint.Endpoint{
 			Targets:    endpoint.Targets{tc.target},
 			RecordType: tc.recordType,
+			IPv6:       tc.ipv6,
 		}
 		assert.Equal(t, tc.expected, isAWSLoadBalancer(ep))
 	}
@@ -827,7 +863,7 @@ func listAWSRecords(t *testing.T, client Route53API, zone string) []*route53.Res
 	}, func(resp *route53.ListResourceRecordSetsOutput, _ bool) bool {
 		for _, recordSet := range resp.ResourceRecordSets {
 			switch aws.StringValue(recordSet.Type) {
-			case endpoint.RecordTypeA, endpoint.RecordTypeCNAME:
+			case endpoint.RecordTypeA, endpoint.RecordTypeAAAA, endpoint.RecordTypeCNAME:
 				recordSets = append(recordSets, recordSet)
 			}
 		}

--- a/provider/recordfilter.go
+++ b/provider/recordfilter.go
@@ -20,7 +20,7 @@ package provider
 // Currently only A, CNAME and TXT record types are supported.
 func supportedRecordType(recordType string) bool {
 	switch recordType {
-	case "A", "CNAME", "TXT":
+	case "A", "AAAA", "CNAME", "TXT":
 		return true
 	default:
 		return false

--- a/provider/recordfilter_test.go
+++ b/provider/recordfilter_test.go
@@ -28,6 +28,10 @@ func TestRecordTypeFilter(t *testing.T) {
 			true,
 		},
 		{
+			"AAAA",
+			true,
+		},
+		{
 			"CNAME",
 			true,
 		},

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -245,12 +245,15 @@ func endpointsForHostname(hostname string, targets endpoint.Targets, ttl endpoin
 	var endpoints []*endpoint.Endpoint
 
 	var aTargets endpoint.Targets
+	var aaaaTargets endpoint.Targets
 	var cnameTargets endpoint.Targets
 
 	for _, t := range targets {
 		switch suitableType(t) {
 		case endpoint.RecordTypeA:
 			aTargets = append(aTargets, t)
+		case endpoint.RecordTypeAAAA:
+			aaaaTargets = append(aaaaTargets, t)
 		default:
 			cnameTargets = append(cnameTargets, t)
 		}
@@ -265,6 +268,17 @@ func endpointsForHostname(hostname string, targets endpoint.Targets, ttl endpoin
 			Labels:     endpoint.NewLabels(),
 		}
 		endpoints = append(endpoints, epA)
+	}
+
+	if len(aaaaTargets) > 0 {
+		epAAAA := &endpoint.Endpoint{
+			DNSName:    strings.TrimSuffix(hostname, "."),
+			Targets:    aaaaTargets,
+			RecordTTL:  ttl,
+			RecordType: endpoint.RecordTypeAAAA,
+			Labels:     endpoint.NewLabels(),
+		}
+		endpoints = append(endpoints, epAAAA)
 	}
 
 	if len(cnameTargets) > 0 {

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -773,6 +773,17 @@ func testIngressEndpoints(t *testing.T) {
 					ips:       []string{},
 					hostnames: []string{},
 				},
+				{
+					name:      "fake4",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "FE80::0202:B3FF:FE1E:8329",
+						ipv6AnnotationKey:   "true",
+					},
+					dnsnames:  []string{},
+					ips:       []string{},
+					hostnames: []string{},
+				},
 			},
 			expected: []*endpoint.Endpoint{
 				{
@@ -789,6 +800,11 @@ func testIngressEndpoints(t *testing.T) {
 					DNSName:    "fake3.ext-dns.test.com",
 					Targets:    endpoint.Targets{"1.2.3.4"},
 					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "fake4.ext-dns.test.com",
+					Targets:    endpoint.Targets{"FE80::0202:B3FF:FE1E:8329"},
+					RecordType: endpoint.RecordTypeAAAA,
 				},
 			},
 			fqdnTemplate: "{{.Name}}.ext-dns.test.com",

--- a/source/service.go
+++ b/source/service.go
@@ -242,6 +242,7 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string) []*
 	if err != nil {
 		log.Warn(err)
 	}
+	isIPv6 := getIPv6FromAnnotations(svc.Annotations)
 
 	epA := &endpoint.Endpoint{
 		RecordTTL:  ttl,
@@ -249,6 +250,16 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string) []*
 		Labels:     endpoint.NewLabels(),
 		Targets:    make(endpoint.Targets, 0, defaultTargetsCapacity),
 		DNSName:    hostname,
+		IPv6:       isIPv6,
+	}
+
+	epAAAA := &endpoint.Endpoint{
+		RecordTTL:  ttl,
+		RecordType: endpoint.RecordTypeAAAA,
+		Labels:     endpoint.NewLabels(),
+		Targets:    make(endpoint.Targets, 0, defaultTargetsCapacity),
+		DNSName:    hostname,
+		IPv6:       isIPv6,
 	}
 
 	epCNAME := &endpoint.Endpoint{
@@ -257,6 +268,7 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string) []*
 		Labels:     endpoint.NewLabels(),
 		Targets:    make(endpoint.Targets, 0, defaultTargetsCapacity),
 		DNSName:    hostname,
+		IPv6:       isIPv6,
 	}
 
 	var endpoints []*endpoint.Endpoint
@@ -279,6 +291,9 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string) []*
 		if suitableType(t) == endpoint.RecordTypeA {
 			epA.Targets = append(epA.Targets, t)
 		}
+		if suitableType(t) == endpoint.RecordTypeAAAA {
+			epAAAA.Targets = append(epAAAA.Targets, t)
+		}
 		if suitableType(t) == endpoint.RecordTypeCNAME {
 			epCNAME.Targets = append(epCNAME.Targets, t)
 		}
@@ -286,6 +301,9 @@ func (sc *serviceSource) generateEndpoints(svc *v1.Service, hostname string) []*
 
 	if len(epA.Targets) > 0 {
 		endpoints = append(endpoints, epA)
+	}
+	if len(epAAAA.Targets) > 0 {
+		endpoints = append(endpoints, epAAAA)
 	}
 	if len(epCNAME.Targets) > 0 {
 		endpoints = append(endpoints, epCNAME)

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -81,6 +81,8 @@ func TestSuitableType(t *testing.T) {
 		target, recordType, expected string
 	}{
 		{"8.8.8.8", "", "A"},
+		{"FE80::0202:B3FF:FE1E:8329", "", "AAAA"},
+		{"fdf8:f53b:82e4::53", "", "AAAA"},
 		{"foo.example.org", "", "CNAME"},
 		{"bar.eu-central-1.elb.amazonaws.com", "", "CNAME"},
 	} {


### PR DESCRIPTION
Initial to support IPv6 including AWS, see #520 

@lareeth since you have been requesting IPv6 support, could you try to test it in your cluster?
You could build external-dns based on my PR.
Let me know how we can make this PR better :).

You need to set the annotation `external-dns.alpha.kubernetes.io/ipv6: "true" , "True", "TRUE" or "1"`

Signed-off-by: Nick Jüttner <nick@juni.io>