### PR TITLE
Tiny clarification about two available deployment methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Note that all flags can be replaced with environment variables; for instance,
 `--dry-run` could be replaced with `EXTERNAL_DNS_DRY_RUN=1`, or
 `--registry txt` could be replaced with `EXTERNAL_DNS_REGISTRY=txt`.
 
+## There are two ways of running ExternalDNS:
+* Deploying to a Cluster
+* Running Locally
+
 ## Deploying to a Cluster
 
 The following tutorials are provided:


### PR DESCRIPTION
This PR is based on my experience as a total beginner with ExternalDNS: I looked at the documentation (didn't know how it works internally) and it wasn't clear for me if I use both methods (Deploying to a Cluster and Running locally) or just one of them. The PR clarifies this confusion.