### PR TITLE
Add ready-pods-only annotation

### DIFF
--- a/source/service.go
+++ b/source/service.go
@@ -175,6 +175,19 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 
 	targetsByHeadlessDomain := make(map[string][]string)
 	for _, v := range pods.Items {
+		if getReadyPodsOnlyFromAnnotations(svc.Annotations) {
+			podReady := false
+			for _, condition := range v.Status.Conditions {
+				if condition.Type == v1.PodReady && condition.Status == v1.ConditionTrue {
+					podReady = true
+					break
+				}
+			}
+			if !podReady {
+				continue
+			}
+		}
+
 		headlessDomain := hostname
 		if v.Spec.Hostname != "" {
 			headlessDomain = v.Spec.Hostname + "." + headlessDomain

--- a/source/service.go
+++ b/source/service.go
@@ -174,8 +174,9 @@ func (sc *serviceSource) extractHeadlessEndpoints(svc *v1.Service, hostname stri
 	}
 
 	targetsByHeadlessDomain := make(map[string][]string)
+	considerReadyPodsOnly := getReadyPodsOnlyFromAnnotations(svc.Annotations)
 	for _, v := range pods.Items {
-		if getReadyPodsOnlyFromAnnotations(svc.Annotations) {
+		if considerReadyPodsOnly {
 			podReady := false
 			for _, condition := range v.Status.Conditions {
 				if condition.Type == v1.PodReady && condition.Status == v1.ConditionTrue {

--- a/source/source.go
+++ b/source/source.go
@@ -35,6 +35,8 @@ const (
 	targetAnnotationKey = "external-dns.alpha.kubernetes.io/target"
 	// The annotation used for defining the desired DNS record TTL
 	ttlAnnotationKey = "external-dns.alpha.kubernetes.io/ttl"
+	// The annotation used for selecting ready pods only for headless services
+	readyPodsOnlyAnnotationKey = "external-dns.alpha.kubernetes.io/ready-pods-only"
 	// The annotation used for switching to the alias record types e. g. AWS Alias records instead of a normal CNAME
 	aliasAnnotationKey = "external-dns.alpha.kubernetes.io/alias"
 	// The value of the controller annotation so that we feel responsible
@@ -79,6 +81,11 @@ func getHostnamesFromAnnotations(annotations map[string]string) []string {
 		return nil
 	}
 	return strings.Split(strings.Replace(hostnameAnnotation, " ", "", -1), ",")
+}
+
+func getReadyPodsOnlyFromAnnotations(annotations map[string]string) bool {
+	_, exists := annotations[readyPodsOnlyAnnotationKey]
+	return exists
 }
 
 func getAliasFromAnnotations(annotations map[string]string) bool {


### PR DESCRIPTION
This annotation can be used to only register IPs of pods that are in
"Ready" state (instead of the default behavior of registering all
running pods) in DNS.