### PR TITLE
Remove superfluous trailing period from hostname

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -216,7 +216,7 @@ kind: Service
 metadata:
   name: nginx
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: nginx.external-dns-test.my-org.com.
+    external-dns.alpha.kubernetes.io/hostname: nginx.external-dns-test.my-org.com
 spec:
   type: LoadBalancer
   ports:
@@ -312,7 +312,7 @@ kind: Service
 metadata:
   name: nginx
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: nginx.external-dns-test.my-org.com.
+    external-dns.alpha.kubernetes.io/hostname: nginx.external-dns-test.my-org.com
     external-dns.alpha.kubernetes.io/ttl: 60
 spec:
     ...


### PR DESCRIPTION
Tutorial specifies version >0.4 which also removed the requirement for a trailing period.  New users could misunderstand the trailing dot as a significant syntax.  Removing the dot simplifies the configuration of the annotation.