### PR TITLE
Bumping istio to 1.1.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -197,6 +197,24 @@
   version = "v0.14.0"
 
 [[projects]]
+  digest = "1:a2d7fd2421a8578c4adea9830bef9d17366e4640edb57735dff2d1dc68815a9e"
+  name = "github.com/envoyproxy/go-control-plane"
+  packages = [
+    "envoy/api/v2",
+    "envoy/api/v2/auth",
+    "envoy/api/v2/cluster",
+    "envoy/api/v2/core",
+    "envoy/api/v2/endpoint",
+    "envoy/api/v2/listener",
+    "envoy/api/v2/route",
+    "envoy/config/grpc_credential/v2alpha",
+    "envoy/type",
+  ]
+  pruneopts = ""
+  revision = "0ad6fa1cf0b9b6ca8f3617a7188a568e81f40b87"
+  version = "v0.6.9"
+
+[[projects]]
   digest = "1:e17d18b233f506404061c27ac4a08624dad38dcd0d49f9cfdae67a7772a4fb8c"
   name = "github.com/exoscale/egoscale"
   packages = ["."]
@@ -239,7 +257,10 @@
 [[projects]]
   digest = "1:54d5c6a784a9de9c836fc070d51d0689c3e99ee6d24dba8a36f0762039dae830"
   name = "github.com/gogo/googleapis"
-  packages = ["google/rpc"]
+  packages = [
+    "google/api",
+    "google/rpc",
+  ]
   pruneopts = ""
   revision = "8558fb44d2f1fc223118afc694129d2c2d2924d1"
   version = "v1.1.0"
@@ -272,13 +293,11 @@
   digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
   name = "github.com/golang/protobuf"
   packages = [
-    "jsonpb",
     "proto",
     "protoc-gen-go/descriptor",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/struct",
     "ptypes/timestamp",
   ]
   pruneopts = ""
@@ -292,19 +311,6 @@
   packages = ["."]
   pruneopts = ""
   revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
-
-[[projects]]
-  digest = "1:f9f45f75f332e03fc7e9fe9188ea4e1ce4d14779ef34fa1b023da67518e36327"
-  name = "github.com/google/go-cmp"
-  packages = [
-    "cmp",
-    "cmp/internal/diff",
-    "cmp/internal/function",
-    "cmp/internal/value",
-  ]
-  pruneopts = ""
-  revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
-  version = "v0.2.0"
 
 [[projects]]
   branch = "master"
@@ -468,6 +474,14 @@
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:a404c6713d3e7fb61746c8bc355c6009ddb8fbb2e376ce33c03881645217f1a1"
+  name = "github.com/lyft/protoc-gen-validate"
+  packages = ["validate"]
+  pruneopts = ""
+  revision = "ff6f7a9bc2e5fe006509b9f8c7594c41a953d50f"
+  version = "v0.0.14"
+
+[[projects]]
   branch = "master"
   digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
   name = "github.com/matttproud/golang_protobuf_extensions"
@@ -574,15 +588,16 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:2f69dc6b2685b31a1a410ef697410aa8a669704fb201d45dbd8c1911728afa75"
+  digest = "1:6f218995d6a74636cfcab45ce03005371e682b4b9bee0e5eb0ccfd83ef85364f"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
+    "prometheus/internal",
     "prometheus/promhttp",
   ]
   pruneopts = ""
-  revision = "967789050ba94deca04a5e84cce8ad472ce313c1"
-  version = "v0.9.0-pre1"
+  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
+  version = "v0.9.2"
 
 [[projects]]
   branch = "master"
@@ -682,6 +697,17 @@
   packages = ["."]
   pruneopts = ""
   revision = "ac974c61c2f990f4115b119354b5e0b47550e888"
