### PR TITLE
Use k8s informer cache instead of making active API GET requests

### DIFF
--- a/source/ingress.go
+++ b/source/ingress.go
@@ -23,14 +23,17 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/kubernetes-incubator/external-dns/endpoint"
 	log "github.com/sirupsen/logrus"
-
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeinformers "k8s.io/client-go/informers"
+	extinformers "k8s.io/client-go/informers/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/kubernetes-incubator/external-dns/endpoint"
+	"k8s.io/client-go/tools/cache"
+	"time"
 )
 
 // ingressSource is an implementation of Source for Kubernetes ingress objects.
@@ -44,6 +47,7 @@ type ingressSource struct {
 	fqdnTemplate             *template.Template
 	combineFQDNAnnotation    bool
 	ignoreHostnameAnnotation bool
+	ingressInformer          extinformers.IngressInformer
 }
 
 // NewIngressSource creates a new ingressSource with the given config.
@@ -61,31 +65,57 @@ func NewIngressSource(kubeClient kubernetes.Interface, namespace, annotationFilt
 		}
 	}
 
-	return &ingressSource{
+	// Use shared informer to listen for add/update/delete of ingresses in the specified namespace.
+	// Set resync period to 0, to prevent processing when nothing has changed.
+	informerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, 0, kubeinformers.WithNamespace(namespace))
+	ingressInformer := informerFactory.Extensions().V1beta1().Ingresses()
+
+	// Add default resource event handlers to properly initialize informer.
+	ingressInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+			},
+		},
+	)
+
+	// TODO informer is not explicitly stopped since controller is not passing in its channel.
+	informerFactory.Start(wait.NeverStop)
+
+	// wait for the local cache to be populated.
+	err = wait.Poll(time.Second, 60*time.Second, func() (bool, error) {
+		return ingressInformer.Informer().HasSynced() == true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to sync cache: %v", err)
+	}
+
+	sc := &ingressSource{
 		client:                   kubeClient,
 		namespace:                namespace,
 		annotationFilter:         annotationFilter,
 		fqdnTemplate:             tmpl,
 		combineFQDNAnnotation:    combineFqdnAnnotation,
 		ignoreHostnameAnnotation: ignoreHostnameAnnotation,
-	}, nil
+		ingressInformer:          ingressInformer,
+	}
+	return sc, nil
 }
 
 // Endpoints returns endpoint objects for each host-target combination that should be processed.
 // Retrieves all ingress resources on all namespaces
 func (sc *ingressSource) Endpoints() ([]*endpoint.Endpoint, error) {
-	ingresses, err := sc.client.Extensions().Ingresses(sc.namespace).List(metav1.ListOptions{})
+	ingresses, err := sc.ingressInformer.Lister().Ingresses(sc.namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
-	ingresses.Items, err = sc.filterByAnnotations(ingresses.Items)
+	ingresses, err = sc.filterByAnnotations(ingresses)
 	if err != nil {
 		return nil, err
 	}
 
 	endpoints := []*endpoint.Endpoint{}
 
-	for _, ing := range ingresses.Items {
+	for _, ing := range ingresses {
 		// Check controller annotation to see if we are responsible.
 		controller, ok := ing.Annotations[controllerAnnotationKey]
 		if ok && controller != controllerAnnotationValue {
@@ -94,11 +124,11 @@ func (sc *ingressSource) Endpoints() ([]*endpoint.Endpoint, error) {
 			continue
 		}
 
-		ingEndpoints := endpointsFromIngress(&ing, sc.ignoreHostnameAnnotation)
+		ingEndpoints := endpointsFromIngress(ing, sc.ignoreHostnameAnnotation)
 
 		// apply template if host is missing on ingress
 		if (sc.combineFQDNAnnotation || len(ingEndpoints) == 0) && sc.fqdnTemplate != nil {
-			iEndpoints, err := sc.endpointsFromTemplate(&ing)
+			iEndpoints, err := sc.endpointsFromTemplate(ing)
 			if err != nil {
 				return nil, err
 			}
@@ -161,7 +191,7 @@ func (sc *ingressSource) endpointsFromTemplate(ing *v1beta1.Ingress) ([]*endpoin
 }
 
 // filterByAnnotations filters a list of ingresses by a given annotation selector.
-func (sc *ingressSource) filterByAnnotations(ingresses []v1beta1.Ingress) ([]v1beta1.Ingress, error) {
+func (sc *ingressSource) filterByAnnotations(ingresses []*v1beta1.Ingress) ([]*v1beta1.Ingress, error) {
 	labelSelector, err := metav1.ParseToLabelSelector(sc.annotationFilter)
 	if err != nil {
 		return nil, err
@@ -176,7 +206,7 @@ func (sc *ingressSource) filterByAnnotations(ingresses []v1beta1.Ingress) ([]v1b
 		return ingresses, nil
 	}
 
-	filteredList := []v1beta1.Ingress{}
+	filteredList := []*v1beta1.Ingress{}
 
 	for _, ingress := range ingresses {
 		// convert the ingress' annotations to an equivalent label selector
@@ -191,7 +221,7 @@ func (sc *ingressSource) filterByAnnotations(ingresses []v1beta1.Ingress) ([]v1b
 	return filteredList, nil
 }
 
-func (sc *ingressSource) setResourceLabel(ingress v1beta1.Ingress, endpoints []*endpoint.Endpoint) {
+func (sc *ingressSource) setResourceLabel(ingress *v1beta1.Ingress, endpoints []*endpoint.Endpoint) {
 	for _, ep := range endpoints {
 		ep.Labels[endpoint.ResourceLabelKey] = fmt.Sprintf("ingress/%s/%s", ingress.Namespace, ingress.Name)
 	}

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -18,10 +18,12 @@ package source
 
 import (
 	"testing"
+	"time"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
@@ -990,7 +992,19 @@ func testIngressEndpoints(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			res, err := ingressSource.Endpoints()
+			var res []*endpoint.Endpoint
+			var err error
+
+			// wait up to a few seconds for new resources to appear in informer cache.
+			err = wait.Poll(time.Second, 3*time.Second, func() (bool, error) {
+				res, err = ingressSource.Endpoints()
+				if err != nil {
+					// stop waiting if we get an error
+					return true, err
+				}
+				return len(res) >= len(ti.expected), nil
+			})
+
 			if ti.expectError {
 				assert.Error(t, err)
 			} else {

--- a/source/service_test.go
+++ b/source/service_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package source
 
 import (
+	"k8s.io/apimachinery/pkg/util/wait"
 	"net"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1087,7 +1089,18 @@ func testServiceSourceEndpoints(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			endpoints, err := client.Endpoints()
+			var res []*endpoint.Endpoint
+
+			// wait up to a few seconds for new resources to appear in informer cache.
+			err = wait.Poll(time.Second, 3*time.Second, func() (bool, error) {
+				res, err = client.Endpoints()
+				if err != nil {
+					// stop waiting if we get an error
+					return true, err
+				}
+				return len(res) >= len(tc.expected), nil
+			})
+
 			if tc.expectError {
 				require.Error(t, err)
 			} else {
@@ -1095,7 +1108,7 @@ func testServiceSourceEndpoints(t *testing.T) {
 			}
 
 			// Validate returned endpoints against desired endpoints.
-			validateEndpoints(t, endpoints, tc.expected)
+			validateEndpoints(t, res, tc.expected)
 		})
 	}
 }

--- a/source/shared_test.go
+++ b/source/shared_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package source
 
 import (
-	"testing"
-
 	"github.com/kubernetes-incubator/external-dns/endpoint"
+	"sort"
+	"strings"
+	"testing"
 )
 
 // test helper functions
@@ -28,6 +29,13 @@ func validateEndpoints(t *testing.T, endpoints, expected []*endpoint.Endpoint) {
 	if len(endpoints) != len(expected) {
 		t.Fatalf("expected %d endpoints, got %d", len(expected), len(endpoints))
 	}
+	// Make sure endpoints are sorted - validateEndpoint() depends on it.
+	sort.SliceStable(endpoints, func(i, j int) bool {
+		return strings.Compare(endpoints[i].DNSName, endpoints[j].DNSName) < 0
+	})
+	sort.SliceStable(expected, func(i, j int) bool {
+		return strings.Compare(expected[i].DNSName, expected[j].DNSName) < 0
+	})
 
 	for i := range endpoints {
 		validateEndpoint(t, endpoints[i], expected[i])


### PR DESCRIPTION
This pull requests updates both `source/ingress.go` and `source/service.go` to use Kubernetes Informer data cache rather than making active API server calls. 

Currently, both `source/ingress.go` and `source/service.go` issue `GET` requests on the API server every sync loop to calculate endpoints. The latter actually issues `GET` requests for `Services`, `Pods`, _and) `Nodes` to calculate its endpoints. As @lbernail [pointed out](https://github.com/kubernetes-incubator/external-dns/pull/687#issuecomment-458547769) in a [related pull request](https://github.com/kubernetes-incubator/external-dns/pull/687), these types of active API calls can be expensive and introduce significant latency on large clusters.