### PR TITLE
Correctly set AWS annotation for EvaluateTargetHealth

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 		KubeMaster:               cfg.Master,
 		ServiceTypeFilter:        cfg.ServiceTypeFilter,
 		IstioIngressGateway:      cfg.IstioIngressGateway,
+		EvaluateTargetHealth:     cfg.AWSEvaluateTargetHealth,
 	}
 
 	// Lookup all the selected sources by names and pass them the desired configuration.
@@ -108,16 +109,15 @@ func main() {
 	case "aws":
 		p, err = provider.NewAWSProvider(
 			provider.AWSConfig{
-				DomainFilter:         domainFilter,
-				ZoneIDFilter:         zoneIDFilter,
-				ZoneTypeFilter:       zoneTypeFilter,
-				ZoneTagFilter:        zoneTagFilter,
-				BatchChangeSize:      cfg.AWSBatchChangeSize,
-				BatchChangeInterval:  cfg.AWSBatchChangeInterval,
-				EvaluateTargetHealth: cfg.AWSEvaluateTargetHealth,
-				AssumeRole:           cfg.AWSAssumeRole,
-				APIRetries:           cfg.AWSAPIRetries,
-				DryRun:               cfg.DryRun,
+				DomainFilter:        domainFilter,
+				ZoneIDFilter:        zoneIDFilter,
+				ZoneTypeFilter:      zoneTypeFilter,
+				ZoneTagFilter:       zoneTagFilter,
+				BatchChangeSize:     cfg.AWSBatchChangeSize,
+				BatchChangeInterval: cfg.AWSBatchChangeInterval,
+				AssumeRole:          cfg.AWSAssumeRole,
+				APIRetries:          cfg.AWSAPIRetries,
+				DryRun:              cfg.DryRun,
 			},
 		)
 	case "aws-sd":

--- a/provider/aws_test.go
+++ b/provider/aws_test.go
@@ -1061,15 +1061,14 @@ func newAWSProviderWithTagFilter(t *testing.T, domainFilter DomainFilter, zoneID
 	client := NewRoute53APIStub()
 
 	provider := &AWSProvider{
-		client:               client,
-		batchChangeSize:      defaultBatchChangeSize,
-		batchChangeInterval:  defaultBatchChangeInterval,
-		evaluateTargetHealth: evaluateTargetHealth,
-		domainFilter:         domainFilter,
-		zoneIDFilter:         zoneIDFilter,
-		zoneTypeFilter:       zoneTypeFilter,
-		zoneTagFilter:        zoneTagFilter,
-		dryRun:               false,
+		client:              client,
+		batchChangeSize:     defaultBatchChangeSize,
+		batchChangeInterval: defaultBatchChangeInterval,
+		domainFilter:        domainFilter,
+		zoneIDFilter:        zoneIDFilter,
+		zoneTypeFilter:      zoneTypeFilter,
+		zoneTagFilter:       zoneTagFilter,
+		dryRun:              false,
 	}
 
 	createAWSZone(t, provider, &route53.HostedZone{

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -46,6 +46,7 @@ type gatewaySource struct {
 	annotationFilter        string
 	fqdnTemplate            *template.Template
 	combineFQDNAnnotation   bool
+	evaluateTargetHealth    bool
 }
 
 // NewIstioGatewaySource creates a new gatewaySource with the given config.
@@ -57,6 +58,7 @@ func NewIstioGatewaySource(
 	annotationFilter string,
 	fqdnTemplate string,
 	combineFqdnAnnotation bool,
+	evaluateTargetHealth bool,
 ) (Source, error) {
 	var (
 		tmpl *template.Template
@@ -85,6 +87,7 @@ func NewIstioGatewaySource(
 		annotationFilter:        annotationFilter,
 		fqdnTemplate:            tmpl,
 		combineFQDNAnnotation:   combineFqdnAnnotation,
+		evaluateTargetHealth:    evaluateTargetHealth,
 	}, nil
 }
 
@@ -172,7 +175,7 @@ func (sc *gatewaySource) endpointsFromTemplate(config *istiomodel.Config) ([]*en
 		}
 	}
 
-	providerSpecific := getProviderSpecificAnnotations(config.Annotations)
+	providerSpecific := getProviderSpecificAnnotations(config.Annotations, sc.evaluateTargetHealth)
 
 	var endpoints []*endpoint.Endpoint
 	// splits the FQDN template and removes the trailing periods
@@ -258,7 +261,7 @@ func (sc *gatewaySource) endpointsFromGatewayConfig(config istiomodel.Config) ([
 
 	gateway := config.Spec.(*istionetworking.Gateway)
 
-	providerSpecific := getProviderSpecificAnnotations(config.Annotations)
+	providerSpecific := getProviderSpecificAnnotations(config.Annotations, sc.evaluateTargetHealth)
 
 	for _, server := range gateway.Servers {
 		for _, host := range server.Hosts {

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -68,6 +68,7 @@ func (suite *GatewaySuite) SetupTest() {
 		"",
 		"{{.Name}}",
 		false,
+		true,
 	)
 	suite.NoError(err, "should initialize gateway source")
 
@@ -141,6 +142,7 @@ func TestNewIstioGatewaySource(t *testing.T) {
 				ti.annotationFilter,
 				ti.fqdnTemplate,
 				ti.combineFQDNAndAnnotation,
+				true,
 			)
 			if ti.expectError {
 				assert.Error(t, err)
@@ -939,6 +941,7 @@ func testGatewayEndpoints(t *testing.T) {
 				ti.annotationFilter,
 				ti.fqdnTemplate,
 				ti.combineFQDNAndAnnotation,
+				true,
 			)
 			require.NoError(t, err)
 
@@ -972,6 +975,7 @@ func newTestGatewaySource(ingress *v1.Service) (*gatewaySource, error) {
 		"",
 		"{{.Name}}",
 		false,
+		true,
 	)
 	if err != nil {
 		return nil, err

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -50,6 +50,7 @@ func (suite *IngressSuite) SetupTest() {
 		"",
 		"{{.Name}}",
 		false,
+		true,
 	)
 	suite.NoError(err, "should initialize ingress source")
 
@@ -123,6 +124,7 @@ func TestNewIngressSource(t *testing.T) {
 				ti.annotationFilter,
 				ti.fqdnTemplate,
 				ti.combineFQDNAndAnnotation,
+				true,
 			)
 			if ti.expectError {
 				assert.Error(t, err)
@@ -210,7 +212,7 @@ func testEndpointsFromIngress(t *testing.T) {
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 			realIngress := ti.ingress.Ingress()
-			validateEndpoints(t, endpointsFromIngress(realIngress), ti.expected)
+			validateEndpoints(t, endpointsFromIngress(realIngress, true), ti.expected)
 		})
 	}
 }
@@ -948,6 +950,7 @@ func testIngressEndpoints(t *testing.T) {
 				ti.annotationFilter,
 				ti.fqdnTemplate,
 				ti.combineFQDNAndAnnotation,
+				true,
 			)
 			for _, ingress := range ingresses {
 				_, err := fakeClient.Extensions().Ingresses(ingress.Namespace).Create(ingress)

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -51,6 +51,7 @@ func (suite *ServiceSuite) SetupTest() {
 		false,
 		false,
 		[]string{},
+		true,
 	)
 	suite.fooWithTargets = &v1.Service{
 		Spec: v1.ServiceSpec{
@@ -142,6 +143,7 @@ func testServiceSourceNewServiceSource(t *testing.T) {
 				false,
 				false,
 				ti.serviceTypesFilter,
+				true,
 			)
 
 			if ti.expectError {
@@ -960,6 +962,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 				false,
 				false,
 				tc.serviceTypesFilter,
+				true,
 			)
 			require.NoError(t, err)
 
@@ -1095,6 +1098,7 @@ func TestClusterIpServices(t *testing.T) {
 				true,
 				false,
 				[]string{},
+				true,
 			)
 			require.NoError(t, err)
 
@@ -1292,6 +1296,7 @@ func TestNodePortServices(t *testing.T) {
 				true,
 				false,
 				[]string{},
+				true,
 			)
 			require.NoError(t, err)
 
@@ -1492,6 +1497,7 @@ func TestHeadlessServices(t *testing.T) {
 				true,
 				false,
 				[]string{},
+				true,
 			)
 			require.NoError(t, err)
 
@@ -1692,6 +1698,7 @@ func TestHeadlessServicesHostIP(t *testing.T) {
 				true,
 				true,
 				[]string{},
+				true,
 			)
 			require.NoError(t, err)
 
@@ -1732,7 +1739,7 @@ func BenchmarkServiceEndpoints(b *testing.B) {
 	_, err := kubernetes.CoreV1().Services(service.Namespace).Create(service)
 	require.NoError(b, err)
 
-	client, err := NewServiceSource(kubernetes, v1.NamespaceAll, "", "", false, "", false, false, []string{})
+	client, err := NewServiceSource(kubernetes, v1.NamespaceAll, "", "", false, "", false, false, []string{}, true)
 	require.NoError(b, err)
 
 	for i := 0; i < b.N; i++ {

--- a/source/source.go
+++ b/source/source.go
@@ -86,7 +86,7 @@ func getAliasFromAnnotations(annotations map[string]string) bool {
 	return exists && aliasAnnotation == "true"
 }
 
-func getProviderSpecificAnnotations(annotations map[string]string) endpoint.ProviderSpecific {
+func getProviderSpecificAnnotations(annotations map[string]string, defaultEvaluateTargetHealth bool) endpoint.ProviderSpecific {
 	providerSpecificAnnotations := endpoint.ProviderSpecific{}
 
 	v, exists := annotations[CloudflareProxiedKey]
@@ -102,10 +102,18 @@ func getProviderSpecificAnnotations(annotations map[string]string) endpoint.Prov
 			Value: "true",
 		})
 	}
-	providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
-		Name:  "aws/evaluate-target-health",
-		Value: "true",
-	})
+	v, exists = annotations["aws/evaluate-target-health"]
+	if exists {
+		providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+			Name:  "aws/evaluate-target-health",
+			Value: v,
+		})
+	} else {
+		providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+			Name:  "aws/evaluate-target-health",
+			Value: fmt.Sprintf("%t", defaultEvaluateTargetHealth),
+		})
+	}
 	return providerSpecificAnnotations
 }
 

--- a/source/source.go
+++ b/source/source.go
@@ -102,6 +102,10 @@ func getProviderSpecificAnnotations(annotations map[string]string) endpoint.Prov
 			Value: "true",
 		})
 	}
+	providerSpecificAnnotations = append(providerSpecificAnnotations, endpoint.ProviderSpecificProperty{
+		Name:  "aws/evaluate-target-health",
+		Value: "true",
+	})
 	return providerSpecificAnnotations
 }
 

--- a/source/store.go
+++ b/source/store.go
@@ -52,6 +52,7 @@ type Config struct {
 	KubeMaster               string
 	ServiceTypeFilter        []string
 	IstioIngressGateway      string
+	EvaluateTargetHealth     bool
 }
 
 // ClientGenerator provides clients
@@ -112,13 +113,13 @@ func BuildWithConfig(source string, p ClientGenerator, cfg *Config) (Source, err
 		if err != nil {
 			return nil, err
 		}
-		return NewServiceSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP, cfg.ServiceTypeFilter)
+		return NewServiceSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.Compatibility, cfg.PublishInternal, cfg.PublishHostIP, cfg.ServiceTypeFilter, cfg.EvaluateTargetHealth)
 	case "ingress":
 		client, err := p.KubeClient()
 		if err != nil {
 			return nil, err
 		}
