### PR TITLE
Updating Azure tutorial

### DIFF
--- a/docs/tutorials/azure.md
+++ b/docs/tutorials/azure.md
@@ -9,7 +9,7 @@ This tutorial uses [Azure CLI 2.0](https://docs.microsoft.com/en-us/cli/azure/in
 Azure commands and assumes that the Kubernetes cluster was created via Azure Container Services and `kubectl` commands
 are being run on an orchestration master.
 
-## Creating a Azure DNS zone
+## Creating an Azure DNS zone
 
 The Azure provider for ExternalDNS will find suitable zones for domains it manages; it will
 not automatically create zones.
@@ -34,62 +34,33 @@ If using your own domain that was registered with a third-party domain registrar
 name servers to the values in the `nameServers` field from the JSON data returned by the `az network dns zone create` command.
 Please consult your registrar's documentation on how to do that.
 
-## Creating Azure Credentials Secret
-The Azure DNS provider expects, by default, that the configuration file is at `/etc/kubernetes/azure.json`.  This can be overridden with
-the `--azure-config-file` option when starting ExternalDNS.
+## Permissions to modify DNS zone
+External-DNS needs permissions to make changes in the Azure DNS server. These permissions are defined in a Service Principal that should be made available to External-DNS as a configuration file.
 
-### Use provisioned VM configuration file
-When running within Azure (ACS or AKS), the agent and master VMs are already provisioned with the configuration file at `/etc/kubernetes/azure.json`.
+The Azure DNS provider expects, by default, that the configuration file is at `/etc/kubernetes/azure.json`.  This can be overridden with the `--azure-config-file` option when starting ExternalDNS.
 
-If you want to use the file directly, make sure that the service principal that is given there has access to contribute to the resource group containing the Azure DNS zone(s).
-
-To use the file, replace the directive
-
-```yaml
-      volumes:
-      - name: azure-config-file
-        secret:
-          secretName: azure-config-file
-```
-
-with
-
-```yaml
-      volumes:
-      - name: azure-config-file
-        hostPath:
-          path: /etc/kubernetes/azure.json
-          type: File
-```
-
-in the manifests below.
-
-### Use custom configuration file
-If you want to customize the configuration, for example because you want to use a different service principal, you have to manually create a secret.
-This is also required if the Kubernetes cluster is not hosted in Azure Container Services (ACS or AKS) and you still want to use Azure DNS.
-
-The secret should contain an object named azure.json with content similar to this:
+### Creating configuration file
+The preferred way to inject the configuration file is by using a Kubernetes secret. The secret should contain an object named azure.json with content similar to this: 
 
 ```json
 {
   "tenantId": "01234abc-de56-ff78-abc1-234567890def",
   "subscriptionId": "01234abc-de56-ff78-abc1-234567890def",
+  "resourceGroup": "MyDnsResourceGroup",
   "aadClientId": "01234abc-de56-ff78-abc1-234567890def",
   "aadClientSecret": "uKiuXeiwui4jo9quae9o",
-  "resourceGroup": "MyDnsResourceGroup",
 }
 ```
 
-You can find the `tenantId` by running `az account show` or by selecting Azure Active Directory in the Azure Portal and checking the _Directory ID_ under Properties.
+You can find the `tenantId` by running `az account show --query "tenantId"` or by selecting Azure Active Directory in the Azure Portal and checking the _Directory ID_ under Properties.
+
 You can find the `subscriptionId` by running `az account show --query "id"` or by selecting Subscriptions in the Azure Portal.
 
-To create the secret:
+The `resourceGroup` is the Resource Group created in a previous step. 
 
-```
-$ kubectl create secret generic azure-config-file --from-file=/local/path/to/azure.json
-```
+The `aadClientID` and `aaClientSecret` are assoiated with the Service Principal, that you need to create next.
 
-#### Create service principal
+### Creating service principal
 A Service Principal with a minimum access level of contribute to the resource group containing the Azure DNS zone(s) is necessary for ExternalDNS to be able to edit DNS records. This is an Azure CLI example on how to query the Azure API for the information required for the Resource Group and DNS zone you would have already created in previous steps.
 
 ```
@@ -126,7 +97,13 @@ A Service Principal with a minimum access level of contribute to the resource gr
 }
 ```
 
-#### Azure Managed Service Identity (MSI)
+Now you can create a file named 'azure.json' with values gathered above and with the structure of the example above. Use this file to create a Kubernetes secret:
+
+```
+$ kubectl create secret generic azure-config-file --from-file=/local/path/to/azure.json
+```
+
+### Azure Managed Service Identity (MSI)
 
 If [Azure Managed Service Identity (MSI)](https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview) is enabled for virtual machines, then there is no need to create separate service principal.
 
@@ -147,7 +124,6 @@ Then add the secret to the Kubernetes cluster before continuing:
 ```
 kubectl create secret generic azure-config-file --from-file=azure.json
 ```
-
 
 
 ## Deploy ExternalDNS


### PR DESCRIPTION
This PR relates to #500, so I did not think it was that great to write a new ticket (sorry for PRing out of the blue!). The main issue discribed in 500 was that /etc/kubernetes/azure.json is no longer accessible using hostPath in the external-dns container, and this makes the tutorial confusing.

Also, I made some other changes in the tutorial after having had some problems follwing it when setting up external-dns myself. These changes are mainly to make the text more readible, but changes are minor.