### PR TITLE
Update DO CNAME type API request to prevent error 422

### DIFF
--- a/provider/digital_ocean.go
+++ b/provider/digital_ocean.go
@@ -214,6 +214,12 @@ func (p *DigitalOceanProvider) submitChanges(changes []*DigitalOceanChange) erro
 				change.ResourceRecordSet.Name = "@"
 			}
 
+			// for some reason the DO API requires the '.' at the end of "data" in case of CNAME request
+			// Example: {"type":"CNAME","name":"hello","data":"www.example.com."}
+			if change.ResourceRecordSet.Type == endpoint.RecordTypeCNAME {
+				change.ResourceRecordSet.Data += "."
+			}
+
 			switch change.Action {
 			case DigitalOceanCreate:
 				_, _, err = p.Client.CreateRecord(context.TODO(), zoneName,

--- a/provider/digital_ocean_test.go
+++ b/provider/digital_ocean_test.go
@@ -436,7 +436,7 @@ func TestDigitalOceanApplyChanges(t *testing.T) {
 	}
 	changes.Delete = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.bar.com", Targets: endpoint.Targets{"target"}}}
 	changes.UpdateOld = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.bar.de", Targets: endpoint.Targets{"target-old"}}}
-	changes.UpdateNew = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.foo.com", Targets: endpoint.Targets{"target-new"}}}
+	changes.UpdateNew = []*endpoint.Endpoint{{DNSName: "foobar.ext-dns-test.foo.com", Targets: endpoint.Targets{"target-new"}, RecordType: "CNAME"}}
 	err := provider.ApplyChanges(changes)
 	if err != nil {
 		t.Errorf("should not fail, %s", err)


### PR DESCRIPTION
For some reason, the DO API requires the '.' at the end of "data" in case of CNAME request
Example: {"type":"CNAME","name":"hello","data":"www.example.com."}
otherwise gives this error:
422 - Data needs to end with a dot (.)