### PR TITLE
AWS provider: Properly check suitable domains

### DIFF
--- a/provider/aws.go
+++ b/provider/aws.go
@@ -435,7 +435,7 @@ func suitableZones(hostname string, zones map[string]*route53.HostedZone) []*rou
 	var publicZone *route53.HostedZone
 
 	for _, z := range zones {
-		if strings.HasSuffix(hostname, aws.StringValue(z.Name)) {
+		if aws.StringValue(z.Name) == hostname || strings.HasSuffix(hostname, "."+aws.StringValue(z.Name)) {
 			if z.Config == nil || !aws.BoolValue(z.Config.PrivateZone) {
 				// Only select the best matching public zone
 				if publicZone == nil || len(aws.StringValue(z.Name)) > len(aws.StringValue(publicZone.Name)) {

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -781,6 +781,12 @@ func TestAWSSuitableZones(t *testing.T) {
 	}{
 		{"foo.bar.example.org.", []*route53.HostedZone{zones["example-org-private"], zones["bar-example-org-private"], zones["bar-example-org"]}},
 		{"foo.example.org.", []*route53.HostedZone{zones["example-org-private"], zones["example-org"]}},
+
+		// bar.example.org is NOT suitable
+		{"foobar.example.org.", []*route53.HostedZone{zones["example-org-private"], zones["example-org"]}},
+
+		// all matching private zones are suitable (i'm not sure why)
+		{"bar.example.org.", []*route53.HostedZone{zones["example-org-private"], zones["bar-example-org-private"], zones["bar-example-org"]}},
 		{"foo.kubernetes.io.", nil},
 	} {
 		suitableZones := suitableZones(tc.hostname, zones)


### PR DESCRIPTION
Similar to #478 , this will correctly detect zones when names overlap with subdomains.  I added a note to #446, but let me know if i should create a separate issue. 

Note:  I am not sure why *all* matching private zones are considered suitable, but did not modify that logic.