### PR TITLE
Azure: Support multiple A targets.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN make build
 FROM registry.opensource.zalan.do/stups/alpine:latest
 LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
 
-COPY --from=builder /kubernetes-incubator/external-dns/build/external-dns /bin/external-dns
+COPY --from=builder /github.com/kubernetes-incubator/external-dns/build/external-dns /bin/external-dns
 
 USER nobody
 

--- a/provider/azure.go
+++ b/provider/azure.go
@@ -179,9 +179,9 @@ func (p *AzureProvider) Records() (endpoints []*endpoint.Endpoint, _ error) {
 				return true
 			}
 			name := formatAzureDNSName(*recordSet.Name, *zone.Name)
-			target := extractAzureTarget(&recordSet)
-			if target == "" {
-				log.Errorf("Failed to extract target for '%s' with type '%s'.", name, recordType)
+			targets := extractAzureTargets(&recordSet)
+			if len(targets) == 0 {
+				log.Errorf("Failed to extract targets for '%s' with type '%s'.", name, recordType)
 				return true
 			}
 			var ttl endpoint.TTL
@@ -189,7 +189,7 @@ func (p *AzureProvider) Records() (endpoints []*endpoint.Endpoint, _ error) {
 				ttl = endpoint.TTL(*recordSet.TTL)
 			}
 
-			ep := endpoint.NewEndpointWithTTL(name, recordType, endpoint.TTL(ttl), target)
+			ep := endpoint.NewEndpointWithTTL(name, recordType, endpoint.TTL(ttl), targets...)
 			log.Debugf(
 				"Found %s record for '%s' with target '%s'.",
 				ep.RecordType,
@@ -414,14 +414,16 @@ func (p *AzureProvider) newRecordSet(endpoint *endpoint.Endpoint) (dns.RecordSet
 	}
 	switch dns.RecordType(endpoint.RecordType) {
 	case dns.A:
+		aRecords := make([]dns.ARecord, len(endpoint.Targets))
+		for i, target := range endpoint.Targets {
+			aRecords[i] = dns.ARecord{
+				Ipv4Address: to.StringPtr(target),
+			}
+		}
 		return dns.RecordSet{
 			RecordSetProperties: &dns.RecordSetProperties{
-				TTL: to.Int64Ptr(ttl),
-				ARecords: &[]dns.ARecord{
-					{
-						Ipv4Address: to.StringPtr(endpoint.Targets[0]),
-					},
-				},
+				TTL:      to.Int64Ptr(ttl),
+				ARecords: &aRecords,
 			},
 		}, nil
 	case dns.CNAME:
@@ -459,22 +461,26 @@ func formatAzureDNSName(recordName, zoneName string) string {
 }
 
 // Helper function (shared with text code)
-func extractAzureTarget(recordSet *dns.RecordSet) string {
+func extractAzureTargets(recordSet *dns.RecordSet) []string {
 	properties := recordSet.RecordSetProperties
 	if properties == nil {
-		return ""
+		return []string{}
 	}
 
 	// Check for A records
 	aRecords := properties.ARecords
 	if aRecords != nil && len(*aRecords) > 0 && (*aRecords)[0].Ipv4Address != nil {
-		return *(*aRecords)[0].Ipv4Address
+		targets := make([]string, len(*aRecords))
+		for i, aRecord := range *aRecords {
+			targets[i] = *aRecord.Ipv4Address
+		}
+		return targets
 	}
 
 	// Check for CNAME records
 	cnameRecord := properties.CnameRecord
 	if cnameRecord != nil && cnameRecord.Cname != nil {
-		return *cnameRecord.Cname
+		return []string{*cnameRecord.Cname}
 	}
 
 	// Check for TXT records
@@ -482,8 +488,8 @@ func extractAzureTarget(recordSet *dns.RecordSet) string {
 	if txtRecords != nil && len(*txtRecords) > 0 && (*txtRecords)[0].Value != nil {
 		values := (*txtRecords)[0].Value
 		if values != nil && len(*values) > 0 {
-			return (*values)[0]
+			return []string{(*values)[0]}
 		}
 	}
-	return ""
+	return []string{}
 }

--- a/provider/azure_test.go
+++ b/provider/azure_test.go
@@ -57,47 +57,52 @@ func (client *mockZonesClient) ListByResourceGroupNextResults(lastResults dns.Zo
 	return dns.ZoneListResult{}, nil
 }
 
-func aRecordSetPropertiesGetter(value string, ttl int64) *dns.RecordSetProperties {
+func aRecordSetPropertiesGetter(values []string, ttl int64) *dns.RecordSetProperties {
+	aRecords := make([]dns.ARecord, len(values))
+	for i, value := range values {
+		aRecords[i] = dns.ARecord{
+			Ipv4Address: to.StringPtr(value),
+		}
+	}
 	return &dns.RecordSetProperties{
-		TTL: to.Int64Ptr(ttl),
-		ARecords: &[]dns.ARecord{
-			{
-				Ipv4Address: to.StringPtr(value),
-			},
-		},
+		TTL:      to.Int64Ptr(ttl),
+		ARecords: &aRecords,
 	}
 }
 
-func cNameRecordSetPropertiesGetter(value string, ttl int64) *dns.RecordSetProperties {
+func cNameRecordSetPropertiesGetter(values []string, ttl int64) *dns.RecordSetProperties {
 	return &dns.RecordSetProperties{
 		TTL: to.Int64Ptr(ttl),
 		CnameRecord: &dns.CnameRecord{
-			Cname: to.StringPtr(value),
+			Cname: to.StringPtr(values[0]),
 		},
 	}
 }
 
-func txtRecordSetPropertiesGetter(value string, ttl int64) *dns.RecordSetProperties {
+func txtRecordSetPropertiesGetter(values []string, ttl int64) *dns.RecordSetProperties {
 	return &dns.RecordSetProperties{
 		TTL: to.Int64Ptr(ttl),
 		TxtRecords: &[]dns.TxtRecord{
 			{
-				Value: &[]string{value},
+				Value: &[]string{values[0]},
 			},
 		},
 	}
 }
 
-func othersRecordSetPropertiesGetter(value string, ttl int64) *dns.RecordSetProperties {
+func othersRecordSetPropertiesGetter(values []string, ttl int64) *dns.RecordSetProperties {
 	return &dns.RecordSetProperties{
 		TTL: to.Int64Ptr(ttl),
 	}
 }
-func createMockRecordSet(name, recordType, value string) dns.RecordSet {
-	return createMockRecordSetWithTTL(name, recordType, value, 0)
+func createMockRecordSet(name, recordType string, values ...string) dns.RecordSet {
+	return createMockRecordSetMultiWithTTL(name, recordType, 0, values...)
 }
 func createMockRecordSetWithTTL(name, recordType, value string, ttl int64) dns.RecordSet {
-	var getterFunc func(value string, ttl int64) *dns.RecordSetProperties
+	return createMockRecordSetMultiWithTTL(name, recordType, ttl, value)
+}
+func createMockRecordSetMultiWithTTL(name, recordType string, ttl int64, values ...string) dns.RecordSet {
+	var getterFunc func(values []string, ttl int64) *dns.RecordSetProperties
 
 	switch recordType {
 	case endpoint.RecordTypeA:
@@ -112,7 +117,7 @@ func createMockRecordSetWithTTL(name, recordType, value string, ttl int64) dns.R
 	return dns.RecordSet{
 		Name:                to.StringPtr(name),
 		Type:                to.StringPtr("Microsoft.Network/dnszones/" + recordType),
-		RecordSetProperties: getterFunc(value, ttl),
+		RecordSetProperties: getterFunc(values, ttl),
 	}
 
 }
@@ -148,7 +153,7 @@ func (client *mockRecordsClient) CreateOrUpdate(resourceGroupName string, zoneNa
 			formatAzureDNSName(relativeRecordSetName, zoneName),
 			string(recordType),
 			ttl,
-			extractAzureTarget(&parameters),
+			extractAzureTargets(&parameters)...,
 		),
 	)
 	return parameters, nil
@@ -209,6 +214,46 @@ func TestAzureRecord(t *testing.T) {
 
 }
 
+func TestAzureMultiRecord(t *testing.T) {
+	zonesClient := mockZonesClient{
+		mockZoneListResult: &dns.ZoneListResult{
+			Value: &[]dns.Zone{
+				createMockZone("example.com", "/dnszones/example.com"),
+			},
+		},
+	}
+
+	recordsClient := mockRecordsClient{
+		mockRecordSet: &[]dns.RecordSet{
+			createMockRecordSet("@", "NS", "ns1-03.azure-dns.com."),
+			createMockRecordSet("@", "SOA", "Email: azuredns-hostmaster.microsoft.com"),
+			createMockRecordSet("@", endpoint.RecordTypeA, "123.123.123.122", "234.234.234.233"),
+			createMockRecordSet("@", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
+			createMockRecordSetMultiWithTTL("nginx", endpoint.RecordTypeA, 3600, "123.123.123.123", "234.234.234.234"),
+			createMockRecordSetWithTTL("nginx", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default", recordTTL),
+			createMockRecordSetWithTTL("hack", endpoint.RecordTypeCNAME, "hack.azurewebsites.net", 10),
+		},
+	}
+
+	provider := newAzureProvider(NewDomainFilter([]string{"example.com"}), NewZoneIDFilter([]string{""}), true, "k8s", &zonesClient, &recordsClient)
+
+	actual, err := provider.Records()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []*endpoint.Endpoint{
+		endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "123.123.123.122", "234.234.234.233"),
+		endpoint.NewEndpoint("example.com", endpoint.RecordTypeTXT, "heritage=external-dns,external-dns/owner=default"),
+		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeA, 3600, "123.123.123.123", "234.234.234.234"),
+		endpoint.NewEndpointWithTTL("nginx.example.com", endpoint.RecordTypeTXT, recordTTL, "heritage=external-dns,external-dns/owner=default"),
+		endpoint.NewEndpointWithTTL("hack.example.com", endpoint.RecordTypeCNAME, 10, "hack.azurewebsites.net"),
+	}
+
+	validateAzureEndpoints(t, actual, expected)
+
+}
+
 func TestAzureApplyChanges(t *testing.T) {
 	recordsClient := mockRecordsClient{}
 
@@ -224,7 +269,7 @@ func TestAzureApplyChanges(t *testing.T) {
 	validateAzureEndpoints(t, recordsClient.updatedEndpoints, []*endpoint.Endpoint{
 		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
 		endpoint.NewEndpointWithTTL("example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
-		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4"),
+		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeA, endpoint.TTL(recordTTL), "1.2.3.4", "1.2.3.5"),
 		endpoint.NewEndpointWithTTL("foo.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
 		endpoint.NewEndpointWithTTL("bar.example.com", endpoint.RecordTypeCNAME, endpoint.TTL(recordTTL), "other.com"),
 		endpoint.NewEndpointWithTTL("bar.example.com", endpoint.RecordTypeTXT, endpoint.TTL(recordTTL), "tag"),
@@ -265,7 +310,7 @@ func testAzureApplyChangesInternal(t *testing.T, dryRun bool, client RecordsClie
 	createRecords := []*endpoint.Endpoint{
 		endpoint.NewEndpoint("example.com", endpoint.RecordTypeA, "1.2.3.4"),
 		endpoint.NewEndpoint("example.com", endpoint.RecordTypeTXT, "tag"),
-		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.4"),
+		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeA, "1.2.3.5", "1.2.3.4"),
 		endpoint.NewEndpoint("foo.example.com", endpoint.RecordTypeTXT, "tag"),
 		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeCNAME, "other.com"),
 		endpoint.NewEndpoint("bar.example.com", endpoint.RecordTypeTXT, "tag"),


### PR DESCRIPTION
This PR implements multiple A-record targets, which solves #979.

Tests are added, and I verified it works for me.
