### PR TITLE
Adds initial support for RFC2136 dynamic DNS updates

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -342,6 +342,12 @@
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
 
 [[projects]]
+  name = "github.com/miekg/dns"
+  packages = ["."]
+  revision = "5a2b9fab83ff0f8bfc99684bd5f43a37abe560f1"
+  version = "v1.0.8"
+
+[[projects]]
   name = "github.com/nesv/go-dynect"
   packages = ["dynect"]
   revision = "cdd946344b54bdf7dbeac406c2f1fe93150f08ea"
@@ -455,7 +461,7 @@
     "lex/httplex",
     "publicsuffix"
   ]
-  revision = "e90d6d0afc4c315a0d87a568ae68577cc15149a0"
+  revision = "a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1"
 
 [[projects]]
   name = "golang.org/x/oauth2"
@@ -492,7 +498,7 @@
     "unicode/rangetable",
     "width"
   ]
-  revision = "2910a502d2bf9e43193af9d68ca516529614eed3"
+  revision = "0605a8320aceb4207a5fb3521281e17ec2075476"
 
 [[projects]]
   name = "google.golang.org/api"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,3 +75,7 @@ ignored = ["github.com/kubernetes/repo-infra/kazel"]
 [[constraint]]
   name = "github.com/oracle/oci-go-sdk"
   version = "1.8.0"
+
+[[constraint]]
+  name = "github.com/miekg/dns"
+  version = "1.0.8"

