### PR TITLE
Fix alibaba cloud config file missing by enable sts token

### DIFF
--- a/docs/tutorials/alibabacloud.md
+++ b/docs/tutorials/alibabacloud.md
@@ -381,4 +381,4 @@ Give ExternalDNS some time to clean up the DNS records for you. Then delete the 
 $ aliyun alidns DeleteDomain --DomainName external-dns-test.com
 ```
 
-For more info about Alibaba Cloud external dns, please refer this docs [link](https://yq.aliyun.com/articles/633412)
+For more info about Alibaba Cloud external dns, please refer this [docs](https://yq.aliyun.com/articles/633412)

--- a/docs/tutorials/alibabacloud.md
+++ b/docs/tutorials/alibabacloud.md
@@ -380,3 +380,5 @@ Give ExternalDNS some time to clean up the DNS records for you. Then delete the 
 ```console
 $ aliyun alidns DeleteDomain --DomainName external-dns-test.com
 ```
+
+For more info about Alibaba Cloud external dns, please refer this docs [link](https://yq.aliyun.com/articles/633412)

--- a/docs/tutorials/alibabacloud.md
+++ b/docs/tutorials/alibabacloud.md
@@ -194,6 +194,7 @@ spec:
         - --alibaba-cloud-zone-type=public # only look at public hosted zones (valid values are public, private or no value for both)
         - --registry=txt
         - --txt-owner-id=my-identifier
+        - --alibaba-cloud-config-file= # enable sts token 
         volumeMounts:
         - mountPath: /usr/share/zoneinfo
           name: hostpath


### PR DESCRIPTION
Without this flag, it will be error log below 

```
time="2019-04-14T07:04:52Z" level=fatal msg="Failed to read Alibaba Cloud config file '/etc/kubernetes/alibaba-cloud.json': open /etc/kubernetes/alibaba-cloud.json: no such file or directory"
```

For docs, the roles will enable sts token function , so add this flag.

Pls @njuettner  take a look.