### PR TITLE
[designate provider] moved recordSet's ID, ZoneID, and OriginalRecords values from Endpoint.Labels to Endpoint.ProviderSpecific

### DIFF
--- a/provider/designate.go
+++ b/provider/designate.go
@@ -321,9 +321,10 @@ func (p designateProvider) Records() ([]*endpoint.Endpoint, error) {
 				}
 				for _, record := range recordSet.Records {
 					ep := endpoint.NewEndpoint(recordSet.Name, recordSet.Type, record)
-					ep.Labels[designateRecordSetID] = recordSet.ID
-					ep.Labels[designateZoneID] = recordSet.ZoneID
-					ep.Labels[designateOriginalRecords] = strings.Join(recordSet.Records, "\000")
+					ep.ProviderSpecific = make(map[string]string)
+					ep.ProviderSpecific[designateRecordSetID] = recordSet.ID
+					ep.ProviderSpecific[designateZoneID] = recordSet.ZoneID
+					ep.ProviderSpecific[designateOriginalRecords] = strings.Join(recordSet.Records, "\000")
 					result = append(result, ep)
 				}
 				return nil
@@ -358,12 +359,12 @@ func addEndpoint(ep *endpoint.Endpoint, recordSets map[string]*recordSet, delete
 		}
 	}
 	if rs.zoneID == "" {
-		rs.zoneID = ep.Labels[designateZoneID]
+		rs.zoneID = ep.ProviderSpecific[designateZoneID]
 	}
 	if rs.recordSetID == "" {
-		rs.recordSetID = ep.Labels[designateRecordSetID]
+		rs.recordSetID = ep.ProviderSpecific[designateRecordSetID]
 	}
