### PR TITLE
Fix for empty target annotation.

### DIFF
--- a/source/ingress.go
+++ b/source/ingress.go
@@ -132,7 +132,7 @@ func getTargetsFromTargetAnnotation(ing *v1beta1.Ingress) endpoint.Targets {
 
 	// Get the desired hostname of the ingress from the annotation.
 	targetAnnotation, exists := ing.Annotations[targetAnnotationKey]
-	if exists {
+	if exists && targetAnnotation != "" {
 		// splits the hostname annotation and removes the trailing periods
 		targetsList := strings.Split(strings.Replace(targetAnnotation, " ", "", -1), ",")
 		for _, targetHostname := range targetsList {

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -870,6 +870,24 @@ func testIngressEndpoints(t *testing.T) {
 			},
 			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
 		},
+		{
+			title:           "Ingress with empty annotation",
+			targetNamespace: "",
+			ingressItems: []fakeIngress{
+				{
+					name:      "fake1",
+					namespace: namespace,
+					annotations: map[string]string{
+						targetAnnotationKey: "",
+					},
+					dnsnames:  []string{},
+					ips:       []string{},
+					hostnames: []string{},
+				},
+			},
+			expected:     []*endpoint.Endpoint{},
+			fqdnTemplate: "{{.Name}}.ext-dns.test.com",
+		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 			ingresses := make([]*v1beta1.Ingress, 0)


### PR DESCRIPTION
If a user mistakenly enters a empty target annotation today, it causes any new records or updates to records to stop with the following error on AWS Route53:

`time="2018-07-26T06:20:16Z" level=error msg="InvalidChangeBatch: Invalid Resource Record: FATAL problem: DomainNameEmpty (Domain name is empty) encountered with ''\n\tstatus code: 400, request id: f6a2b9a4-909b-11e8-b1ae-fbaf69c94a56"`

This ensures that an empty target annotation is treaded the same way as an unset target annotation.