### PR TITLE
Fix Host field in HTTP request when using pdns provider

### DIFF
--- a/provider/pdns.go
+++ b/provider/pdns.go
@@ -231,7 +231,6 @@ func NewPDNSProvider(config PDNSConfig) (*PDNSProvider, error) {
 	}
 
 	pdnsClientConfig := pgo.NewConfiguration()
-	pdnsClientConfig.Host = config.Server
 	pdnsClientConfig.BasePath = config.Server + apiBase
 	if err := config.TLSConfig.setHTTPClient(pdnsClientConfig); err != nil {
 		return nil, err


### PR DESCRIPTION
The Host field of the HTTP request is set incorrectly when passing
the configured server.  The underlying HTTP library experts a hostname
to be passed.  When passing it a string of the form 'http://pdns.example.com'
this gets converted into 'http:' (stripping everything from the first
slash onward).  However setting the Host field in the pdnsClientConfig
object is not needed because the underlying library will then parse the
hostname from the URL.

Fixes #661

Signed-off-by: Bartel Sielski <bartel.sielski@gmail.com>