### PR TITLE
Add metrics info to FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,7 +28,7 @@ ExternalDNS can solve this for you as well.
 
 ### Which DNS providers are supported?
 
-Currently, the following providers are supported: 
+Currently, the following providers are supported:
 
 - Google CloudDNS
 - AWS Route 53
@@ -154,6 +154,18 @@ CNAMEs cannot co-exist with other records, therefore you can use the `--txt-pref
 ### Which permissions do I need when running ExternalDNS on a GCE or GKE node.
 
 You need to add either https://www.googleapis.com/auth/ndev.clouddns.readwrite or https://www.googleapis.com/auth/cloud-platform on your instance group's scope.
+
+### What metrics can I get from ExternalDNS and what do they mean?  
+
+ExternalDNS exposes 2 types of metrics: Sources and Registry errors.
+
+`Source`s are mostly Kubernetes API objects. Examples of `source` errors may be connection errors to the Kubernetes API server itself or missing RBAC permissions. It can also stem from incompatible configuration in the objects itself like invalid characters, processing a broken fqdnTemplate etc.
+
+`Registry` errors are mostly Provider errors, unless there's some coding flaw in the registry package. Provider errors often arise due to accessing their APIs due to network or missing cloud-provider permissions when reading records. When applying a changeset, errors arise when the changeset applied is incompatible with the current state, in which case ExternalDNS can get stuck forever.
+
+In case of an increased error count, you could correlate them with the `http_request_duration_seconds{handler="instrumented_http"}` metric which should show increased numbers for status codes 4xx (permissions, configuration, invalid changeset) or 5xx (apiserver down).
+
+You can use the host label in the metric to figure out if the request was against the Kubernetes API server (Source errors) or the DNS provider API (Registry/Provider errors).
 
 ### How can I run ExternalDNS under a specific GCP Service Account, e.g. to access DNS records in other projects?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -159,9 +159,9 @@ You need to add either https://www.googleapis.com/auth/ndev.clouddns.readwrite o
 
 ExternalDNS exposes 2 types of metrics: Sources and Registry errors.
 
-`Source`s are mostly Kubernetes API objects. Examples of `source` errors may be connection errors to the Kubernetes API server itself or missing RBAC permissions. It can also stem from incompatible configuration in the objects itself like invalid characters, processing a broken fqdnTemplate etc.
+`Source`s are mostly Kubernetes API objects. Examples of `source` errors may be connection errors to the Kubernetes API server itself or missing RBAC permissions. It can also stem from incompatible configuration in the objects itself like invalid characters, processing a broken fqdnTemplate, etc.
 
-`Registry` errors are mostly Provider errors, unless there's some coding flaw in the registry package. Provider errors often arise due to accessing their APIs due to network or missing cloud-provider permissions when reading records. When applying a changeset, errors arise when the changeset applied is incompatible with the current state, in which case ExternalDNS can get stuck forever.
+`Registry` errors are mostly Provider errors, unless there's some coding flaw in the registry package. Provider errors often arise due to accessing their APIs due to network or missing cloud-provider permissions when reading records. When applying a changeset, errors will arise if the changeset applied is incompatible with the current state.  
 
 In case of an increased error count, you could correlate them with the `http_request_duration_seconds{handler="instrumented_http"}` metric which should show increased numbers for status codes 4xx (permissions, configuration, invalid changeset) or 5xx (apiserver down).
 


### PR DESCRIPTION
Update FAQ to include information about `source` and `registry` errors exposed by ExternalDNS