### PR TITLE
Expose managed resources and records as metrics

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -40,11 +40,29 @@ var (
 			Help: "Number of Source errors.",
 		},
 	)
+	sourceEndpointsTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "external_dns",
+			Subsystem: "source",
+			Name:      "endpoints_total",
+			Help:      "Number of Endpoints in all sources",
+		},
+	)
+	registryEndpointsTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "external_dns",
+			Subsystem: "registry",
+			Name:      "endpoints_total",
+			Help:      "Number of Endpoints in the registry",
+		},
+	)
 )
 
 func init() {
 	prometheus.MustRegister(registryErrors)
 	prometheus.MustRegister(sourceErrors)
+	prometheus.MustRegister(sourceEndpointsTotal)
+	prometheus.MustRegister(registryEndpointsTotal)
 }
 
 // Controller is responsible for orchestrating the different components.
@@ -69,12 +87,14 @@ func (c *Controller) RunOnce() error {
 		registryErrors.Inc()
 		return err
 	}
+	registryEndpointsTotal.Set(float64(len(records)))
 
 	endpoints, err := c.Source.Endpoints()
 	if err != nil {
 		sourceErrors.Inc()
 		return err
 	}
+	sourceEndpointsTotal.Set(float64(len(endpoints)))
 
 	plan := &plan.Plan{
 		Policies: []plan.Policy{c.Policy},


### PR DESCRIPTION
Exposes the number of managed Endpoints and DNS records as metrics. /cc @njuettner 

Example:
```console
# HELP external_dns_registry_endpoints_total Number of Endpoints in the registry
# TYPE external_dns_registry_endpoints_total gauge
external_dns_registry_endpoints_total 218
# HELP external_dns_source_endpoints_total Number of Endpoints in all sources
# TYPE external_dns_source_endpoints_total gauge
external_dns_source_endpoints_total 176
```

This gives an estimate of how much DNS records ExternalDNS manages for you.

`external_dns_registry_endpoints_total`: all supported records fetched from provider (merged with TXT ownership record)
`external_dns_source_endpoints_total`: all desired Endpoints generated by all Sources