### PR TITLE
coredns - Use withPrefix directive to delete services (closes #669)

### DIFF
--- a/provider/coredns.go
+++ b/provider/coredns.go
@@ -153,7 +153,7 @@ func (c etcdClient) DeleteService(key string) error {
 	ctx, cancel := context.WithTimeout(c.ctx, etcdTimeout)
 	defer cancel()
 
-	_, err := c.client.Delete(ctx, key)
+	_, err := c.client.Delete(ctx, key, etcdcv3.WithPrefix())
 	return err
 }
 


### PR DESCRIPTION
Hi,

As said in the issue, the key used to delete does not correspond to the path on ETCD.

service -> /skydns/in/numberly/default/memcached
etcd key -> /skydns/in/numberly/default/memcached/41bb06c2

imho, there are two ways to fix this issue; retrieve the correct path or delete the key(s) based on the prefix. Deleting seemed easier to implement without changing the code too much.

I don't usually write tests in Go, if someone can give me some guidance :)

Thanks.