### PR TITLE
Pass all relevant CLI flags to AWS provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,13 +107,14 @@ func main() {
 	case "aws":
 		p, err = provider.NewAWSProvider(
 			provider.AWSConfig{
-				DomainFilter:        domainFilter,
-				ZoneIDFilter:        zoneIDFilter,
-				ZoneTypeFilter:      zoneTypeFilter,
-				BatchChangeSize:     cfg.AWSBatchChangeSize,
-				BatchChangeInterval: cfg.AWSBatchChangeInterval,
-				AssumeRole:          cfg.AWSAssumeRole,
-				DryRun:              cfg.DryRun,
+				DomainFilter:         domainFilter,
+				ZoneIDFilter:         zoneIDFilter,
+				ZoneTypeFilter:       zoneTypeFilter,
+				BatchChangeSize:      cfg.AWSBatchChangeSize,
+				BatchChangeInterval:  cfg.AWSBatchChangeInterval,
+				EvaluateTargetHealth: cfg.AWSEvaluateTargetHealth,
+				AssumeRole:           cfg.AWSAssumeRole,
+				DryRun:               cfg.DryRun,
 			},
 		)
 	case "aws-sd":


### PR DESCRIPTION
Partial fix for https://github.com/kubernetes-incubator/external-dns/issues/718

This avoids spreading new records with a possible wrong value for `EvaluateTargetHealth`. For already affected clusters we would need to fix https://github.com/kubernetes-incubator/external-dns/issues/720.

/cc @muaazsaleem @njuettner @peterbale 