--- a/main.go
+++ b/main.go
@@ -178,6 +178,8 @@ func main() {
 		if err == nil {
 			p, err = provider.NewOCIProvider(*config, domainFilter, zoneIDFilter, cfg.DryRun)
 		}
+	case "rfc2136":
+		p, err = provider.NewRfc2136Provider(cfg.RFC2136Host, cfg.RFC2136Port, cfg.RFC2136Zone, cfg.RFC2136Insecure, cfg.RFC2136TSIGKeyName, cfg.RFC2136TSIGSecret, domainFilter, cfg.DryRun)
 	default:
 		log.Fatalf("unknown dns provider: %s", cfg.Provider)
 	}

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -89,6 +89,12 @@ type Config struct {
 	ExoscaleEndpoint         string
 	ExoscaleAPIKey           string
 	ExoscaleAPISecret        string
+	RFC2136Host              string
+	RFC2136Port              int
+	RFC2136Zone              string
+	RFC2136Insecure          bool
+	RFC2136TSIGKeyName       string
+	RFC2136TSIGSecret        string
 }
 
 var defaultConfig = &Config{
@@ -140,6 +146,12 @@ var defaultConfig = &Config{
 	ExoscaleEndpoint:         "https://api.exoscale.ch/dns",
 	ExoscaleAPIKey:           "",
 	ExoscaleAPISecret:        "",
+	RFC2136Host:              "",
+	RFC2136Port:              53,
+	RFC2136Zone:              "",
+	RFC2136Insecure:          false,
+	RFC2136TSIGKeyName:       "",
+	RFC2136TSIGSecret:        "",
 }
 
 // NewConfig returns new Config object
@@ -193,7 +205,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("connector-source-server", "The server to connect for connector source, valid only when using connector source").Default(defaultConfig.ConnectorSourceServer).StringVar(&cfg.ConnectorSourceServer)
 
 	// Flags related to providers
-	app.Flag("provider", "The DNS provider where the DNS records will be created (required, options: aws, aws-sd, google, azure, cloudflare, digitalocean, dnsimple, infoblox, dyn, designate, coredns, skydns, inmemory, pdns, oci, exoscale)").Required().PlaceHolder("provider").EnumVar(&cfg.Provider, "aws", "aws-sd", "google", "azure", "cloudflare", "digitalocean", "dnsimple", "infoblox", "dyn", "designate", "coredns", "skydns", "inmemory", "pdns", "oci", "exoscale")
+	app.Flag("provider", "The DNS provider where the DNS records will be created (required, options: aws, aws-sd, google, azure, cloudflare, digitalocean, dnsimple, infoblox, dyn, designate, coredns, skydns, inmemory, pdns, oci, exoscale, rfc2136)").Required().PlaceHolder("provider").EnumVar(&cfg.Provider, "aws", "aws-sd", "google", "azure", "cloudflare", "digitalocean", "dnsimple", "infoblox", "dyn", "designate", "coredns", "skydns", "inmemory", "pdns", "oci", "exoscale", "rfc2136")
 	app.Flag("domain-filter", "Limit possible target zones by a domain suffix; specify multiple times for multiple domains (optional)").Default("").StringsVar(&cfg.DomainFilter)
 	app.Flag("zone-id-filter", "Filter target zones by hosted zone id; specify multiple times for multiple zones (optional)").Default("").StringsVar(&cfg.ZoneIDFilter)
 	app.Flag("google-project", "When using the Google provider, current project is auto-detected, when running on GCP. Specify other project with this. Must be specified when running outside GCP.").Default(defaultConfig.GoogleProject).StringVar(&cfg.GoogleProject)
@@ -229,6 +241,14 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("exoscale-endpoint", "Provide the endpoint for the Exoscale provider").Default(defaultConfig.ExoscaleEndpoint).StringVar(&cfg.ExoscaleEndpoint)
 	app.Flag("exoscale-apikey", "Provide your API Key for the Exoscale provider").Default(defaultConfig.ExoscaleAPIKey).StringVar(&cfg.ExoscaleAPIKey)
 	app.Flag("exoscale-apisecret", "Provide your API Secret for the Exoscale provider").Default(defaultConfig.ExoscaleAPISecret).StringVar(&cfg.ExoscaleAPISecret)
+
+	// Flags related to RFC2136 provider
+	app.Flag("rfc2136-host", "When using the RFC2136 provider, specify the host of the DNS server").Default(defaultConfig.RFC2136Host).StringVar(&cfg.RFC2136Host)
+	app.Flag("rfc2136-port", "When using the RFC2136 provider, specify the port of the DNS server").Default(strconv.Itoa(defaultConfig.RFC2136Port)).IntVar(&cfg.RFC2136Port)
+	app.Flag("rfc2136-zone", "When using the RFC2136 provider, specify the zone entry of the DNS server to use").Default(defaultConfig.RFC2136Zone).StringVar(&cfg.RFC2136Zone)
+	app.Flag("rfc2136-insecure", "When using the RFC2136 provider, specify whether to attach TSIG or not (default: false, requires --rfc2136-tsig-keyname and rfc2136-tsig-secret)").Default(strconv.FormatBool(defaultConfig.RFC2136Insecure)).BoolVar(&cfg.RFC2136Insecure)
+	app.Flag("rfc2136-tsig-keyname", "When using the RFC2136 provider, specify the TSIG key to attached to DNS messages (required when --rfc2136-insecure=false)").Default(defaultConfig.RFC2136TSIGKeyName).StringVar(&cfg.RFC2136TSIGKeyName)
+	app.Flag("rfc2136-tsig-secret", "When using the RFC2136 provider, specify the TSIG (base64) value to attached to DNS messages (required when --rfc2136-insecure=false)").Default(defaultConfig.RFC2136TSIGSecret).StringVar(&cfg.RFC2136TSIGSecret)
 
 	// Flags related to policies
 	app.Flag("policy", "Modify how DNS records are sychronized between sources and providers (default: sync, options: sync, upsert-only)").Default(defaultConfig.Policy).EnumVar(&cfg.Policy, "sync", "upsert-only")

--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -71,6 +71,12 @@ var (
 		ExoscaleEndpoint:        "https://api.exoscale.ch/dns",
 		ExoscaleAPIKey:          "",
 		ExoscaleAPISecret:       "",
+		RFC2136Host:              "",
+		RFC2136Port:              53,
+		RFC2136Zone:              "",
+		RFC2136Insecure:          false,
+		RFC2136TSIGKeyName:       "",
+		RFC2136TSIGSecret:        "",
 	}
 
 	overriddenConfig = &Config{
@@ -120,6 +126,12 @@ var (
 		ExoscaleEndpoint:        "https://api.foo.ch/dns",
 		ExoscaleAPIKey:          "1",
 		ExoscaleAPISecret:       "2",
+		RFC2136Host:             "localhost",
+		RFC2136Port:             123,
+		RFC2136Zone:             "myzone",
+		RFC2136Insecure:         true,
+		RFC2136TSIGKeyName:      "myTsigKeyName",
+		RFC2136TSIGSecret:       "myTsigSecret",
 	}
 )
 
@@ -193,6 +205,12 @@ func TestParseFlags(t *testing.T) {
 				"--exoscale-endpoint=https://api.foo.ch/dns",
 				"--exoscale-apikey=1",
 				"--exoscale-apisecret=2",
+				"--rfc2136-host=localhost",
+				"--rfc2136-port=123",
+				"--rfc2136-zone=myzone",
+				"--rfc2136-insecure",
+				"--rfc2136-tsig-keyname=myTsigKeyName",
+				"--rfc2136-tsig-secret=myTsigSecret",
 			},
 			envVars:  map[string]string{},
 			expected: overriddenConfig,
@@ -247,6 +265,12 @@ func TestParseFlags(t *testing.T) {
 				"EXTERNAL_DNS_EXOSCALE_ENDPOINT":          "https://api.foo.ch/dns",
 				"EXTERNAL_DNS_EXOSCALE_APIKEY":            "1",
 				"EXTERNAL_DNS_EXOSCALE_APISECRET":         "2",
+				"EXTERNAL_DNS_RFC2136_HOST":               "localhost",
+				"EXTERNAL_DNS_RFC2136_PORT":               "123",
+				"EXTERNAL_DNS_RFC2136_ZONE":               "myzone",
+				"EXTERNAL_DNS_RFC2136_INSCURE":            "1",
+				"EXTERNAL_DNS_RFC2136_TSIG_KEYNAME":       "myTsigKeyName",
+				"EXTERNAL_DNS_RFC2136_TSIG_SECRET":        "myTsigSecret",
 			},
 			expected: overriddenConfig,
 		},

