### PR TITLE
Dropping owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,12 +2,7 @@
 #  https://github.com/kubernetes/kubernetes/blob/master/docs/devel/owners.md
 
 approvers:
-  - justinsb
   - hjacobs
   - raffo
   - linki
-  - ideahitme
-  - chrislovecnm
-  - kris-nova
-  - iterion
   - njuettner


### PR DESCRIPTION
In favour of assigning people who are still actively reviewing PR's, I would like to drop people who don't have the time to review or are not active in this project anymore.

This is only a proposal and open for discussion.