### PR TITLE
Use SOAP API to improve DYN's providers performance

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -586,6 +586,14 @@
   revision = "a6e9df898b1336106c743392c48ee0b71f5c4efa"
 
 [[projects]]
+  branch = "master"
+  digest = "1:bb2ccb2d56cbafdec58af0f473f45304e19876f09fa671960ca87802b656a9c0"
+  name = "github.com/sanyu/dynectsoap"
+  packages = ["dynectsoap"]
+  pruneopts = ""
+  revision = "b83de5edc4e022f22903eeb3b428d2f39fb740e5"
+
+[[projects]]
   digest = "1:7f569d906bdd20d906b606415b7d794f798f91a62fcfb6a4daa6d50690fb7a3f"
   name = "github.com/satori/go.uuid"
   packages = ["."]
@@ -1149,6 +1157,7 @@
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/sanyu/dynectsoap/dynectsoap",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -115,3 +115,7 @@ ignored = ["github.com/kubernetes/repo-infra/kazel"]
 [[constraint]]
   name = "github.com/miekg/dns"
   version = "1.0.8"
+
+[[constraint]]
+  name = "github.com/sanyu/dynectsoap"
+  branch = "master"

--- a/provider/dyn.go
+++ b/provider/dyn.go
@@ -26,6 +26,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/nesv/go-dynect/dynect"
+	"github.com/sanyu/dynectsoap/dynectsoap"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
 	"github.com/kubernetes-incubator/external-dns/plan"