-		return NewIngressSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation)
+		return NewIngressSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.EvaluateTargetHealth)
 	case "istio-gateway":
 		kubernetesClient, err := p.KubeClient()
 		if err != nil {
@@ -128,7 +129,7 @@ func BuildWithConfig(source string, p ClientGenerator, cfg *Config) (Source, err
 		if err != nil {
 			return nil, err
 		}
-		return NewIstioGatewaySource(kubernetesClient, istioClient, cfg.IstioIngressGateway, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation)
+		return NewIstioGatewaySource(kubernetesClient, istioClient, cfg.IstioIngressGateway, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.EvaluateTargetHealth)
 	case "fake":
 		return NewFakeSource(cfg.FQDNTemplate)
 	case "connector":


### PR DESCRIPTION
In https://github.com/kubernetes-incubator/external-dns/pull/650 we added that the planning phase is able to detect when provider-specific annotations have changed so that a record update can be triggered (`shouldUpdateProviderSpecific`).

However, we didn't consider all the cases and forgot to define the annotation in the `desired` set of records. This leads to a permanent diff between current and desired records which will trigger a lot of `ApplyChanges` calls.

The issue that triggered this: https://github.com/kubernetes-incubator/external-dns/issues/869#issuecomment-458291804

The actual fix is rather simple: https://github.com/kubernetes-incubator/external-dns/commit/606db32416eb6de5d04cd17cf1d0b429aa936755 (similar to the cloudflare proxy annotation). However, making sure that the global flag `--aws-evaluate-target-health` works as before turned out to require a lot of other changes (the other commit). We needed to move the struct field `evaluateTargetHealth` from the provider to the source.