### PR TITLE
Correctly populate target health check on existing records

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -151,8 +151,21 @@ func NewEndpointWithTTL(dnsName, recordType string, ttl TTL, targets ...string) 
 	}
 }
 
+// WithProviderSpecific attaches a key/value pair to the Endpoint and returns the Endpoint.
+// This can be used to pass additional data through the stages of ExternalDNS's Endpoint processing.
+// The assumption is that most of the time this will be provider specific metadata that doesn't
+// warrant its own field on the Endpoint object itself. It differs from Labels in the fact that it's
+// not persisted in the Registry but only kept in memory during a single record synchronization.
+func (e *Endpoint) WithProviderSpecific(key, value string) *Endpoint {
+	if e.ProviderSpecific == nil {
+		e.ProviderSpecific = ProviderSpecific{}
+	}
+	e.ProviderSpecific[key] = value
+	return e
+}
+
 func (e *Endpoint) String() string {
-	return fmt.Sprintf("%s %d IN %s %s", e.DNSName, e.RecordTTL, e.RecordType, e.Targets)
+	return fmt.Sprintf("%s %d IN %s %s %s", e.DNSName, e.RecordTTL, e.RecordType, e.Targets, e.ProviderSpecific)
 }
 
 // DNSEndpointSpec defines the desired state of DNSEndpoint

--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -48,7 +48,8 @@ func (b byAllFields) Less(i, j int) bool {
 func SameEndpoint(a, b *endpoint.Endpoint) bool {
 	return a.DNSName == b.DNSName && a.Targets.Same(b.Targets) && a.RecordType == b.RecordType &&
 		a.Labels[endpoint.OwnerLabelKey] == b.Labels[endpoint.OwnerLabelKey] && a.RecordTTL == b.RecordTTL &&
-		a.Labels[endpoint.ResourceLabelKey] == b.Labels[endpoint.ResourceLabelKey]
+		a.Labels[endpoint.ResourceLabelKey] == b.Labels[endpoint.ResourceLabelKey] &&
+		SameMap(a.ProviderSpecific, b.ProviderSpecific)
 }
 
 // SameEndpoints compares two slices of endpoints regardless of order
@@ -78,4 +79,19 @@ func SameEndpoints(a, b []*endpoint.Endpoint) bool {
 func SamePlanChanges(a, b map[string][]*endpoint.Endpoint) bool {
 	return SameEndpoints(a["Create"], b["Create"]) && SameEndpoints(a["Delete"], b["Delete"]) &&
 		SameEndpoints(a["UpdateOld"], b["UpdateOld"]) && SameEndpoints(a["UpdateNew"], b["UpdateNew"])
+}
+
+// SameMap verifies that two maps contain the same string/string key/value pairs
+func SameMap(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for k, v := range a {
+		if v != b[k] {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/testutils/endpoint_test.go
+++ b/internal/testutils/endpoint_test.go
@@ -55,16 +55,22 @@ func ExampleSameEndpoints() {
 			RecordType: "CNAME",
 			RecordTTL:  endpoint.TTL(60),
 		},
+		{
+			DNSName:          "example.org",
+			Targets:          endpoint.Targets{"load-balancer.org"},
+			ProviderSpecific: endpoint.ProviderSpecific{"foo": "bar"},
+		},
 	}
 	sort.Sort(byAllFields(eps))
 	for _, ep := range eps {
 		fmt.Println(ep)
 	}
 	// Output:
-	// abc.com 0 IN A 1.2.3.4
-	// abc.com 0 IN TXT something
-	// bbc.com 0 IN CNAME foo.com
-	// cbc.com 60 IN CNAME foo.com
-	// example.org 0 IN  load-balancer.org
-	// example.org 0 IN TXT load-balancer.org
+	// abc.com 0 IN A 1.2.3.4 map[]
+	// abc.com 0 IN TXT something map[]
+	// bbc.com 0 IN CNAME foo.com map[]
+	// cbc.com 60 IN CNAME foo.com map[]
+	// example.org 0 IN  load-balancer.org map[]
+	// example.org 0 IN  load-balancer.org map[foo:bar]
+	// example.org 0 IN TXT load-balancer.org map[]
 }


### PR DESCRIPTION
This is a fix for https://github.com/kubernetes-incubator/external-dns/issues/720.

It uses the `ProviderSpecific` field of `Endpoint` to capture the value of `EvaluateTargetHealth` on existing ALIAS records in `provider.Records()`. It allows it to correctly delete those records in a later stage (`provider.ApplyChanges`).

For new records it uses the value of the `--aws-evaluate-target-health` flag.