--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -71,12 +71,12 @@ var (
 		ExoscaleEndpoint:        "https://api.exoscale.ch/dns",
 		ExoscaleAPIKey:          "",
 		ExoscaleAPISecret:       "",
-		RFC2136Host:              "",
-		RFC2136Port:              53,
-		RFC2136Zone:              "",
-		RFC2136Insecure:          false,
-		RFC2136TSIGKeyName:       "",
-		RFC2136TSIGSecret:        "",
+		RFC2136Host:             "",
+		RFC2136Port:             53,
+		RFC2136Zone:             "",
+		RFC2136Insecure:         false,
+		RFC2136TSIGKeyName:      "",
+		RFC2136TSIGSecret:       "",
 	}
 
 	overriddenConfig = &Config{
@@ -268,7 +268,7 @@ func TestParseFlags(t *testing.T) {
 				"EXTERNAL_DNS_RFC2136_HOST":               "localhost",
 				"EXTERNAL_DNS_RFC2136_PORT":               "123",
 				"EXTERNAL_DNS_RFC2136_ZONE":               "myzone",
-				"EXTERNAL_DNS_RFC2136_INSCURE":            "1",
+				"EXTERNAL_DNS_RFC2136_INSECURE":           "1",
 				"EXTERNAL_DNS_RFC2136_TSIG_KEYNAME":       "myTsigKeyName",
 				"EXTERNAL_DNS_RFC2136_TSIG_SECRET":        "myTsigSecret",
 			},

--- a/provider/rfc2136.go
+++ b/provider/rfc2136.go
@@ -1,0 +1,281 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"net"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/kubernetes-incubator/external-dns/endpoint"
+	"github.com/kubernetes-incubator/external-dns/plan"
+)
+
+// rfc2136 provider type
+type rfc2136Provider struct {
+	nameserver  string
+	zoneName    string
+	tsigKeyName string
+	tsigSecret  string
+	insecure    bool
+
+	// only consider hosted zones managing domains ending in this suffix
+	domainFilter DomainFilter
+	dryRun       bool
+}
+
+// NewRfc2136Provider is a factory function for OpenStack rfc2136 providers
+func NewRfc2136Provider(host string, port int, zoneName string, insecure bool, keyName string, secret string, domainFilter DomainFilter, dryRun bool) (Provider, error) {
+	r := &rfc2136Provider{
+		nameserver:   net.JoinHostPort(host, strconv.Itoa(port)),
+		zoneName:     dns.Fqdn(zoneName),
+		insecure:     insecure,
+		domainFilter: domainFilter,
+		dryRun:       dryRun,
+	}
+
+	if !insecure {
+		r.tsigKeyName = dns.Fqdn(keyName)
+		r.tsigSecret = secret
+	}
+
+	log.Infof("Configured RFC2136 with zone '%s' and nameserver '%s'", r.zoneName, r.nameserver)
+	return r, nil
+}
+
+// Records returns the list of records.
+func (r rfc2136Provider) Records() ([]*endpoint.Endpoint, error) {
+	rrs, err := r.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var eps []*endpoint.Endpoint
+
+OuterLoop:
+	for _, rr := range rrs {
+		log.Debugf("Record=%s", rr)
+
+		if rr.Header().Class != dns.ClassINET {
+			continue
+		}
+
+		rrFqdn := rr.Header().Name
+		rrTTL := endpoint.TTL(rr.Header().Ttl)
+		var rrType string
+		var rrValues []string
+		switch rr.Header().Rrtype {
+		case dns.TypeCNAME:
+			rrValues = []string{rr.(*dns.CNAME).Target}
+			rrType = "CNAME"
+		case dns.TypeA:
+			rrValues = []string{rr.(*dns.A).A.String()}
+			rrType = "A"
+		case dns.TypeAAAA:
+			rrValues = []string{rr.(*dns.AAAA).AAAA.String()}
+			rrType = "AAAA"
+		case dns.TypeTXT:
+			rrValues = (rr.(*dns.TXT).Txt)
+			rrType = "TXT"
+		default:
+			continue // Unhandled record type
+		}
+
+		for idx, existingEndpoint := range eps {
+			if existingEndpoint.DNSName == rrFqdn && existingEndpoint.RecordType == rrType {
+				eps[idx].Targets = append(eps[idx].Targets, rrValues...)
+				continue OuterLoop
+			}
+		}
+
+		ep := endpoint.NewEndpointWithTTL(
+			rrFqdn,
+			rrType,
+			rrTTL,
+			rrValues...,
+		)
+
+		eps = append(eps, ep)
+	}
+
+	return eps, nil
+}
+
+func (r rfc2136Provider) List() ([]dns.RR, error) {
+	log.Debugf("Fetching records for '%s'", r.zoneName)
+
+	t := new(dns.Transfer)
+	if !r.insecure {
+		t.TsigSecret = map[string]string{r.tsigKeyName: r.tsigSecret}
+	}
+
+	m := new(dns.Msg)
+	m.SetAxfr(r.zoneName)
+	if !r.insecure {
+		m.SetTsig(r.tsigKeyName, dns.HmacMD5, 300, time.Now().Unix())
+	}
+
+	env, err := t.In(m, r.nameserver)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch records via AXFR: %v", err)
+	}
+
+	records := make([]dns.RR, 0)
+	for e := range env {
+		if e.Error != nil {
+			if e.Error == dns.ErrSoa {
+				log.Error("AXFR error: unexpected response received from the server")
+			} else {
+				log.Errorf("AXFR error: %v", e.Error)
+			}
+			continue
+		}
+		records = append(records, e.RR...)
+	}
+
+	return records, nil
+}
+
+// ApplyChanges applies a given set of changes in a given zone.
+func (r rfc2136Provider) ApplyChanges(changes *plan.Changes) error {
+	log.Debugf("ApplyChanges")
+
+	for _, ep := range changes.Create {
+
+		if !r.domainFilter.Match(ep.DNSName) {
+			log.Debugf("Skipping record %s because it was filtered out by the specified --domain-filter", ep.DNSName)
+			continue
+		}
+
+		r.AddRecord(ep)
+	}
+	for _, ep := range changes.UpdateNew {
+
+		if !r.domainFilter.Match(ep.DNSName) {
+			log.Debugf("Skipping record %s because it was filtered out by the specified --domain-filter", ep.DNSName)
+			continue
+		}
+
+		r.UpdateRecord(ep)
+	}
+	for _, ep := range changes.Delete {
+
+		if !r.domainFilter.Match(ep.DNSName) {
+			log.Debugf("Skipping record %s because it was filtered out by the specified --domain-filter", ep.DNSName)
+			continue
+		}
+
+		r.RemoveRecord(ep)
+	}
+	
+	return nil
+}
+
+func (r rfc2136Provider) UpdateRecord(ep *endpoint.Endpoint) error {
+	err := r.RemoveRecord(ep)
+	if err != nil {
+		return err
+	}
+
+	return r.AddRecord(ep)
+}
+
+func (r rfc2136Provider) AddRecord(ep *endpoint.Endpoint) error {
+	log.Debugf("AddRecord.ep=%s", ep)
+
+	newRR := fmt.Sprintf("%s %d %s %s", ep.DNSName, ep.RecordTTL, ep.RecordType, ep.Targets)
+	log.Debugf("Adding RR: %s", newRR)
+
+	rr, err := dns.NewRR(newRR)
+	if err != nil {
+		return fmt.Errorf("Failed to build RR: %v", err)
+	}
+
+	rrs := make([]dns.RR, 1)
+	rrs[0] = rr
+
+	m := new(dns.Msg)
+	m.SetUpdate(r.zoneName)
+	m.Insert(rrs)
+
+	err = r.SendMessage(m)
+	if err != nil {
+		return fmt.Errorf("RFC2136 query failed: %v", err)
+	}
+
+	return nil
+}
+
+func (r rfc2136Provider) RemoveRecord(ep *endpoint.Endpoint) error {
+	log.Debugf("RemoveRecord.ep=%s", ep)
+
+	newRR := fmt.Sprintf("%s 0 %s 0.0.0.0", ep.DNSName, ep.RecordType)
+	log.Debugf("Adding RR: %s", newRR)
+
+	rr, err := dns.NewRR(newRR)
+	if err != nil {
+		return fmt.Errorf("Failed to build RR: %v", err)
+	}
+
+	rrs := make([]dns.RR, 1)
+	rrs[0] = rr
+
+	m := new(dns.Msg)
+	m.SetUpdate(r.zoneName)
+	m.RemoveRRset(rrs)
+
+	err = r.SendMessage(m)
+	if err != nil {
+		return fmt.Errorf("RFC2136 query failed: %v", err)
+	}
+
+	return nil
+}
+
+func (r rfc2136Provider) SendMessage(msg *dns.Msg) error {
+	if !r.dryRun {
+		log.Debugf("SendMessage")
+	} else {
+		log.Debugf("SendMessage.skipped")
+		return nil
+	}
+
+	c := new(dns.Client)
+	c.SingleInflight = true
+
+	if !r.insecure {
+		c.TsigSecret = map[string]string{r.tsigKeyName: r.tsigSecret}
+		msg.SetTsig(r.tsigKeyName, dns.HmacMD5, 300, time.Now().Unix())
+	}
+
+	resp, _, err := c.Exchange(msg, r.nameserver)
+	if err != nil {
+		log.Infof("error in dns.Client.Exchange: %s", err)
+		return err
+	}
+	if resp != nil && resp.Rcode != dns.RcodeSuccess {
+		log.Infof("Bad dns.Client.Exchange response: %s", resp)
+		return fmt.Errorf("Bad return code: %s", dns.RcodeToString[resp.Rcode])
+	}
+
+	log.Debugf("SendMessage.success")
+	return nil
+}

--- a/provider/rfc2136.go
+++ b/provider/rfc2136.go
@@ -17,8 +17,8 @@ limitations under the License.
 package provider
 
 import (
-	"net"
 	"fmt"
+	"net"
 	"strconv"
 	"time"
 
@@ -185,7 +185,7 @@ func (r rfc2136Provider) ApplyChanges(changes *plan.Changes) error {
 
 		r.RemoveRecord(ep)
 	}
-	
+
 	return nil
 }
 


### PR DESCRIPTION
Adds initial support for RFC2136 dynamic DNS updates.

Fixes #510 

Based on https://github.com/rancher/external-dns/blob/master/providers/rfc2136/rfc2136.go
(https://github.com/rancher/external-dns/blob/master/LICENSE)