### PR TITLE
Add filter by service type feature

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,6 +75,7 @@ func main() {
 		PublishInternal:          cfg.PublishInternal,
 		PublishHostIP:            cfg.PublishHostIP,
 		ConnectorServer:          cfg.ConnectorSourceServer,
+		ServiceTypeFilter:        cfg.ServiceTypeFilter,
 	}
 
 	// Lookup all the selected sources by names and pass them the desired configuration.

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -91,6 +91,7 @@ type Config struct {
 	ExoscaleEndpoint         string
 	ExoscaleAPIKey           string
 	ExoscaleAPISecret        string
+	ServiceTypeFilter        []string
 }
 
 var defaultConfig = &Config{
@@ -144,6 +145,7 @@ var defaultConfig = &Config{
 	ExoscaleEndpoint:         "https://api.exoscale.ch/dns",
 	ExoscaleAPIKey:           "",
 	ExoscaleAPISecret:        "",
+	ServiceTypeFilter:        []string{},
 }
 
 // NewConfig returns new Config object
@@ -197,6 +199,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("publish-internal-services", "Allow external-dns to publish DNS records for ClusterIP services (optional)").BoolVar(&cfg.PublishInternal)
 	app.Flag("publish-host-ip", "Allow external-dns to publish host-ip for headless services (optional)").BoolVar(&cfg.PublishHostIP)
 	app.Flag("connector-source-server", "The server to connect for connector source, valid only when using connector source").Default(defaultConfig.ConnectorSourceServer).StringVar(&cfg.ConnectorSourceServer)
+	app.Flag("service-type-filter", "The service types to take care about (default: all, expected: ClusterIP, NodePort, LoadBalancer or ExternalName)").StringsVar(&cfg.ServiceTypeFilter)
 
 	// Flags related to providers
 	app.Flag("provider", "The DNS provider where the DNS records will be created (required, options: aws, aws-sd, google, azure, cloudflare, digitalocean, dnsimple, infoblox, dyn, designate, coredns, skydns, inmemory, pdns, oci, exoscale, linode)").Required().PlaceHolder("provider").EnumVar(&cfg.Provider, "aws", "aws-sd", "google", "azure", "cloudflare", "digitalocean", "dnsimple", "infoblox", "dyn", "designate", "coredns", "skydns", "inmemory", "pdns", "oci", "exoscale", "linode")

--- a/source/store.go
+++ b/source/store.go
@@ -44,6 +44,7 @@ type Config struct {
 	PublishInternal          bool
 	PublishHostIP            bool
 	ConnectorServer          string
+	ServiceTypeFilter        []string
 }
 
 // ClientGenerator provides clients
@@ -92,7 +93,7 @@ func BuildWithConfig(source string, p ClientGenerator, cfg *Config) (Source, err
 		if err != nil {
 			return nil, err
 		}
-		return NewServiceSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP)
+		return NewServiceSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP, cfg.ServiceTypeFilter)
 	case "ingress":
 		client, err := p.KubeClient()
 		if err != nil {


### PR DESCRIPTION
This PR adds a flag allowing users to provide a list of service types to take care about. Non-listed service types are ignored by external-dns. If no list is provided, all service types are selected.