+
+[[projects]]
+  branch = "master"
+  digest = "1:cd1c3692d12b8c8e4a2d8af87de070b21a1c8e67fdd1d8dc31aa14791394fa17"
+  name = "github.com/yl2chen/cidranger"
+  packages = [
+    ".",
+    "net",
+  ]
+  pruneopts = ""
+  revision = "928b519e5268fe386d0f7decce320205cc09ca95"
 
 [[projects]]
   digest = "1:74f86c458e82e1c4efbab95233e0cf51b7cc02dc03193be9f62cd81224e10401"
@@ -905,8 +931,8 @@
   version = "v2.2.1"
 
 [[projects]]
-  branch = "release-1.0"
-  digest = "1:bc43af6616d8ca12a7b8e806874387f0f1e181c08f547e9cd77f6cbac8cefd86"
+  branch = "release-1.1"
+  digest = "1:17f75d4a08eab0d4bb4a862a6a0e6789c9065063b450c7850c835ccde85e0981"
   name = "istio.io/api"
   packages = [
     "authentication/v1alpha1",
@@ -914,26 +940,31 @@
     "mixer/v1",
     "mixer/v1/config/client",
     "networking/v1alpha3",
+    "policy/v1beta1",
     "rbac/v1alpha1",
   ]
   pruneopts = ""
-  revision = "76349c53b87f03f1e610b3aa3843dba3c38138d7"
+  revision = "db16d82d3672586b4beec10c1af0643d518cb454"
 
 [[projects]]
-  digest = "1:7eb25280e1f610470bb0c43ab6c91573cfc78672a58542106b9b71705581429a"
+  digest = "1:901e05af6afa9e7b49028d97c5f39c86470bec561153e0cc931dfd6c9c5ec2ed"
   name = "istio.io/istio"
   packages = [
+    "galley/pkg/metadata",
+    "galley/pkg/runtime/resource",
     "pilot/pkg/config/kube/crd",
     "pilot/pkg/model",
     "pilot/pkg/model/test",
     "pilot/pkg/serviceregistry/kube",
     "pkg/cache",
+    "pkg/features/pilot",
     "pkg/kube",
     "pkg/log",
+    "pkg/spiffe",
   ]
   pruneopts = ""
-  revision = "42773aacced474d97159902d20579a25b1f98106"
-  version = "1.0.1"
+  revision = "2b1331886076df103179e3da5dc9077fed59c989"
+  version = "1.1.1"
 
 [[projects]]
   digest = "1:f420c8548c93242d8e5dcfa5b34e0243883b4e660f65076e869daafac877144d"
@@ -974,7 +1005,8 @@
   version = "kubernetes-1.11.0"
 
 [[projects]]
-  digest = "1:66d1421ecff35bc48ee0b11a3f891f3af6f775ed6bb1d3e0deeaba221bf42490"
+  branch = "release-1.11"
+  digest = "1:545b132408a3b9c330cd062bb336b91d9578576623b440c753d81b45c968d7d3"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -984,8 +1016,7 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
   ]
   pruneopts = ""
-  revision = "8e7f43002fec5394a8d96ebca781aa9d4b37aaef"
-  version = "kubernetes-1.10.4"
+  revision = "57c81b676ab11a0924f53d62f3fdccb8e784df03"
 
 [[projects]]
   digest = "1:b6b2fb7b4da1ac973b64534ace2299a02504f16bc7820cb48edb8ca4077183e1"
