### PR TITLE
Remove disable-addon argument from gke + nginx tutorial

### DIFF
--- a/docs/tutorials/nginx-ingress.md
+++ b/docs/tutorials/nginx-ingress.md
@@ -15,8 +15,7 @@ Create a GKE cluster without using the default ingress controller.
 ```console
 $ gcloud container clusters create "external-dns" \
     --num-nodes 1 \
-    --scopes "https://www.googleapis.com/auth/ndev.clouddns.readwrite" \
-    --disable-addons=HttpLoadBalancing
+    --scopes "https://www.googleapis.com/auth/ndev.clouddns.readwrite"
 ```
 
 Create a DNS zone which will contain the managed DNS records.


### PR DESCRIPTION
[The option isn't part of the the create cluster command](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create).