### PR TITLE
Configure req timeout calling k8s APIs

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,8 +79,9 @@ func main() {
 
 	// Lookup all the selected sources by names and pass them the desired configuration.
 	sources, err := source.ByNames(&source.SingletonClientGenerator{
-		KubeConfig: cfg.KubeConfig,
-		KubeMaster: cfg.Master,
+		KubeConfig:     cfg.KubeConfig,
+		KubeMaster:     cfg.Master,
+		RequestTimeout: cfg.RequestTimeout,
 	}, cfg.Sources, sourceCfg)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -38,6 +38,7 @@ var (
 type Config struct {
 	Master                   string
 	KubeConfig               string
+	RequestTimeout           time.Duration
 	Sources                  []string
 	Namespace                string
 	AnnotationFilter         string
@@ -95,6 +96,7 @@ type Config struct {
 var defaultConfig = &Config{
 	Master:                   "",
 	KubeConfig:               "",
+	RequestTimeout:           time.Second * 30,
 	Sources:                  nil,
 	Namespace:                "",
 	AnnotationFilter:         "",
@@ -183,6 +185,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	// Flags related to Kubernetes
 	app.Flag("master", "The Kubernetes API server to connect to (default: auto-detect)").Default(defaultConfig.Master).StringVar(&cfg.Master)
 	app.Flag("kubeconfig", "Retrieve target cluster configuration from a Kubernetes configuration file (default: auto-detect)").Default(defaultConfig.KubeConfig).StringVar(&cfg.KubeConfig)
+	app.Flag("request-timeout", "Request timeout when calling Kubernetes APIs. 0s means no timeout").Default(defaultConfig.RequestTimeout.String()).DurationVar(&cfg.RequestTimeout)
 
 	// Flags related to processing sources
 	app.Flag("source", "The resource types that are queried for endpoints; specify multiple times for multiple sources (required, options: service, ingress, fake, connector)").Required().PlaceHolder("source").EnumsVar(&cfg.Sources, "service", "ingress", "fake", "connector")

--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -31,6 +31,7 @@ var (
 	minimalConfig = &Config{
 		Master:                  "",
 		KubeConfig:              "",
+		RequestTimeout:          time.Second * 30,
 		Sources:                 []string{"service"},
 		Namespace:               "",
 		FQDNTemplate:            "",
@@ -76,6 +77,7 @@ var (
 	overriddenConfig = &Config{
 		Master:                  "http://127.0.0.1:8080",
 		KubeConfig:              "/some/path",
+		RequestTimeout:          time.Second * 77,
 		Sources:                 []string{"service", "ingress", "connector"},
 		Namespace:               "namespace",
 		FQDNTemplate:            "{{.Name}}.service.example.com",
@@ -144,6 +146,7 @@ func TestParseFlags(t *testing.T) {
 			args: []string{
 				"--master=http://127.0.0.1:8080",
 				"--kubeconfig=/some/path",
+				"--request-timeout=77s",
 				"--source=service",
 				"--source=ingress",
 				"--source=connector",
@@ -203,6 +206,7 @@ func TestParseFlags(t *testing.T) {
 			envVars: map[string]string{
 				"EXTERNAL_DNS_MASTER":                     "http://127.0.0.1:8080",
 				"EXTERNAL_DNS_KUBECONFIG":                 "/some/path",
+				"EXTERNAL_DNS_REQUEST_TIMEOUT":            "77s",
 				"EXTERNAL_DNS_SOURCE":                     "service\ningress\nconnector",
 				"EXTERNAL_DNS_NAMESPACE":                  "namespace",
 				"EXTERNAL_DNS_FQDN_TEMPLATE":              "{{.Name}}.service.example.com",

--- a/provider/google.go
+++ b/provider/google.go
@@ -143,10 +143,10 @@ func NewGoogleProvider(project string, domainFilter DomainFilter, zoneIDFilter Z
 	}
 
 	provider := &GoogleProvider{
-		project:                  project,
-		domainFilter:             domainFilter,
-		zoneIDFilter:             zoneIDFilter,
-		dryRun:                   dryRun,
+		project:      project,
+		domainFilter: domainFilter,
+		zoneIDFilter: zoneIDFilter,
+		dryRun:       dryRun,
 		resourceRecordSetsClient: resourceRecordSetsService{dnsClient.ResourceRecordSets},
 		managedZonesClient:       managedZonesService{dnsClient.ManagedZones},
 		changesClient:            changesService{dnsClient.Changes},

--- a/provider/google_test.go
+++ b/provider/google_test.go
@@ -569,10 +569,10 @@ func validateChangeRecord(t *testing.T, record *dns.ResourceRecordSet, expected 
 
 func newGoogleProvider(t *testing.T, domainFilter DomainFilter, zoneIDFilter ZoneIDFilter, dryRun bool, records []*endpoint.Endpoint) *GoogleProvider {
 	provider := &GoogleProvider{
-		project:                  "zalando-external-dns-test",
-		domainFilter:             domainFilter,
-		zoneIDFilter:             zoneIDFilter,
-		dryRun:                   false,
+		project:      "zalando-external-dns-test",
+		domainFilter: domainFilter,
+		zoneIDFilter: zoneIDFilter,
+		dryRun:       false,
 		resourceRecordSetsClient: &mockResourceRecordSetsClient{},
 		managedZonesClient:       &mockManagedZonesClient{},
 		changesClient:            &mockChangesClient{},


### PR DESCRIPTION
When running in a pod sometimes the request to get ingreses/services
stalls indefinitely. A simple pod restart fixes this. Hard to reproduce
but I got lucky and did thread dump which revealed a gorouting blocked
on call to k8s.

What's new is a `--request-timeout` flag that makes requests to k8s
bounded in time. Leaving it empty preserves the original behavior.