### PR TITLE
Adding a flag for splitting log output (--log-splitting) 

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,10 +37,10 @@ import (
 	"github.com/kubernetes-incubator/external-dns/source"
 )
 
-type LogOutputSplitter struct{}
+type logOutputSplitter struct{}
 
 // Splits log output, error and fatal to stderr and the rest to stdout
-func (splitter *LogOutputSplitter) Write(p []byte) (n int, err error) {
+func (splitter *logOutputSplitter) Write(p []byte) (n int, err error) {
 	if bytes.Contains(p, []byte("level=debug")) || bytes.Contains(p, []byte("level=info")) ||
 		bytes.Contains(p, []byte("level=trace")) || bytes.Contains(p, []byte("level=warn")) {
 		return os.Stdout.Write(p)
@@ -64,7 +64,7 @@ func main() {
 	}
 
 	if cfg.LogSplitting {
-		log.SetOutput(&LogOutputSplitter{})
+		log.SetOutput(&logOutputSplitter{})
 		log.Info("Configured splitting of logs, error & fatal to stderr and the rest to stdout")
 	}
 

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -106,6 +106,7 @@ type Config struct {
 	RFC2136TSIGSecret        string
 	RFC2136TSIGSecretAlg     string
 	RFC2136TAXFR             bool
+	LogSplitting			 bool
 }
 
 var defaultConfig = &Config{
@@ -173,6 +174,7 @@ var defaultConfig = &Config{
 	RFC2136TSIGSecret:        "",
 	RFC2136TSIGSecretAlg:     "",
 	RFC2136TAXFR:             true,
+	LogSplitting:             false,
 }
 
 // NewConfig returns new Config object
@@ -302,6 +304,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("log-format", "The format in which log messages are printed (default: text, options: text, json)").Default(defaultConfig.LogFormat).EnumVar(&cfg.LogFormat, "text", "json")
 	app.Flag("metrics-address", "Specify where to serve the metrics and health check endpoint (default: :7979)").Default(defaultConfig.MetricsAddress).StringVar(&cfg.MetricsAddress)
 	app.Flag("log-level", "Set the level of logging. (default: info, options: panic, debug, info, warning, error, fatal").Default(defaultConfig.LogLevel).EnumVar(&cfg.LogLevel, allLogLevelsAsStrings()...)
+	app.Flag("log-splitting", "Splits log output, below 'error' to stdout and above & including 'error' to stderr (default: false)").BoolVar(&cfg.LogSplitting)
 
 	_, err := app.Parse(args)
 	if err != nil {

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -106,7 +106,7 @@ type Config struct {
 	RFC2136TSIGSecret        string
 	RFC2136TSIGSecretAlg     string
 	RFC2136TAXFR             bool
-	LogSplitting			 bool
+	LogSplitting             bool
 }
 
 var defaultConfig = &Config{


### PR DESCRIPTION
Fixes #772 

Basically, the issue is that `logrus` by default pipes all logs to `stderr`. This displays logs as being errors when they are actually `level=info`, etc in Google Stackdriver and DataDog.

Because of this, we are not able to have generic alerts on errors (as all lines are seen as errors). See screenshot in #772 

The simplest way to test this PR is to run the application and redirect output:

The example below will send all logs to `stderr` (the default behavior).
```
external-dns --registry txt --txt-owner-id my-cluster-id --provider google --google-project example-project --source service --once --dry-run > 1.stdout 2> 2.stderr
```

This example shows the `--log-splitting` flag
```
external-dns --registry txt --txt-owner-id my-cluster-id --provider google --google-project example-project --source service --once --log-splitting --dry-run > 1.stdout 2> 2.stderr
```

To verify it, you can just `cat 1.stdout` and `cat 2.stderr`.

References:
sirupsen/logrus#403
Azure/open-service-broker-azure#25