### PR TITLE
Support SRV Records For Services

### DIFF
--- a/docs/srv.md
+++ b/docs/srv.md
@@ -1,0 +1,41 @@
+# Configure Service Discovery
+
+An optional annotation `external-dns.alpha.kubernetes.io/service` may be added to a service that has an `external-dns.alpha.kubernetes.io/hostname` annotation.
+
+When a service is configured with a hostname e.g. `ldap0.example.com`, a service annotation will cause an SRV record to be created pointing to that hostname.  The SRV record weight, priority and port are all configurable via the annotation.
+
+In order to configure this functionality, an example Service manifest would look like the following:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: ldap0.example.com
+    external-dns.alpha.kubernetes.io/service: _ldaps._tcp.example.com 0 0 636
+```
+
+The fields of the `external-dns.alpha.kubernetes.io/service` annotation are separated by white space and are described as follows:
+
+1. SRV record DNS name, including the service name, protocol and domain (string)
+2. Priority of the record (integer)
+3. Weight of the record (integer)
+4. Port of the service (integer)
+
+## Providers
+
+- [ ] AWS (Route53)
+- [ ] Azure
+- [x] Cloudflare
+- [ ] DigitalOcean
+- [ ] Google
+- [ ] InMemory
+- [ ] Linode
+
+## Implementation Details
+
+The DNS planner uses a map internally to aggregate A record targets and select a target, as they can only have a single definition.  With record types such as SRV, MX, NS, etc. records the DNS allows multiple records for the same name.  In order to support this we create a new list based planner which takes into account both name and target to make decisions.  This is used for records that support multiple records for the same name.
+
+The registries need to be aware that multiple records can exist for a single endpoint.  To solve this instead of maintaining a map from name to labels, we maintain a list.  When looking up a matching endpoint we also match on the target (for types that allow multiple records).  The target is encoded as `target` for this purpose.  For example `external-dns/target=0 0 636 ldap0.example.com` can be used to uniquely identify a matching endpoint.
+
+The provisioners likewise must check the entire record for a match and not just the DNS name, as the priority, weight, port and target are relevant.  Additionally when handling registry TXT entries related to managed records they must also be able to uniquely identify the record corresponding to the related resource.

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -168,6 +168,15 @@ func (e *Endpoint) String() string {
 	return fmt.Sprintf("%s %d IN %s %s %s", e.DNSName, e.RecordTTL, e.RecordType, e.Targets, e.ProviderSpecific)
 }
 
+// HasNonUniqueRecords tells us whether the endpoint type can have multiple records.
+func (e *Endpoint) HasNonUniqueRecords() bool {
+	switch e.RecordType {
+	case RecordTypeSRV:
+		return true
+	}
+	return false
+}
+
 // DNSEndpointSpec defines the desired state of DNSEndpoint
 type DNSEndpointSpec struct {
 	Endpoints []*Endpoint `json:"endpoints,omitempty"`

--- a/endpoint/labels.go
+++ b/endpoint/labels.go
@@ -38,6 +38,9 @@ const (
 	// AWSSDDescriptionLabel label responsible for storing raw owner/resource combination information in the Labels
 	// supposed to be inserted by AWS SD Provider, and parsed into OwnerLabelKey and ResourceLabelKey key by AWS SD Registry
 	AWSSDDescriptionLabel = "aws-sd-description"
+
+	// TargetLabel is used to disabiguate registry entries for resources that may have multiple records e.g. SRV and MX
+	TargetLabel = "target"
 )
 
 // Labels store metadata related to the endpoint
@@ -100,4 +103,14 @@ func (l Labels) Serialize(withQuotes bool) string {
 		return fmt.Sprintf("\"%s\"", strings.Join(tokens, ","))
 	}
 	return strings.Join(tokens, ",")
+}
+
+// HasNonUniqueRecords tells us whether the DNS name is not necessarily unique.  This means
+// that the DNS name and the target data together in order to uniquely identify a record
+// that shares the same name e.g. SRV, MX, etc.  Returns the target if true.
+func (l Labels) HasNonUniqueRecords() (bool, string) {
+	if target, ok := l[TargetLabel]; ok {
+		return true, target
+	}
+	return false, ""
 }

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -913,6 +913,30 @@ func testServiceSourceEndpoints(t *testing.T) {
 			[]*endpoint.Endpoint{},
 			false,
 		},
+		{
+			"create srv records for hostnames",
+			"",
+			"",
+			"testing",
+			"foo",
+			v1.ServiceTypeLoadBalancer,
+			"",
+			"",
+			false,
+			map[string]string{},
+			map[string]string{
+				hostnameAnnotationKey: "foo.bar.example.org.",
+				serviceAnnotationKey:  "_http._tcp.bar.example.org 0 50 443",
+			},
+			"",
+			[]string{"1.2.3.4"},
+			[]string{string(v1.ServiceTypeLoadBalancer)},
+			[]*endpoint.Endpoint{
+				{DNSName: "foo.bar.example.org", Targets: endpoint.Targets{"1.2.3.4"}, RecordTTL: endpoint.TTL(0)},
+				{DNSName: "_http._tcp.bar.example.org", Targets: endpoint.Targets{"0 50 443 foo.bar.example.org"}, RecordType: endpoint.RecordTypeSRV},
+			},
+			false,
+		},
 	} {
 		t.Run(tc.title, func(t *testing.T) {
 			// Create a Kubernetes testing client

--- a/source/source.go
+++ b/source/source.go
@@ -35,6 +35,8 @@ const (
 	targetAnnotationKey = "external-dns.alpha.kubernetes.io/target"
 	// The annotation used for defining the desired DNS record TTL
 	ttlAnnotationKey = "external-dns.alpha.kubernetes.io/ttl"
+	// The annotation used for defining the SRV record to add the hostname to
+	serviceAnnotationKey = "external-dns.alpha.kubernetes.io/service"
 	// The value of the controller annotation so that we feel responsible
 	controllerAnnotationValue = "dns-controller"
 )
@@ -72,6 +74,17 @@ func getHostnamesFromAnnotations(annotations map[string]string) []string {
 	}
 
 	return strings.Split(strings.Replace(hostnameAnnotation, " ", "", -1), ",")
+}
+
+// getServicesFromAnnotations extracts services from resource annotations.  The format is
+// expected to be "_service._proto.domain priority weight port[, ...]"
+func getServicesFromAnnotations(annotations map[string]string) []string {
+	serviceAnnotation, exists := annotations[serviceAnnotationKey]
+	if !exists {
+		return nil
+	}
+
+	return strings.Split(serviceAnnotation, ",")
 }
 
 // getTargetsFromTargetAnnotation gets endpoints from optional "target" annotation.

--- a/srv/srv.go
+++ b/srv/srv.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package srv
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// DummyTarget is used as an SRV target as records are passed around as
+	// composite DNS names, where the target is encoded in the DNS name
+	DummyTarget = "dummy"
+)
+
+// Name holds SRV name specific fields.
+type Name struct {
+	// Service name e.g. _http.
+	Service string
+	// Protocol name e.g. _tcp.
+	Proto string
+	// DNS Domain name.
+	Name string
+}
+
+// ParseName accepts a name in the for _service._proto.domain and
+// unmarshalls into a Name.
+func ParseName(name string) Name {
+	parts := strings.Split(name, ".")
+	return Name{
+		Service: parts[0],
+		Proto:   parts[1],
+		Name:    strings.Join(parts[2:], "."),
+	}
+}
+
+// Format returns the stringified version of a Name.
+func (s Name) Format() string {
+	return fmt.Sprintf("%s.%s.%s", s.Service, s.Proto, s.Name)
+}
+
+// Target holds SRV target specific fields.
+type Target struct {
+	// Priority is the priority with which a record will be considered by a client.
+	Priority int
+	// Weight is the weight of requests as issued by a client.
+	Weight int
+	// Port is the port number the service can be dialed.
+	Port int
+	// Target is the DNS record that this target refers to.
+	Target string
+}
+
+// ParseTarget takes an endpoint target string and unmarshals into an SRV record.
+func ParseTarget(target string) Target {
+	s := Target{}
+	fmt.Sscanf(target, "%d %d %d %s", &s.Priority, &s.Weight, &s.Port, &s.Target)
+	return s
+}
+
+// Format takes an SRV record and formats an endpoint target string.
+func (s Target) Format() string {
+	return fmt.Sprintf("%d %d %d %s", s.Priority, s.Weight, s.Port, s.Target)
+}
+
+// Record allows SRV record names and targets to be manipulated in
+// supported providers.
+type Record struct {
+	Name   Name
+	Target Target
+}
+
+// ParseRecord decodes a DNS name into an SRV record for providers.
+func ParseRecord(name, target string) Record {
+	return Record{
+		Name:   ParseName(name),
+		Target: ParseTarget(target),
+	}
+}
+
+// ParseAnnotation creates an SRV record based on an SRV annotation.
+func ParseAnnotation(annotation string) Record {
+	var name string
+	var priority, weight, target int
+
+	fmt.Sscanf(annotation, "%s %d %d %d", &name, &priority, &weight, &target)
+
+	return Record{
+		Name: ParseName(name),
+		Target: Target{
+			Priority: priority,
+			Weight:   weight,
+			Port:     target,
+		},
+	}
+}


### PR DESCRIPTION
Addresses feature request #642
    
This allows individual load balancer services to be annotated with an SRV record annotation which references the A record created by that service.
    
As the planner aggregates records with the same name and only chooses a single target, we need a way to force it to maintain a 1:1 mapping for SRV and MX records.  To this end we have a separate handler for these record types.
    
The DNS provider and registry now need to be aware that these record types are special, and require marshaling and unmarshaling as appropriate.