### PR TITLE
Publish unready pods

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func main() {
 		Compatibility:            cfg.Compatibility,
 		PublishInternal:          cfg.PublishInternal,
 		PublishHostIP:            cfg.PublishHostIP,
+		PublishUnreadyPods:       cfg.PublishUnreadyPods,
 		ConnectorServer:          cfg.ConnectorSourceServer,
 		CRDSourceAPIVersion:      cfg.CRDSourceAPIVersion,
 		CRDSourceKind:            cfg.CRDSourceKind,

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -48,6 +48,7 @@ type Config struct {
 	Compatibility            string
 	PublishInternal          bool
 	PublishHostIP            bool
+	PublishUnreadyPods       bool
 	ConnectorSourceServer    string
 	Provider                 string
 	GoogleProject            string
@@ -122,6 +123,7 @@ var defaultConfig = &Config{
 	Compatibility:            "",
 	PublishInternal:          false,
 	PublishHostIP:            false,
+	PublishUnreadyPods:       false,
 	ConnectorSourceServer:    "localhost:8080",
 	Provider:                 "",
 	GoogleProject:            "",
@@ -230,6 +232,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("compatibility", "Process annotation semantics from legacy implementations (optional, options: mate, molecule)").Default(defaultConfig.Compatibility).EnumVar(&cfg.Compatibility, "", "mate", "molecule")
 	app.Flag("publish-internal-services", "Allow external-dns to publish DNS records for ClusterIP services (optional)").BoolVar(&cfg.PublishInternal)
 	app.Flag("publish-host-ip", "Allow external-dns to publish host-ip for headless services (optional)").BoolVar(&cfg.PublishHostIP)
+	app.Flag("publish-unready-pods", "Allow external-dns to publish unready pods in headless services (optional)").BoolVar(&cfg.PublishUnreadyPods)
 	app.Flag("connector-source-server", "The server to connect for connector source, valid only when using connector source").Default(defaultConfig.ConnectorSourceServer).StringVar(&cfg.ConnectorSourceServer)
 	app.Flag("crd-source-apiversion", "API version of the CRD for crd source, e.g. `externaldns.k8s.io/v1alpha1`, valid only when using crd source").Default(defaultConfig.CRDSourceAPIVersion).StringVar(&cfg.CRDSourceAPIVersion)
 	app.Flag("crd-source-kind", "Kind of the CRD for the crd source in API group and version specified by crd-source-apiversion").Default(defaultConfig.CRDSourceKind).StringVar(&cfg.CRDSourceKind)

--- a/source/service.go
+++ b/source/service.go
@@ -48,16 +48,17 @@ type serviceSource struct {
 	namespace        string
 	annotationFilter string
 	// process Services with legacy annotations
-	compatibility         string
-	fqdnTemplate          *template.Template
-	combineFQDNAnnotation bool
-	publishInternal       bool
-	publishHostIP         bool
-	serviceTypeFilter     map[string]struct{}
+	compatibility           string
+	fqdnTemplate            *template.Template
+	combineFQDNAnnotation   bool
+	publishInternal         bool
+	publishHostIP           bool
+	publishUnreadyEndpoints bool
+	serviceTypeFilter       map[string]struct{}
 }
 
 // NewServiceSource creates a new serviceSource with the given config.
-func NewServiceSource(kubeClient kubernetes.Interface, namespace, annotationFilter string, fqdnTemplate string, combineFqdnAnnotation bool, compatibility string, publishInternal bool, publishHostIP bool, serviceTypeFilter []string) (Source, error) {
+func NewServiceSource(kubeClient kubernetes.Interface, namespace, annotationFilter string, fqdnTemplate string, combineFqdnAnnotation bool, compatibility string, publishInternal bool, publishHostIP bool, publishUnreadyEndpoints bool, serviceTypeFilter []string) (Source, error) {
 	var (
 		tmpl *template.Template
 		err  error
@@ -79,15 +80,16 @@ func NewServiceSource(kubeClient kubernetes.Interface, namespace, annotationFilt
 	}
 
 	return &serviceSource{
-		client:                kubeClient,
-		namespace:             namespace,
-		annotationFilter:      annotationFilter,
-		compatibility:         compatibility,
-		fqdnTemplate:          tmpl,
-		combineFQDNAnnotation: combineFqdnAnnotation,
-		publishInternal:       publishInternal,
-		publishHostIP:         publishHostIP,
-		serviceTypeFilter:     serviceTypes,
+		client:                  kubeClient,
+		namespace:               namespace,
+		annotationFilter:        annotationFilter,
+		compatibility:           compatibility,
+		fqdnTemplate:            tmpl,
+		combineFQDNAnnotation:   combineFqdnAnnotation,
+		publishInternal:         publishInternal,
+		publishHostIP:           publishHostIP,
+		publishUnreadyEndpoints: publishUnreadyEndpoints,
+		serviceTypeFilter:       serviceTypes,
 	}, nil
 }
 
@@ -180,7 +182,7 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 		if sc.publishHostIP == true {
 			log.Debugf("Generating matching endpoint %s with HostIP %s", headlessDomain, v.Status.HostIP)
 			// To reduce traffice on the DNS API only add record for running Pods. Good Idea?
-			if v.Status.Phase == v1.PodRunning {
+			if v.Status.Phase == v1.PodRunning || sc.publishUnreadyEndpoints {
 				if ttl.IsConfigured() {
 					endpoints = append(endpoints, endpoint.NewEndpointWithTTL(headlessDomain, endpoint.RecordTypeA, ttl, v.Status.HostIP))
 				} else {
@@ -192,7 +194,7 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 		} else {
 			log.Debugf("Generating matching endpoint %s with PodIP %s", headlessDomain, v.Status.PodIP)
 			// To reduce traffice on the DNS API only add record for running Pods. Good Idea?
-			if v.Status.Phase == v1.PodRunning {
+			if v.Status.Phase == v1.PodRunning || sc.publishUnreadyEndpoints {
 				if ttl.IsConfigured() {
 					endpoints = append(endpoints, endpoint.NewEndpointWithTTL(headlessDomain, endpoint.RecordTypeA, ttl, v.Status.PodIP))
 				} else {

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -50,6 +50,7 @@ func (suite *ServiceSuite) SetupTest() {
 		"",
 		false,
 		false,
+		false,
 		[]string{},
 	)
 	suite.fooWithTargets = &v1.Service{
@@ -139,6 +140,7 @@ func testServiceSourceNewServiceSource(t *testing.T) {
 				ti.fqdnTemplate,
 				false,
 				"",
+				false,
 				false,
 				false,
 				ti.serviceTypesFilter,
@@ -959,6 +961,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				tc.compatibility,
 				false,
 				false,
+				false,
 				tc.serviceTypesFilter,
 			)
 			require.NoError(t, err)
@@ -1093,6 +1096,7 @@ func TestClusterIpServices(t *testing.T) {
 				false,
 				tc.compatibility,
 				true,
+				false,
 				false,
 				[]string{},
 			)
@@ -1290,6 +1294,7 @@ func TestNodePortServices(t *testing.T) {
 				false,
 				tc.compatibility,
 				true,
+				false,
 				false,
 				[]string{},
 			)
@@ -1492,6 +1497,7 @@ func TestHeadlessServices(t *testing.T) {
 				tc.compatibility,
 				true,
 				false,
+				false,
 				[]string{},
 			)
 			require.NoError(t, err)
@@ -1693,6 +1699,7 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 				tc.compatibility,
 				true,
 				true,
+				false,
 				[]string{},
 			)
 			require.NoError(t, err)
@@ -1734,7 +1741,7 @@ func BenchmarkServiceEndpoints(b *testing.B) {
 	_, err := kubernetes.CoreV1().Services(service.Namespace).Create(service)
 	require.NoError(b, err)
 
-	client, err := NewServiceSource(kubernetes, v1.NamespaceAll, "", "", false, "", false, false, []string{})
+	client, err := NewServiceSource(kubernetes, v1.NamespaceAll, "", "", false, "", false, false, false, []string{})
 	require.NoError(b, err)
 
 	for i := 0; i < b.N; i++ {

--- a/source/store.go
+++ b/source/store.go
@@ -45,6 +45,7 @@ type Config struct {
 	Compatibility            string
 	PublishInternal          bool
 	PublishHostIP            bool
+	PublishUnreadyPods       bool
 	ConnectorServer          string
 	CRDSourceAPIVersion      string
 	CRDSourceKind            string
@@ -112,7 +113,7 @@ func BuildWithConfig(source string, p ClientGenerator, cfg *Config) (Source, err
 		if err != nil {
 			return nil, err
 		}
-		return NewServiceSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP, cfg.ServiceTypeFilter)
+		return NewServiceSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP, cfg.PublishUnreadyPods, cfg.ServiceTypeFilter)
 	case "ingress":
 		client, err := p.KubeClient()
 		if err != nil {


### PR DESCRIPTION
This PR adds the addition of a command line flag to cause publishing unready pod's when using a headless service. 

The new flag is:`--publish-unready-pods`