### PR TITLE
Fix typos: sychronized->synchronized, resouce->resource

### DIFF
--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -285,7 +285,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("rfc2136-tsig-axfr", "When using the RFC2136 provider, specify the TSIG (base64) value to attached to DNS messages (required when --rfc2136-insecure=false)").BoolVar(&cfg.RFC2136TAXFR)
 
 	// Flags related to policies
-	app.Flag("policy", "Modify how DNS records are sychronized between sources and providers (default: sync, options: sync, upsert-only)").Default(defaultConfig.Policy).EnumVar(&cfg.Policy, "sync", "upsert-only")
+	app.Flag("policy", "Modify how DNS records are synchronized between sources and providers (default: sync, options: sync, upsert-only)").Default(defaultConfig.Policy).EnumVar(&cfg.Policy, "sync", "upsert-only")
 
 	// Flags related to the registry
 	app.Flag("registry", "The registry implementation to use to keep track of DNS record ownership (default: txt, options: txt, noop, aws-sd)").Default(defaultConfig.Registry).EnumVar(&cfg.Registry, "txt", "noop", "aws-sd")

--- a/provider/azure_test.go
+++ b/provider/azure_test.go
@@ -48,7 +48,7 @@ func createMockZone(zone string, id string) dns.Zone {
 }
 
 func (client *mockZonesClient) ListByResourceGroup(resourceGroupName string, top *int32) (dns.ZoneListResult, error) {
-	// Don't bother filtering by resouce group or implementing paging since that's the responsibility
+	// Don't bother filtering by resource group or implementing paging since that's the responsibility
 	// of the Azure DNS service
 	return *client.mockZoneListResult, nil
 }

--- a/provider/pdns.go
+++ b/provider/pdns.go
@@ -321,7 +321,7 @@ func (p *PDNSProvider) ConvertEndpointsToZones(eps []*endpoint.Endpoint, changet
 						return nil, errors.New("Value of record TTL overflows, limited to int32")
 					}
 					if ep.RecordTTL == 0 {
-						// No TTL was sepecified for the record, we use the default
+						// No TTL was specified for the record, we use the default
 						rrset.Ttl = int32(defaultTTL)
 					} else {
 						rrset.Ttl = int32(ep.RecordTTL)


### PR DESCRIPTION
Fix typos: 

1. sychronized->synchronized
2. resouce->resource
3. sepecified-specified