### PR TITLE
Fix dry-run mode in rfc2136 provider

### DIFF
--- a/provider/rfc2136.go
+++ b/provider/rfc2136.go
@@ -293,6 +293,7 @@ func (r rfc2136Provider) RemoveRecord(ep *endpoint.Endpoint) error {
 func (r rfc2136Provider) SendMessage(msg *dns.Msg) error {
 	if r.dryRun {
 		log.Debugf("SendMessage.skipped")
+		return nil
 	}
 	log.Debugf("SendMessage")
 


### PR DESCRIPTION
In dry-run mode we need to return early to avoid sending messages.

Fixes #816.