### PR TITLE
Fix domain-filter matching logic to not match similar domain names

### DIFF
--- a/provider/domain_filter.go
+++ b/provider/domain_filter.go
@@ -46,8 +46,17 @@ func (df DomainFilter) Match(domain string) bool {
 	}
 
 	for _, filter := range df.filters {
+		strippedDomain := strings.TrimSuffix(domain, ".")
 
-		if strings.HasSuffix(strings.TrimSuffix(domain, "."), filter) {
+		if filter == "" {
+			return true
+		} else if strings.HasPrefix(filter, ".") && strings.HasSuffix(strippedDomain, filter) {
+			return true
+		} else if strings.Count(strippedDomain, ".") == strings.Count(filter, ".") {
+			if strippedDomain == filter {
+				return true
+			}
+		} else if strings.HasSuffix(strippedDomain, "."+filter) {
 			return true
 		}
 	}

--- a/provider/domain_filter_test.go
+++ b/provider/domain_filter_test.go
@@ -99,6 +99,36 @@ var domainFilterTests = []domainFilterTest{
 		[]string{"foo.bar.sub.example.org"},
 		true,
 	},
+	{
+		[]string{"example.org"},
+		[]string{"anexample.org", "test.anexample.org"},
+		false,
+	},
+	{
+		[]string{".example.org"},
+		[]string{"anexample.org", "test.anexample.org"},
+		false,
+	},
+	{
+		[]string{".example.org"},
+		[]string{"example.org"},
+		false,
+	},
+	{
+		[]string{".example.org"},
+		[]string{"test.example.org"},
+		true,
+	},
+	{
+		[]string{"anexample.org"},
+		[]string{"example.org", "test.example.org"},
+		false,
+	},
+	{
+		[]string{".org"},
+		[]string{"example.org", "test.example.org", "foo.test.example.org"},
+		true,
+	},
 }
 
 func TestDomainFilterMatch(t *testing.T) {


### PR DESCRIPTION
While working on PowerDNS domain filter integration and writing test cases, I ran into an issue where domain filters were being applied to non-related zones.

During testing, anexample.org was being matched to a Domain Filter of example.org specified by the user. These are distinct domain names and the expectation is that they should not be considered the same.

Providers that manipulate DNS entries based off of zones rely on this expectation/assumption to make the right decision on which zone to manipulate.

As well, I added additional test coverage around domain filters with "." prefixes to capture what I've seen other provider (eg. Linode) integrations test for, and also how people use domain filters in the field. 