@@ -34,9 +35,6 @@ import (
 const (
 	// 10 minutes default timeout if not configured using flags
 	dynDefaultTTL = 600
-	// can store 20000 entries globally, that's about 4MB of memory
-	// may be made configurable in the future but 20K records seems like enough for a few zones
-	cacheMaxSize = 20000
 
 	// when rate limit is hit retry up to 5 times after sleep 1m between retries
 	dynMaxRetriesOnErrRateLimited = 5
@@ -51,48 +49,8 @@ const (
 	restAPIPrefix = "/REST/"
 )
 
-// A simple non-thread-safe cache with TTL. The TTL of the records is used here to
-// This cache is used to save on requests to DynAPI
-type cache struct {
-	contents map[string]*entry
-}
-
-type entry struct {
-	expires int64
-	ep      *endpoint.Endpoint
-}
-
-func (c *cache) Put(link string, ep *endpoint.Endpoint) {
-	// flush the whole cache on overflow
-	if len(c.contents) >= cacheMaxSize {
-		log.Debugf("Flushing cache")
-		c.contents = make(map[string]*entry)
-	}
-
-	c.contents[link] = &entry{
-		ep:      ep,
-		expires: unixNow() + int64(ep.RecordTTL),
-	}
-}
-
 func unixNow() int64 {
 	return int64(time.Now().Unix())
-}
-
-func (c *cache) Get(link string) *endpoint.Endpoint {
-	result, ok := c.contents[link]
-	if !ok {
-		return nil
-	}
-
-	now := unixNow()
-
-	if result.expires < now {
-		delete(c.contents, link)
-		return nil
-	}
-
-	return result.ep
 }
 
 // DynConfig hold connection parameters to dyn.com and internal state
@@ -145,7 +103,6 @@ func (snap *ZoneSnapshot) StoreRecordsForSerial(zone string, serial int, records
 // DynProvider is the actual interface impl.
 type dynProviderState struct {
 	DynConfig
-	Cache              *cache
 	LastLoginErrorTime int64
 
 	ZoneSnapshot *ZoneSnapshot
@@ -186,9 +143,6 @@ type ZonePublishResponse struct {
 func NewDynProvider(config DynConfig) (Provider, error) {
 	return &dynProviderState{
 		DynConfig: config,
-		Cache: &cache{
-			contents: make(map[string]*entry),
-		},
 		ZoneSnapshot: &ZoneSnapshot{
 			endpoints: map[string][]*endpoint.Endpoint{},
 			serials:   map[string]int{},
@@ -315,40 +269,48 @@ func apiRetryLoop(f func() error) error {
 	return err
 }
 
-// recordLinkToEndpoint makes an Endpoint given a resource link optinally making a remote call if a cached entry is expired
-func (d *dynProviderState) recordLinkToEndpoint(client *dynect.Client, recordLink string) (*endpoint.Endpoint, error) {
-	result := d.Cache.Get(recordLink)
-	if result != nil {
-		log.Infof("Using cached endpoint for %s: %+v", recordLink, result)
-		return result, nil
+func (d *dynProviderState) allRecordsToEndpoints(records *dynectsoap.GetAllRecordsResponseType) []*endpoint.Endpoint {
+	result := []*endpoint.Endpoint{}
+	//Convert each record to an endpoint
+
+	//Process A Records
+	for _, rec := range records.Data.A_records {
+		ep := &endpoint.Endpoint{
+			DNSName:    rec.Fqdn,
+			RecordTTL:  endpoint.TTL(rec.Ttl),
+			RecordType: rec.Record_type,
+			Targets:    endpoint.Targets{rec.Rdata.Address},
+		}
+		log.Debugf("A record: %v", *ep)
+		result = append(result, ep)
 	}
 
-	rec := dynect.RecordResponse{}
-
-	err := apiRetryLoop(func() error {
-		return client.Do("GET", recordLink, nil, &rec)
-	})
-
-	if err != nil {
-		return nil, err
+	//Process CNAME Records
+	for _, rec := range records.Data.Cname_records {
+		ep := &endpoint.Endpoint{
+			DNSName:    rec.Fqdn,
+			RecordTTL:  endpoint.TTL(rec.Ttl),
+			RecordType: rec.Record_type,
+			Targets:    endpoint.Targets{strings.TrimSuffix(rec.Rdata.Cname, ".")},
+		}
+		log.Debugf("CNAME record: %v", *ep)
+		result = append(result, ep)
 	}
 
-	// ignore all records but the types supported by external-
-	target := extractTarget(rec.Data.RecordType, &rec.Data.RData)
-	if target == "" {
-		return nil, nil
+	//Process TXT Records
+	for _, rec := range records.Data.Txt_records {
+		ep := &endpoint.Endpoint{
+			DNSName:    rec.Fqdn,
+			RecordTTL:  endpoint.TTL(rec.Ttl),
+			RecordType: rec.Record_type,
+			Targets:    endpoint.Targets{rec.Rdata.Txtdata},
+		}
+		log.Debugf("TXT record: %v", *ep)
+		result = append(result, ep)
 	}
 
-	result = &endpoint.Endpoint{
-		DNSName:    rec.Data.FQDN,
-		RecordTTL:  endpoint.TTL(rec.Data.TTL),
-		RecordType: rec.Data.RecordType,
-		Targets:    endpoint.Targets{target},
-	}
+	return result
 
-	log.Debugf("Fetched new endpoint for %s: %+v", recordLink, result)
-	d.Cache.Put(recordLink, result)
-	return result, nil
 }
 
 func errorOrValue(err error, value interface{}) interface{} {
@@ -385,6 +347,72 @@ func (d *dynProviderState) fetchZoneSerial(client *dynect.Client, zone string) (
 	}
 
 	return resp.Data.Serial, nil
+}
+
+//Use SOAP to fetch all records with a single call
+func (d *dynProviderState) fetchAllRecordsInZone(zone string) (*dynectsoap.GetAllRecordsResponseType, error) {
+	var err error
+	client := dynectsoap.NewClient("https://api2.dynect.net/SOAP/")
+	service := dynectsoap.NewDynect(client)
+
+	sessionRequest := dynectsoap.SessionLoginRequestType{
+		Customer_name:  d.CustomerName,
+		User_name:      d.Username,
+		Password:       d.Password,
+		Fault_incompat: 0,
+	}
+	resp := dynectsoap.SessionLoginResponseType{}
+	err = apiRetryLoop(func() error {
+		return service.Do(&sessionRequest, &resp)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	token := resp.Data.Token
+
+	logoutRequest := dynectsoap.SessionLogoutRequestType{
+		Token:          token,
+		Fault_incompat: 0,
+	}
+	logoutResponse := dynectsoap.SessionLogoutResponseType{}
+	defer service.Do(&logoutRequest, &logoutResponse)
+
+	req := dynectsoap.GetAllRecordsRequestType{
+		Token:          token,
+		Zone:           zone,
+		Fault_incompat: 0,
+	}
+	records := dynectsoap.GetAllRecordsResponseType{}
+	err = apiRetryLoop(func() error {
+		return service.Do(&req, &records)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("Got all Records, status is %s", records.Status)
+
+	if strings.ToLower(records.Status) == "incomplete" {
+		jobRequest := dynectsoap.GetJobRequestType{
+			Token:          token,
+			Job_id:         records.Job_id,
+			Fault_incompat: 0,
+		}
+
+		jobResults := dynectsoap.GetJobResponseType{}
+		err = apiRetryLoop(func() error {
+			return service.GetJobRetry(&jobRequest, &jobResults)
+		})
+		if err != nil {
+			return nil, err
+		}
+		return jobResults.Data.(*dynectsoap.GetAllRecordsResponseType), nil
+	}
+
+	return &records, nil
+
 }
 
 // fetchAllRecordLinksInZone list all records in a zone with a single call. Records not matched by the
@@ -611,22 +639,14 @@ func (d *dynProviderState) Records() ([]*endpoint.Endpoint, error) {
 			continue
 		}
 
-		recordLinks, err := d.fetchAllRecordLinksInZone(client, zone)
+		//Fetch All Records
+		records, err := d.fetchAllRecordsInZone(zone)
 		if err != nil {
 			return nil, err
 		}
+		relevantRecords = d.allRecordsToEndpoints(records)
 
-		log.Infof("Found %d relevant records found in zone %s: %+v", len(recordLinks), zone, recordLinks)
-		for _, link := range recordLinks {
-			ep, err := d.recordLinkToEndpoint(client, link)
-			if err != nil {
-				return nil, err
-			}
-
-			if ep != nil {
-				relevantRecords = append(relevantRecords, ep)
-			}
-		}
+		log.Debugf("Relevant records %+v", relevantRecords)
 
 		d.ZoneSnapshot.StoreRecordsForSerial(zone, serial, relevantRecords)
 		log.Infof("Stored %d records for %s@%d", len(relevantRecords), zone, serial)

--- a/provider/dyn.go
+++ b/provider/dyn.go
@@ -231,27 +231,6 @@ func merge(updateOld, updateNew []*endpoint.Endpoint) []*endpoint.Endpoint {
 	return result
 }
 
-// extractTarget populates the correct field given a record type.
-// See dynect.DataBlock comments for details. Empty response means nothing
-// was populated - basically an error
-func extractTarget(recType string, data *dynect.DataBlock) string {
-	result := ""
-	if recType == endpoint.RecordTypeA {
-		result = data.Address
-	}
-
-	if recType == endpoint.RecordTypeCNAME {
-		result = data.CName
-		result = strings.TrimSuffix(result, ".")
-	}
-
-	if recType == endpoint.RecordTypeTXT {
-		result = data.TxtData
-	}
-
-	return result
-}
-
 func apiRetryLoop(f func() error) error {
 	var err error
 	for i := 0; i < dynMaxRetriesOnErrRateLimited; i++ {

--- a/provider/dyn_test.go
+++ b/provider/dyn_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/nesv/go-dynect/dynect"
 	"github.com/stretchr/testify/assert"
@@ -262,42 +261,6 @@ func TestDyn_fixMissingTTL(t *testing.T) {
 
 	// apply min TTL
 	assert.Equal(t, "1992", fixMissingTTL(endpoint.TTL(111), 1992))
-}
-
-func TestDyn_cachePut(t *testing.T) {
-	c := cache{
-		contents: make(map[string]*entry),
-	}
-
-	c.Put("link", &endpoint.Endpoint{
-		DNSName:    "name",
-		Targets:    endpoint.Targets{"target"},
-		RecordTTL:  endpoint.TTL(10000),
-		RecordType: "A",
-	})
-
-	found := c.Get("link")
-	assert.NotNil(t, found)
-}
-
-func TestDyn_cachePutExpired(t *testing.T) {
-	c := cache{
-		contents: make(map[string]*entry),
-	}
-
-	c.Put("link", &endpoint.Endpoint{
-		DNSName:    "name",
-		Targets:    endpoint.Targets{"target"},
-		RecordTTL:  endpoint.TTL(0),
-		RecordType: "A",
-	})
-
-	time.Sleep(2 * time.Second)
-
-	found := c.Get("link")
-	assert.Nil(t, found)
-
-	assert.Nil(t, c.Get("no-such-records"))
 }
 
 func TestDyn_Snapshot(t *testing.T) {

--- a/provider/dyn_test.go
+++ b/provider/dyn_test.go
@@ -168,22 +168,6 @@ func TestDynMerge_NoUpdateIfTTLUnchanged(t *testing.T) {
 	assert.Equal(t, 0, len(merged))
 }
 
-func TestDyn_extractTarget(t *testing.T) {
-	tests := []struct {
-		recordType string
-		block      *dynect.DataBlock
-		target     string
-	}{
-		{"A", &dynect.DataBlock{Address: "address"}, "address"},
-		{"CNAME", &dynect.DataBlock{CName: "name."}, "name"}, // note trailing dot is trimmed for CNAMEs
-		{"TXT", &dynect.DataBlock{TxtData: "text."}, "text."},
-	}
-
-	for _, tc := range tests {
-		assert.Equal(t, tc.target, extractTarget(tc.recordType, tc.block))
-	}
-}
-
 func TestDyn_endpointToRecord(t *testing.T) {
 	tests := []struct {
 		ep        *endpoint.Endpoint


### PR DESCRIPTION
When reconciling DNS zones with thousands of records, the current version of the DYN provider will fetch each and every one of these records one at a time. 
If the zone has 4000 records it would need 13 minutes to retrieve all these records if we don't want to be rate limited by DYN (max 300 requests per minute). This is assuming this instance of external-dns is the only one updating the domain. 
As soon as you add multiple instances of external-dns (different kubernetes clusters updating the same domain), you'll start getting rate limited, so the reconcile loop can easily take hours.

It doesn't seem like its possible to get the entire zone using the REST API, so this patch uses  DYN's SOAP API to retrieve the entire zone with 1 single API call. This will happen every time the serial number changes. If the zone's serial does not change, it will use whatever is cached.