### PR TITLE
Change default AWSBatchChangeSize to 1000

### DIFF
--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -130,7 +130,7 @@ var defaultConfig = &Config{
 	AWSZoneType:              "",
 	AWSZoneTagFilter:         []string{},
 	AWSAssumeRole:            "",
-	AWSBatchChangeSize:       4000,
+	AWSBatchChangeSize:       1000,
 	AWSBatchChangeInterval:   time.Second,
 	AWSEvaluateTargetHealth:  true,
 	AzureConfigFile:          "/etc/kubernetes/azure.json",

--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -45,7 +45,7 @@ var (
 		AWSZoneType:             "",
 		AWSZoneTagFilter:        []string{""},
 		AWSAssumeRole:           "",
-		AWSBatchChangeSize:      4000,
+		AWSBatchChangeSize:      1000,
 		AWSBatchChangeInterval:  time.Second,
 		AWSEvaluateTargetHealth: true,
 		AzureConfigFile:         "/etc/kubernetes/azure.json",


### PR DESCRIPTION
AWS API ChangeResourceRecordSets method only allows 1000 ResourceRecord
elements in one call, so the previous value was not very useful.

See the AWS API docs here:
https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests-changeresourcerecordsets