### PR TITLE
Document make dep step which may be needed to run make build

### DIFF
--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -2,7 +2,7 @@
 
 ### Building
 
-You can build ExternalDNS for your platform with `make build`, you may have to install the necessary dependencies with `sudo make dep`. The binary will land at `build/external-dns`.
+You can build ExternalDNS for your platform with `make build`, you may have to install the necessary dependencies with `make dep`. The binary will land at `build/external-dns`.
 
 ### Design
 

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -2,7 +2,7 @@
 
 ### Building
 
-You can build ExternalDNS for your platform with `make build`. The binary will land at `build/external-dns`.
+You can build ExternalDNS for your platform with `make build`, you may have to install the necessary dependencies with `sudo make dep`. The binary will land at `build/external-dns`.
 
 ### Design
 


### PR DESCRIPTION
This PR adds more information to the `Building` section of the getting started guide, by adding the required `make dep` step. 

Closed #908. 