### PR TITLE
Fix typos in rfc2136 provider

### DIFF
--- a/provider/rfc2136.go
+++ b/provider/rfc2136.go
@@ -43,7 +43,7 @@ type rfc2136Provider struct {
 	// only consider hosted zones managing domains ending in this suffix
 	domainFilter DomainFilter
 	dryRun       bool
-	actions      rfc1236Actions
+	actions      rfc2136Actions
 }
 
 var (
@@ -56,13 +56,13 @@ var (
 	}
 )
 
-type rfc1236Actions interface {
+type rfc2136Actions interface {
 	SendMessage(msg *dns.Msg) error
 	IncomeTransfer(m *dns.Msg, a string) (env chan *dns.Envelope, err error)
 }
 
 // NewRfc2136Provider is a factory function for OpenStack rfc2136 providers
-func NewRfc2136Provider(host string, port int, zoneName string, insecure bool, keyName string, secret string, secretAlg string, axfr bool, domainFilter DomainFilter, dryRun bool, actions rfc1236Actions) (Provider, error) {
+func NewRfc2136Provider(host string, port int, zoneName string, insecure bool, keyName string, secret string, secretAlg string, axfr bool, domainFilter DomainFilter, dryRun bool, actions rfc2136Actions) (Provider, error) {
 	secretAlgChecked, ok := tsigAlgs[secretAlg]
 	if !ok {
 		return nil, errors.Errorf("%s is not supported TSIG algorithm", secretAlg)

--- a/provider/rfc2136_test.go
+++ b/provider/rfc2136_test.go
@@ -93,7 +93,7 @@ func createRfc2136StubProvider(stub *rfc2136Stub) (Provider, error) {
 	return NewRfc2136Provider("", 0, "", false, "key", "secret", "hmac-sha512", true, DomainFilter{}, false, stub)
 }
 
-func TestRfc1236GetRecords(t *testing.T) {
+func TestRfc2136GetRecords(t *testing.T) {
 	stub := newStub()
 	err := stub.setOutput([]string{
 		"v4.barfoo.com 3600 TXT test1",


### PR DESCRIPTION
The rfc2136Actions interface was misspelled.

Signed-off-by: Lachlan Cooper <lachlancooper@gmail.com>