### PR TITLE
Read hostnames from spec.tls.hosts on Ingress object

### DIFF
--- a/docs/initial-design.md
+++ b/docs/initial-design.md
@@ -37,7 +37,9 @@ New cloud providers should be easily pluggable. Initially only AWS/Google platfo
 
 DNS records will be automatically created in multiple situations:
 1. Setting `spec.rules.host` on an ingress object.
-2. Adding the annotation `external-dns.alpha.kubernetes.io/hostname` on a `type=LoadBalancer` service object.
+2. Setting `spec.tls.hosts` on an ingress object.
+3. Adding the annotation `external-dns.alpha.kubernetes.io/hostname` on an ingress object.
+4. Adding the annotation `external-dns.alpha.kubernetes.io/hostname` on a `type=LoadBalancer` service object.
 
 ### Annotations
 

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -233,6 +233,15 @@ func endpointsFromIngress(ing *v1beta1.Ingress) []*endpoint.Endpoint {
 		endpoints = append(endpoints, endpointsForHostname(rule.Host, targets, ttl)...)
 	}
 
+	for _, tls := range ing.Spec.TLS {
+		for _, host := range tls.Hosts {
+			if host == "" {
+				continue
+			}
+			endpoints = append(endpoints, endpointsForHostname(host, targets, ttl)...)
+		}
+	}
+
 	hostnameList := getHostnamesFromAnnotations(ing.Annotations)
 	for _, hostname := range hostnameList {
 		endpoints = append(endpoints, endpointsForHostname(hostname, targets, ttl)...)

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -616,6 +616,83 @@ func testIngressEndpoints(t *testing.T) {
 			},
 		},
 		{
+			title:           "ingress rules with single tls having single hostname",
+			targetNamespace: "",
+			ingressItems: []fakeIngress{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					tlsdnsnames: [][]string{{"example.org"}},
+					ips:      []string{"1.2.3.4"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+			},
+		},
+		{
+			title:           "ingress rules with single tls having multiple hostnames",
+			targetNamespace: "",
+			ingressItems: []fakeIngress{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					tlsdnsnames: [][]string{{"example.org", "example2.org"}},
+					ips:      []string{"1.2.3.4"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "example2.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+			},
+		},
+		{
+			title:           "ingress rules with multiple tls having multiple hostnames",
+			targetNamespace: "",
+			ingressItems: []fakeIngress{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					tlsdnsnames: [][]string{{"example.org", "example2.org"},{"example3.org", "example4.org"}},
+					ips:      []string{"1.2.3.4"},
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName:    "example.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "example2.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "example3.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+				{
+					DNSName:    "example4.org",
+					Targets:    endpoint.Targets{"1.2.3.4"},
+					RecordType: endpoint.RecordTypeA,
+				},
+			},
+		},
+		{
 			title:           "ingress rules with hostname annotation",
 			targetNamespace: "",
 			ingressItems: []fakeIngress{
@@ -828,6 +905,7 @@ func testIngressEndpoints(t *testing.T) {
 // ingress specific helper functions
 type fakeIngress struct {
 	dnsnames    []string
+	tlsdnsnames [][]string
 	ips         []string
 	hostnames   []string
 	namespace   string
@@ -854,6 +932,11 @@ func (ing fakeIngress) Ingress() *v1beta1.Ingress {
 	for _, dnsname := range ing.dnsnames {
 		ingress.Spec.Rules = append(ingress.Spec.Rules, v1beta1.IngressRule{
 			Host: dnsname,
+		})
+	}
+	for _, hosts := range ing.tlsdnsnames {
+		ingress.Spec.TLS = append(ingress.Spec.TLS, v1beta1.IngressTLS{
+			Hosts: hosts,
 		})
 	}
 	for _, ip := range ing.ips {

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -620,10 +620,10 @@ func testIngressEndpoints(t *testing.T) {
 			targetNamespace: "",
 			ingressItems: []fakeIngress{
 				{
-					name:      "fake1",
-					namespace: namespace,
+					name:        "fake1",
+					namespace:   namespace,
 					tlsdnsnames: [][]string{{"example.org"}},
-					ips:      []string{"1.2.3.4"},
+					ips:         []string{"1.2.3.4"},
 				},
 			},
 			expected: []*endpoint.Endpoint{
@@ -639,10 +639,10 @@ func testIngressEndpoints(t *testing.T) {
 			targetNamespace: "",
 			ingressItems: []fakeIngress{
 				{
-					name:      "fake1",
-					namespace: namespace,
+					name:        "fake1",
+					namespace:   namespace,
 					tlsdnsnames: [][]string{{"example.org", "example2.org"}},
-					ips:      []string{"1.2.3.4"},
+					ips:         []string{"1.2.3.4"},
 				},
 			},
 			expected: []*endpoint.Endpoint{
@@ -663,10 +663,10 @@ func testIngressEndpoints(t *testing.T) {
 			targetNamespace: "",
 			ingressItems: []fakeIngress{
 				{
-					name:      "fake1",
-					namespace: namespace,
-					tlsdnsnames: [][]string{{"example.org", "example2.org"},{"example3.org", "example4.org"}},
-					ips:      []string{"1.2.3.4"},
+					name:        "fake1",
+					namespace:   namespace,
+					tlsdnsnames: [][]string{{"example.org", "example2.org"}, {"example3.org", "example4.org"}},
+					ips:         []string{"1.2.3.4"},
 				},
 			},
 			expected: []*endpoint.Endpoint{


### PR DESCRIPTION
Fixes #610 

Not sure about check for empty "host" value, if it's needed, just copied from rules handling.

Also updated docs, to reflect annotations support on ingress (see #545 ) and this new hostsnames from tls feature.