### PR TITLE
Fix nil map access of endpoint labels

### DIFF
--- a/registry/txt.go
+++ b/registry/txt.go
@@ -98,13 +98,11 @@ func (im *TXTRegistry) Records() ([]*endpoint.Endpoint, error) {
 	}
 
 	for _, ep := range endpoints {
+		ep.Labels = endpoint.NewLabels()
 		if labels, ok := labelMap[ep.DNSName]; ok {
 			for k, v := range labels {
 				ep.Labels[k] = v
 			}
-		} else {
-			//this indicates that owner could not be identified, as there is no corresponding TXT record
-			ep.Labels = endpoint.NewLabels()
 		}
 	}
 


### PR DESCRIPTION
We are seeing crash in latest code as below
```
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/kubernetes-incubator/external-dns/registry.(*TXTRegistry).Records(0xc0001025b0, 0xc000000300, 0xc0006ed828, 0xc0004ca8a0, 0xc0004ca8a0, 0xc0006ed828)
	/go/src/github.com/kubernetes-incubator/external-dns/registry/txt.go:103 +0x49a
github.com/kubernetes-incubator/external-dns/controller.(*Controller).RunOnce(0xc0004c0b80, 0xc0006ed7f8, 0x2)
	/go/src/github.com/kubernetes-incubator/external-dns/controller/controller.go:67 +0x49
github.com/kubernetes-incubator/external-dns/controller.(*Controller).Run(0xc0004c0b80, 0xc000086960)
	/go/src/github.com/kubernetes-incubator/external-dns/controller/controller.go:100 +0x84
main.main()
	/go/src/github.com/kubernetes-incubator/external-dns/main.go:240 +0xb0e
```

probably this was introduced by https://github.com/kubernetes-incubator/external-dns/pull/713 

/cc @njuettner @linki 