### PR TITLE
Document how to use a different security context

### DIFF
--- a/docs/tutorials/security-context.md
+++ b/docs/tutorials/security-context.md
@@ -1,0 +1,32 @@
+# Running ExternalDNS with limited privileges
+
+You can run ExternalDNS with reduced privileges since `v0.5.6` using the following `SecurityContext`.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:v0.5.6 # minimum version is v0.5.6
+        args:
+        - ... # your arguments here
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65534
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+```


### PR DESCRIPTION
Document how to run ExternalDNS with reduced privileges.

related https://github.com/kubernetes-incubator/external-dns/issues/595 https://github.com/kubernetes-incubator/external-dns/pull/684