-	for _, rec := range strings.Split(ep.Labels[designateOriginalRecords], "\000") {
+	for _, rec := range strings.Split(ep.ProviderSpecific[designateOriginalRecords], "\000") {
 		if _, ok := rs.names[rec]; !ok && rec != "" {
 			rs.names[rec] = true
 		}

--- a/provider/designate_test.go
+++ b/provider/designate_test.go
@@ -240,7 +240,8 @@ func TestDesignateRecords(t *testing.T) {
 			DNSName:    "www.example.com",
 			RecordType: endpoint.RecordTypeA,
 			Targets:    endpoint.Targets{"10.1.1.1"},
-			Labels: map[string]string{
+			Labels:     map[string]string{},
+			ProviderSpecific: map[string]string{
 				designateRecordSetID:     rs11ID,
 				designateZoneID:          zone1ID,
 				designateOriginalRecords: "10.1.1.1",
@@ -250,7 +251,8 @@ func TestDesignateRecords(t *testing.T) {
 			DNSName:    "www.example.com",
 			RecordType: endpoint.RecordTypeTXT,
 			Targets:    endpoint.Targets{"text1"},
-			Labels: map[string]string{
+			Labels:     map[string]string{},
+			ProviderSpecific: map[string]string{
 				designateRecordSetID:     rs12ID,
 				designateZoneID:          zone1ID,
 				designateOriginalRecords: "text1",
@@ -260,7 +262,8 @@ func TestDesignateRecords(t *testing.T) {
 			DNSName:    "ftp.example.com",
 			RecordType: endpoint.RecordTypeA,
 			Targets:    endpoint.Targets{"10.1.1.2"},
-			Labels: map[string]string{
+			Labels:     map[string]string{},
+			ProviderSpecific: map[string]string{
 				designateRecordSetID:     rs14ID,
 				designateZoneID:          zone1ID,
 				designateOriginalRecords: "10.1.1.2",
@@ -270,7 +273,8 @@ func TestDesignateRecords(t *testing.T) {
 			DNSName:    "srv.test.net",
 			RecordType: endpoint.RecordTypeA,
 			Targets:    endpoint.Targets{"10.2.1.1"},
-			Labels: map[string]string{
+			Labels:     map[string]string{},
+			ProviderSpecific: map[string]string{
 				designateRecordSetID:     rs21ID,
 				designateZoneID:          zone2ID,
 				designateOriginalRecords: "10.2.1.1\00010.2.1.2",
@@ -280,7 +284,8 @@ func TestDesignateRecords(t *testing.T) {
 			DNSName:    "srv.test.net",
 			RecordType: endpoint.RecordTypeA,
 			Targets:    endpoint.Targets{"10.2.1.2"},
-			Labels: map[string]string{
+			Labels:     map[string]string{},
+			ProviderSpecific: map[string]string{
 				designateRecordSetID:     rs21ID,
 				designateZoneID:          zone2ID,
 				designateOriginalRecords: "10.2.1.1\00010.2.1.2",
@@ -290,7 +295,8 @@ func TestDesignateRecords(t *testing.T) {
 			DNSName:    "db.test.net",
 			RecordType: endpoint.RecordTypeCNAME,
 			Targets:    endpoint.Targets{"sql.test.net"},
-			Labels: map[string]string{
+			Labels:     map[string]string{},
+			ProviderSpecific: map[string]string{
 				designateRecordSetID:     rs22ID,
 				designateZoneID:          zone2ID,
 				designateOriginalRecords: "sql.test.net.",
@@ -334,40 +340,46 @@ func testDesignateCreateRecords(t *testing.T, client *fakeDesignateClient) []*re
 	}
 	endpoints := []*endpoint.Endpoint{
 		{
-			DNSName:    "www.example.com",
-			RecordType: endpoint.RecordTypeA,
-			Targets:    endpoint.Targets{"10.1.1.1"},
-			Labels:     map[string]string{},
+			DNSName:          "www.example.com",
+			RecordType:       endpoint.RecordTypeA,
+			Targets:          endpoint.Targets{"10.1.1.1"},
+			Labels:           map[string]string{},
+			ProviderSpecific: map[string]string{},
 		},
 		{
-			DNSName:    "www.example.com",
-			RecordType: endpoint.RecordTypeTXT,
-			Targets:    endpoint.Targets{"text1"},
-			Labels:     map[string]string{},
+			DNSName:          "www.example.com",
+			RecordType:       endpoint.RecordTypeTXT,
+			Targets:          endpoint.Targets{"text1"},
+			Labels:           map[string]string{},
+			ProviderSpecific: map[string]string{},
 		},
 		{
-			DNSName:    "ftp.example.com",
-			RecordType: endpoint.RecordTypeA,
-			Targets:    endpoint.Targets{"10.1.1.2"},
-			Labels:     map[string]string{},
+			DNSName:          "ftp.example.com",
+			RecordType:       endpoint.RecordTypeA,
+			Targets:          endpoint.Targets{"10.1.1.2"},
+			Labels:           map[string]string{},
+			ProviderSpecific: map[string]string{},
 		},
 		{
-			DNSName:    "srv.test.net",
-			RecordType: endpoint.RecordTypeA,
-			Targets:    endpoint.Targets{"10.2.1.1"},
-			Labels:     map[string]string{},
+			DNSName:          "srv.test.net",
+			RecordType:       endpoint.RecordTypeA,
+			Targets:          endpoint.Targets{"10.2.1.1"},
+			Labels:           map[string]string{},
+			ProviderSpecific: map[string]string{},
 		},
 		{
-			DNSName:    "srv.test.net",
-			RecordType: endpoint.RecordTypeA,
-			Targets:    endpoint.Targets{"10.2.1.2"},
-			Labels:     map[string]string{},
+			DNSName:          "srv.test.net",
+			RecordType:       endpoint.RecordTypeA,
+			Targets:          endpoint.Targets{"10.2.1.2"},
+			Labels:           map[string]string{},
+			ProviderSpecific: map[string]string{},
 		},
 		{
-			DNSName:    "db.test.net",
-			RecordType: endpoint.RecordTypeCNAME,
-			Targets:    endpoint.Targets{"sql.test.net"},
-			Labels:     map[string]string{},
+			DNSName:          "db.test.net",
+			RecordType:       endpoint.RecordTypeCNAME,
+			Targets:          endpoint.Targets{"sql.test.net"},
+			Labels:           map[string]string{},
+			ProviderSpecific: map[string]string{},
 		},
 	}
 	expected := []*recordsets.RecordSet{
@@ -448,7 +460,8 @@ func testDesignateUpdateRecords(t *testing.T, client *fakeDesignateClient) []*re
 			DNSName:    "ftp.example.com",
 			RecordType: endpoint.RecordTypeA,
 			Targets:    endpoint.Targets{"10.1.1.2"},
-			Labels: map[string]string{
+			Labels:     map[string]string{},
+			ProviderSpecific: map[string]string{
 				designateZoneID:          "zone-1",
 				designateRecordSetID:     expected[2].ID,
 				designateOriginalRecords: "10.1.1.2",
@@ -458,7 +471,8 @@ func testDesignateUpdateRecords(t *testing.T, client *fakeDesignateClient) []*re
 			DNSName:    "srv.test.net.",
 			RecordType: endpoint.RecordTypeA,
 			Targets:    endpoint.Targets{"10.2.1.2"},
-			Labels: map[string]string{
+			Labels:     map[string]string{},
+			ProviderSpecific: map[string]string{
 				designateZoneID:          "zone-2",
 				designateRecordSetID:     expected[3].ID,
 				designateOriginalRecords: "10.2.1.1\00010.2.1.2",
@@ -470,7 +484,8 @@ func testDesignateUpdateRecords(t *testing.T, client *fakeDesignateClient) []*re
 			DNSName:    "ftp.example.com",
 			RecordType: endpoint.RecordTypeA,
 			Targets:    endpoint.Targets{"10.3.3.1"},
-			Labels: map[string]string{
+			Labels:     map[string]string{},
+			ProviderSpecific: map[string]string{
 				designateZoneID:          "zone-1",
 				designateRecordSetID:     expected[2].ID,
 				designateOriginalRecords: "10.1.1.2",
@@ -480,7 +495,8 @@ func testDesignateUpdateRecords(t *testing.T, client *fakeDesignateClient) []*re
 			DNSName:    "srv.test.net.",
 			RecordType: endpoint.RecordTypeA,
 			Targets:    endpoint.Targets{"10.3.3.2"},
-			Labels: map[string]string{
+			Labels:     map[string]string{},
+			ProviderSpecific: map[string]string{
 				designateZoneID:          "zone-2",
 				designateRecordSetID:     expected[3].ID,
 				designateOriginalRecords: "10.2.1.1\00010.2.1.2",
@@ -531,7 +547,8 @@ func testDesignateDeleteRecords(t *testing.T, client *fakeDesignateClient) {
 			DNSName:    "www.example.com.",
 			RecordType: endpoint.RecordTypeA,
 			Targets:    endpoint.Targets{"10.1.1.1"},
-			Labels: map[string]string{
+			Labels:     map[string]string{},
+			ProviderSpecific: map[string]string{
 				designateZoneID:          "zone-1",
 				designateRecordSetID:     expected[0].ID,
 				designateOriginalRecords: "10.1.1.1",
@@ -541,7 +558,8 @@ func testDesignateDeleteRecords(t *testing.T, client *fakeDesignateClient) {
 			DNSName:    "srv.test.net.",
 			RecordType: endpoint.RecordTypeA,
 			Targets:    endpoint.Targets{"10.2.1.1"},
-			Labels: map[string]string{
+			Labels:     map[string]string{},
+			ProviderSpecific: map[string]string{
 				designateZoneID:          "zone-2",
 				designateRecordSetID:     expected[3].ID,
 				designateOriginalRecords: "10.2.1.1\00010.3.3.2",


### PR DESCRIPTION
**THE PROBLEM**
This is to address a bug in the interaction of the TXT registry and the OpenStack Designate provider. The TXT registry calls the provider's Records() function and uses the records it returns to generate an array of endpoints. During the construction of each endpoint, the TXT registry makes a new .Labels field. The problem is that the designate provider stores three critical pieces of information in the Labels field it passes up to the registry: the ID of the recordSet, the ZoneID, and the designateOriginalRecords string. The loss of these fields causes issues down the line when external-dns tries to upsert records. Without a recordSetID or ZoneID, the loop that should update or delete the records exits silently.

**THE SOLUTION**
This PR solves this problem by stashing the three fields (designateRecordSetID, designateZoneID, and designateOriginalRecords) in a different map on the Endpoint struct. Instead of Endpoint.Labels, it uses Endpoint.ProviderSpecific. Since these values are not stripped by TXT registry, they are available later for the upsert functions.