### PR TITLE
fix test of ProviderSpecific comparison

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -186,6 +186,9 @@ func shouldUpdateTTL(desired, current *endpoint.Endpoint) bool {
 }
 
 func shouldUpdateProviderSpecific(desired, current *endpoint.Endpoint) bool {
+	if current.ProviderSpecific == nil && len(desired.ProviderSpecific) == 0 {
+		return false
+	}
 	for _, c := range current.ProviderSpecific {
 		// don't consider target health when detecting changes
 		// see: https://github.com/kubernetes-incubator/external-dns/issues/869#issuecomment-458576954


### PR DESCRIPTION
I believe this will fix the "constant updating" issue introduced in 0.5.10 for all providers (#883, #879) except AWS, which will still require something like #880 to be applied, since that is a different comparison problem of properties that exist on one side only.

At issue is that providers not using the new ProviderSpecific mechanism will have endpoints where ProviderSpecific is `<nil>`, where the endpoints from sources with no ProviderSpecific elements is instead set to an empty list of that type.

This change simply adds a test for the specific test of "provider is nil, source is empty" and returns false.

There may be a better way to fix this impedance mismatch between the two interfaces, but this quick fix should address the majority of problems.

A built container combining this with #880 is available at `viafoura/external-dns:combined-update-fix`, and seems to fix the issue. (Though I am only testing AWS provider... which is testing #880 more than this PR....)

Signed-off-by: Joe Hohertz <joe@viafoura.com>