### PR TITLE
Emit kubernetes event for changes

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -1,0 +1,54 @@
+package event
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	client kubernetes.Interface
+	kubeOnce sync.Once
+)
+
+// Set the client if it has not been set already
+func InitializeClient(kc kubernetes.Interface) {
+	kubeOnce.Do(func() {
+		client = kc
+	})
+}
+
+// Sends an event using kubeClient
+func Emit(msg string) error {
+	if client == nil {
+		return nil
+	}
+	var err error
+	now := metav1.NewTime(time.Now())
+	event := &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%v.%x", "external-dns-event", time.Now().Nanosecond()),
+			Namespace: "default",
+		},
+		Reason: "Started",
+		Message: msg,
+		FirstTimestamp: now,
+		LastTimestamp:  now,
+		Source: v1.EventSource{
+			Component: "external-dns-event",
+		},
+		Count: 1,
+		Type: v1.EventTypeNormal,
+	}
+
+	_, err = client.CoreV1().Events("default").Create(event)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/provider/google.go
+++ b/provider/google.go
@@ -32,6 +32,7 @@ import (
 	googleapi "google.golang.org/api/googleapi"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
+	"github.com/kubernetes-incubator/external-dns/event"
 	"github.com/kubernetes-incubator/external-dns/plan"
 )
 
@@ -292,9 +293,18 @@ func (p *GoogleProvider) submitChange(change *dns.Change) error {
 		log.Infof("Change zone: %v", z)
 		for _, del := range c.Deletions {
 			log.Infof("Del records: %s %s %s %d", del.Name, del.Type, del.Rrdatas, del.Ttl)
+			err = event.Emit(fmt.Sprintf("Del records: %s %s %s %d", del.Name, del.Type, del.Rrdatas, del.Ttl))
+			if err != nil {
+				log.Fatal(err)
+			}
+
 		}
 		for _, add := range c.Additions {
 			log.Infof("Add records: %s %s %s %d", add.Name, add.Type, add.Rrdatas, add.Ttl)
+			err = event.Emit(fmt.Sprintf("Add records: %s %s %s %d", add.Name, add.Type, add.Rrdatas, add.Ttl))
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Addresses feature request: #646 

Initial commit only implements google as the provider. It would be the same for all the other providers which I can add when the structure of this feature is approved.

Some reasoning for how this is structured:
- the events package gets the kubernetes client in main so that the client does not need to be passed in for each provider. This avoids having to change the parameters for each `provider.New<Provider>Provider`, and updating each provider test case. Instead each provider will need to import the `event` package and call `Emit`.
- for rbac, the deployment, needs the following rule
```
- apiGroups: [""]
  resources: ["events"]
  verbs: ["create"]
```
- A toggle flag could easily be added by not calling `InitializeClient`.

Example of output:
```
$ kubectl get events
LAST SEEN   FIRST SEEN   COUNT     NAME                         KIND  SUBOBJECT  TYPE      REASON   SOURCE              MESSAGE
2m          2m           1         external-dns-event.36a8edc1                   Normal    Started  external-dns-event  Add records: nginx.tay.one. A [35.243.183.241] 300
2m          2m           1         external-dns-event.373c9c9c                   Normal    Started  external-dns-event  Add records: nginx.tay.one. TXT ["heritage=external-dns,external-dns/owner=my-identifier,external-dns/resource=service/default/nginx"] 300
```