@@ -1043,6 +1074,47 @@
   packages = [
     "discovery",
     "discovery/fake",
+    "informers",
+    "informers/admissionregistration",
+    "informers/admissionregistration/v1alpha1",
+    "informers/admissionregistration/v1beta1",
+    "informers/apps",
+    "informers/apps/v1",
+    "informers/apps/v1beta1",
+    "informers/apps/v1beta2",
+    "informers/autoscaling",
+    "informers/autoscaling/v1",
+    "informers/autoscaling/v2beta1",
+    "informers/batch",
+    "informers/batch/v1",
+    "informers/batch/v1beta1",
+    "informers/batch/v2alpha1",
+    "informers/certificates",
+    "informers/certificates/v1beta1",
+    "informers/core",
+    "informers/core/v1",
+    "informers/events",
+    "informers/events/v1beta1",
+    "informers/extensions",
+    "informers/extensions/v1beta1",
+    "informers/internalinterfaces",
+    "informers/networking",
+    "informers/networking/v1",
+    "informers/policy",
+    "informers/policy/v1beta1",
+    "informers/rbac",
+    "informers/rbac/v1",
+    "informers/rbac/v1alpha1",
+    "informers/rbac/v1beta1",
+    "informers/scheduling",
+    "informers/scheduling/v1alpha1",
+    "informers/scheduling/v1beta1",
+    "informers/settings",
+    "informers/settings/v1alpha1",
+    "informers/storage",
+    "informers/storage/v1",
+    "informers/storage/v1alpha1",
+    "informers/storage/v1beta1",
     "kubernetes",
     "kubernetes/fake",
     "kubernetes/scheme",
@@ -1104,6 +1176,31 @@
     "kubernetes/typed/storage/v1alpha1/fake",
     "kubernetes/typed/storage/v1beta1",
     "kubernetes/typed/storage/v1beta1/fake",
+    "listers/admissionregistration/v1alpha1",
+    "listers/admissionregistration/v1beta1",
+    "listers/apps/v1",
+    "listers/apps/v1beta1",
+    "listers/apps/v1beta2",
+    "listers/autoscaling/v1",
+    "listers/autoscaling/v2beta1",
+    "listers/batch/v1",
+    "listers/batch/v1beta1",
+    "listers/batch/v2alpha1",
+    "listers/certificates/v1beta1",
+    "listers/core/v1",
+    "listers/events/v1beta1",
+    "listers/extensions/v1beta1",
+    "listers/networking/v1",
+    "listers/policy/v1beta1",
+    "listers/rbac/v1",
+    "listers/rbac/v1alpha1",
+    "listers/rbac/v1beta1",
+    "listers/scheduling/v1alpha1",
+    "listers/scheduling/v1beta1",
+    "listers/settings/v1alpha1",
+    "listers/storage/v1",
+    "listers/storage/v1alpha1",
+    "listers/storage/v1beta1",
     "pkg/apis/clientauthentication",
     "pkg/apis/clientauthentication/v1alpha1",
     "pkg/apis/clientauthentication/v1beta1",
@@ -1218,11 +1315,16 @@
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/client-go/informers",
+    "k8s.io/client-go/informers/core/v1",
+    "k8s.io/client-go/informers/extensions/v1beta1",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/plugin/pkg/client/auth",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/rest/fake",
+    "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -78,7 +78,7 @@ ignored = ["github.com/kubernetes/repo-infra/kazel"]
 
 [[constraint]]
   name = "istio.io/istio"
-  version = "1.0.0"
+  version = "1.1.0"
 
 [[override]]
   name = "github.com/golang/glog"

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -1224,13 +1224,12 @@ func (f *fakeConfigStore) ConfigDescriptor() istiomodel.ConfigDescriptor {
 	return f.descriptor
 }
 
-func (f *fakeConfigStore) Get(typ, name, namespace string) (config *istiomodel.Config, exists bool) {
+func (f *fakeConfigStore) Get(typ, name, namespace string) (config *istiomodel.Config) {
 	f.RLock()
 	defer f.RUnlock()
 
 	if cfg, _ := f.get(typ, name, namespace); cfg != nil {
 		config = cfg
-		exists = true
 	}
 
 	return


### PR DESCRIPTION
- Adjusting dep to pull in istio 1.1.0 libraries.
- Updating fake GatewayConfigStore Get method to work with 1.1.0

Tested with `make test` and this worked correctly with my test cluster (while current external-dns could not work if istio 1.1.0-specific features were enabled (like Multicluster Gateways, etc.))

Should fix #933 ... without this patch I can't get external-dns to work on my istio-1.1.0 powered cluster... but I don't personally use SDS yet.  You can pull the compiled/built container image [here](http://quay.io/venezia/external-dns:latest)
