### PR TITLE
Support multi architecture for binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,20 @@
 # builder image
 FROM golang as builder
 
+ARG GOARCH
+
 WORKDIR /go/src/github.com/kubernetes-incubator/external-dns
 COPY . .
 RUN make dep
 RUN make test
-RUN make build
+RUN GOARCH=${GOARCH} make build
 
 # final image
 FROM registry.opensource.zalan.do/stups/alpine:latest
 MAINTAINER Team Teapot @ Zalando SE <team-teapot@zalando.de>
 
-COPY --from=builder /go/src/github.com/kubernetes-incubator/external-dns/build/external-dns /bin/external-dns
+ARG GOARCH
+
+COPY --from=builder /go/src/github.com/kubernetes-incubator/external-dns/build/external-dns-${GOARCH} /bin/external-dns
 
 ENTRYPOINT ["/bin/external-dns"]

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ dep:
 .PHONY: verify test
 
 test:
-	go test -v -race $(shell go list ./... | grep -v /vendor/)
+	go test -v $(shell go list ./... | grep -v /vendor/)
 
 verify: test
 	vendor/github.com/kubernetes/repo-infra/verify/verify-boilerplate.sh --rootdir=${CURDIR}

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build.push: build.docker
 	docker push "$(IMAGE):$(VERSION)"
 
 build.docker:
-	docker build --rm --tag "$(IMAGE):$(VERSION)" .
+	docker build --build-arg GOARCH=$(GOARCH) --rm --tag "$(IMAGE):$(VERSION)" .
 
 clean:
 	@rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ verify: test
 # The build targets allow to build the binary and docker image
 .PHONY: build build.docker
 
-BINARY        ?= external-dns
+GOARCH        ?= amd64
+BINARY        ?= external-dns-$(GOARCH)
 SOURCES        = $(shell find . -name '*.go')
 IMAGE         ?= registry.opensource.zalan.do/teapot/$(BINARY)
 VERSION       ?= $(shell git describe --tags --always --dirty)


### PR DESCRIPTION
Specify GOARCH to build a binary : 

```bash
$ make
$ make GOARCH=arm64
$ ls build/
external-dns-amd64  external-dns-arm64
```

Signed-off-by: Nicolas Lamirault <nicolas.lamirault@gmail.com>