### PR TITLE
Reduce number of API requests by caching a bit

### DIFF
--- a/provider/aws.go
+++ b/provider/aws.go
@@ -368,10 +368,15 @@ func (p *AWSProvider) submitChanges(changes []*route53.Change) error {
 
 // newChanges returns a collection of Changes based on the given records and action.
 func (p *AWSProvider) newChanges(action string, endpoints []*endpoint.Endpoint) []*route53.Change {
+	records, err := p.Records()
+	if err != nil {
+		log.Errorf("getting records failed: %v", err)
+	}
+
 	changes := make([]*route53.Change, 0, len(endpoints))
 
 	for _, endpoint := range endpoints {
-		changes = append(changes, p.newChange(action, endpoint))
+		changes = append(changes, p.newChange(action, endpoint, records))
 	}
 
 	return changes
@@ -380,17 +385,12 @@ func (p *AWSProvider) newChanges(action string, endpoints []*endpoint.Endpoint) 
 // newChange returns a Change of the given record by the given action, e.g.
 // action=ChangeActionCreate returns a change for creation of the record and
 // action=ChangeActionDelete returns a change for deletion of the record.
-func (p *AWSProvider) newChange(action string, endpoint *endpoint.Endpoint) *route53.Change {
+func (p *AWSProvider) newChange(action string, endpoint *endpoint.Endpoint, recordsCache []*endpoint.Endpoint) *route53.Change {
 	change := &route53.Change{
 		Action: aws.String(action),
 		ResourceRecordSet: &route53.ResourceRecordSet{
 			Name: aws.String(endpoint.DNSName),
 		},
-	}
-
-	rec, err := p.Records()
-	if err != nil {
-		log.Infof("getting records failed: %v", err)
 	}
 
 	if isAWSLoadBalancer(endpoint) {
@@ -405,7 +405,7 @@ func (p *AWSProvider) newChange(action string, endpoint *endpoint.Endpoint) *rou
 			HostedZoneId:         aws.String(canonicalHostedZone(endpoint.Targets[0])),
 			EvaluateTargetHealth: aws.Bool(evalTargetHealth),
 		}
-	} else if hostedZone := isAWSAlias(endpoint, rec); hostedZone != "" {
+	} else if hostedZone := isAWSAlias(endpoint, recordsCache); hostedZone != "" {
 		zones, err := p.Zones()
 		if err != nil {
 			log.Errorf("getting zones failed: %v", err)


### PR DESCRIPTION
This moves the call to `Records()` one level above so that it's not called once per record but only ~once per zone. In reality it's called three times per zone plus the initial call, so four times, per zone per iteration.

The goal of this quick fix is to avoid calling it once per record which currently leads to an enormous amount of requests to AWS.

The relevant issue: #869

/cc @njuettner @lbernail