### PR TITLE
distroless/static image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # builder image
-FROM golang as builder
+FROM golang:1.12.4 as builder
 
 WORKDIR /github.com/kubernetes-incubator/external-dns
 COPY . .

--- a/Dockerfile.mini
+++ b/Dockerfile.mini
@@ -3,6 +3,6 @@ WORKDIR /external-dns
 COPY . .
 RUN make build
 
-FROM grc.io/distroless/static
+FROM gcr.io/distroless/static
 COPY --from=builder /external-dns/build/external-dns /external-dns
 ENTRYPOINT ["./external-dns"]

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -3,12 +3,6 @@ WORKDIR /external-dns
 COPY . .
 RUN make build
 
-FROM alpine:latest as pkgs
-RUN apk --update add ca-certificates
-
-FROM scratch
-COPY --from=pkgs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=pkgs /etc/passwd /etc/passwd
+FROM grc.io/distroless/static
 COPY --from=builder /external-dns/build/external-dns /external-dns
-USER nobody
 ENTRYPOINT ["./external-dns"]

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,3 +1,14 @@
+FROM golang:1.12.4 as builder
+WORKDIR /external-dns
+COPY . .
+RUN make build
+
+FROM alpine:latest as pkgs
+RUN apk --update add ca-certificates
+
 FROM scratch
-COPY ./build/external-dns /bin/external-dns
-ENTRYPOINT ["/bin/external-dns"]
+COPY --from=pkgs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=pkgs /etc/passwd /etc/passwd
+COPY --from=builder /external-dns/build/external-dns /external-dns
+USER nobody
+ENTRYPOINT ["./external-dns"]

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,0 +1,3 @@
+FROM scratch
+COPY ./build/external-dns /bin/external-dns
+ENTRYPOINT ["/bin/external-dns"]

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test:
 	go test -v -race $(shell go list ./... | grep -v /vendor/)
 
 # The build targets allow to build the binary and docker image
-.PHONY: build build.docker build.scratch
+.PHONY: build build.docker build.mini
 
 BINARY        ?= external-dns
 SOURCES        = $(shell find . -name '*.go')
@@ -61,8 +61,8 @@ build.push: build.docker
 build.docker:
 	docker build --rm --tag "$(IMAGE):$(VERSION)" .
 
-build.scratch:
-	docker build --rm --tag "$(IMAGE):$(VERSION)" -f Dockerfile.scratch .
+build.mini:
+	docker build --rm --tag "$(IMAGE):$(VERSION)" -f Dockerfile.mini .
 
 clean:
 	@rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test:
 	go test -v -race $(shell go list ./... | grep -v /vendor/)
 
 # The build targets allow to build the binary and docker image
-.PHONY: build build.docker
+.PHONY: build build.docker build.scratch
 
 BINARY        ?= external-dns
 SOURCES        = $(shell find . -name '*.go')
@@ -60,6 +60,9 @@ build.push: build.docker
 
 build.docker:
 	docker build --rm --tag "$(IMAGE):$(VERSION)" .
+
+build.scratch:
+	docker build --rm --tag "$(IMAGE):$(VERSION)" -f Dockerfile.scratch .
 
 clean:
 	@rm -rf build


### PR DESCRIPTION
Add `Dockerfile.scratch` for a minimalist & more secure resulting image.
Add target to makefile `build.scratch`.