### PR TITLE
Normalize DNS names during planning

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -79,7 +79,7 @@ type planTableRow struct {
 }
 
 func (t planTable) addCurrent(e *endpoint.Endpoint) {
-	dnsName := sanitizeDNSName(e.DNSName)
+	dnsName := normalizeDNSName(e.DNSName)
 	if _, ok := t.rows[dnsName]; !ok {
 		t.rows[dnsName] = &planTableRow{}
 	}
@@ -87,7 +87,7 @@ func (t planTable) addCurrent(e *endpoint.Endpoint) {
 }
 
 func (t planTable) addCandidate(e *endpoint.Endpoint) {
-	dnsName := sanitizeDNSName(e.DNSName)
+	dnsName := normalizeDNSName(e.DNSName)
 	if _, ok := t.rows[dnsName]; !ok {
 		t.rows[dnsName] = &planTableRow{}
 	}
@@ -204,8 +204,12 @@ func filterRecordsForPlan(records []*endpoint.Endpoint) []*endpoint.Endpoint {
 	return filtered
 }
 
-// sanitizeDNSName checks if the DNS name is correct
-// for now it only removes space and lower case
-func sanitizeDNSName(dnsName string) string {
-	return strings.TrimSpace(strings.ToLower(dnsName))
+// normalizeDNSName converts a DNS name to a canonical form, so that we can use string equality
+// it: removes space, converts to lower case, ensures there is a trailing dot
+func normalizeDNSName(dnsName string) string {
+	s := strings.TrimSpace(strings.ToLower(dnsName))
+	if !strings.HasSuffix(s, ".") {
+		s += "."
+	}
+	return s
 }

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -385,54 +385,58 @@ func validateEntries(t *testing.T, entries, expected []*endpoint.Endpoint) {
 	}
 }
 
-func TestSanitizeDNSName(t *testing.T) {
+func TestNormalizeDNSName(t *testing.T) {
 	records := []struct {
 		dnsName string
 		expect  string
 	}{
 		{
 			"3AAAA.FOO.BAR.COM    ",
-			"3aaaa.foo.bar.com",
+			"3aaaa.foo.bar.com.",
 		},
 		{
-			"   example.foo.com",
-			"example.foo.com",
+			"   example.foo.com.",
+			"example.foo.com.",
 		},
 		{
 			"example123.foo.com ",
-			"example123.foo.com",
+			"example123.foo.com.",
 		},
 		{
 			"foo",
-			"foo",
+			"foo.",
 		},
 		{
 			"123foo.bar",
-			"123foo.bar",
+			"123foo.bar.",
 		},
 		{
 			"foo.com",
-			"foo.com",
+			"foo.com.",
+		},
+		{
+			"foo.com.",
+			"foo.com.",
 		},
 		{
 			"foo123.COM",
-			"foo123.com",
+			"foo123.com.",
 		},
 		{
 			"my-exaMple3.FOO.BAR.COM",
-			"my-example3.foo.bar.com",
+			"my-example3.foo.bar.com.",
 		},
 		{
 			"   my-example1214.FOO-1235.BAR-foo.COM   ",
-			"my-example1214.foo-1235.bar-foo.com",
+			"my-example1214.foo-1235.bar-foo.com.",
 		},
 		{
 			"my-example-my-example-1214.FOO-1235.BAR-foo.COM",
-			"my-example-my-example-1214.foo-1235.bar-foo.com",
+			"my-example-my-example-1214.foo-1235.bar-foo.com.",
 		},
 	}
 	for _, r := range records {
-		gotName := sanitizeDNSName(r.dnsName)
+		gotName := normalizeDNSName(r.dnsName)
 		assert.Equal(t, r.expect, gotName)
 	}
 }


### PR DESCRIPTION
Ensure that we don't consider names with and without a trailing dot
differently at this stage.