### PR TITLE
Support for multiple targets per hostname, enabling DNS round robining

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/kubernetes-incubator/external-dns/endpoint"
+	"sort"
 )
 
 // Plan can convert a list of desired and current records to a series of create,
@@ -50,15 +51,15 @@ type Changes struct {
 }
 
 // planTable is a supplementary struct for Plan
-// each row correspond to a dnsName -> (current record + all desired records)
+// each row correspond to a dnsName -> (current records + all desired records)
 /*
 planTable: (-> = target)
 --------------------------------------------------------
-DNSName | Current record | Desired Records             |
+DNSName | Current records | Desired Records             |
 --------------------------------------------------------
-foo.com | -> 1.1.1.1     | [->1.1.1.1, ->elb.com]      |  = no action
+foo.com | [->1.1.1.1]     | [->1.1.1.1]                 |  = no action
 --------------------------------------------------------
-bar.com |                | [->191.1.1.1, ->190.1.1.1]  |  = create (bar.com -> 190.1.1.1)
+bar.com |                 | [->191.1.1.1, ->190.1.1.1]  |  = create (bar.com -> 190.1.1.1, bar.com -> 191.1.1.1)
 --------------------------------------------------------
 "=", i.e. result of calculation relies on supplied ConflictResolver
 */
@@ -102,10 +103,12 @@ func (t planTable) addCandidate(e *endpoint.Endpoint) {
 // TODO: allows record type change, which might not be supported by all dns providers
 func (t planTable) getUpdates() (updateNew []*endpoint.Endpoint, updateOld []*endpoint.Endpoint) {
 	for _, row := range t.rows {
+		// If candidate and current list sizes are different, these will be treated as deletions/creations
 		if len(row.candidates) != len(row.currents) {
 			continue
 		}
 
+		// Update each current entry to its corresponding candidate entry
 		for i, candidate := range row.candidates {
 			current := row.currents[i]
 			update := t.resolver.ResolveUpdate(current, []*endpoint.Endpoint{candidate})
@@ -123,9 +126,11 @@ func (t planTable) getUpdates() (updateNew []*endpoint.Endpoint, updateOld []*en
 
 func (t planTable) getCreates() (createList []*endpoint.Endpoint) {
 	for _, row := range t.rows {
+		// If candidate and current list sizes are equal, these will be treated as updates
 		if len(row.candidates) == len(row.currents) {
 			continue
 		}
+		// Otherwise, we'll delete the currents and create the candidates
 		for _, cand := range row.candidates {
 			createList = append(createList, t.resolver.ResolveCreate([]*endpoint.Endpoint{cand}))
 		}
@@ -135,9 +140,11 @@ func (t planTable) getCreates() (createList []*endpoint.Endpoint) {
 
 func (t planTable) getDeletes() (deleteList []*endpoint.Endpoint) {
 	for _, row := range t.rows {
+		// If candidate and current list sizes are equal, these will be treated as updates
 		if len(row.candidates) == len(row.currents) {
 			continue
 		}
+		// Otherwise, we'll delete the currents and create the candidates
 		for _, curr := range row.currents {
 			deleteList = append(deleteList, t.resolver.ResolveCreate([]*endpoint.Endpoint{curr}))
 		}
@@ -151,11 +158,22 @@ func (t planTable) getDeletes() (deleteList []*endpoint.Endpoint) {
 func (p *Plan) Calculate() *Plan {
 	t := newPlanTable()
 
-	for _, current := range filterRecordsForPlan(p.Current) {
-		t.addCurrent(current)
+	for _, currents := range filterRecordsForPlan(p.Current) {
+		t.addCurrent(currents)
 	}
 	for _, desired := range filterRecordsForPlan(p.Desired) {
 		t.addCandidate(desired)
+	}
+
+	// Sort current and candidate list for each plan row, for consistency of results
+	perResource := PerResource{}
+	for _, row := range t.rows {
+		sort.SliceStable(row.currents, func(i, j int) bool {
+			return perResource.less(row.currents[i], row.currents[j])
+		})
+		sort.SliceStable(row.candidates, func(i, j int) bool {
+			return perResource.less(row.candidates[i], row.candidates[j])
+		})
 	}
 
 	changes := &Changes{}
@@ -175,10 +193,6 @@ func (p *Plan) Calculate() *Plan {
 	return plan
 }
 
-func targetChanged(desired, current *endpoint.Endpoint) bool {
-	return !desired.Targets.Same(current.Targets)
-}
-
 func inheritOwner(from, to *endpoint.Endpoint) {
 	if to.Labels == nil {
 		to.Labels = map[string]string{}
@@ -187,6 +201,10 @@ func inheritOwner(from, to *endpoint.Endpoint) {
 		from.Labels = map[string]string{}
 	}
 	to.Labels[endpoint.OwnerLabelKey] = from.Labels[endpoint.OwnerLabelKey]
+}
+
+func targetChanged(desired, current *endpoint.Endpoint) bool {
+	return !desired.Targets.Same(current.Targets)
 }
 
 func shouldUpdateTTL(desired, current *endpoint.Endpoint) bool {

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -158,8 +158,8 @@ func (t planTable) getDeletes() (deleteList []*endpoint.Endpoint) {
 func (p *Plan) Calculate() *Plan {
 	t := newPlanTable()
 
-	for _, currents := range filterRecordsForPlan(p.Current) {
-		t.addCurrent(currents)
+	for _, current := range filterRecordsForPlan(p.Current) {
+		t.addCurrent(current)
 	}
 	for _, desired := range filterRecordsForPlan(p.Desired) {
 		t.addCandidate(desired)

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -296,69 +296,6 @@ func (suite *PlanTestSuite) TestDifferentTypes() {
 	validateEntries(suite.T(), changes.Delete, expectedDelete)
 }
 
-func (suite *PlanTestSuite) TestMultipleRecords() {
-	current := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname, suite.bar127A, suite.bar192A}
-	desired := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname, suite.fooV3CnameSameResource, suite.bar127AWithTTL, suite.bar192A}
-	expectedCreate := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname, suite.fooV3CnameSameResource} // change in the number of "foo" records triggers deletion/recreation
-	expectedUpdateOld := []*endpoint.Endpoint{suite.bar127A}
-	expectedUpdateNew := []*endpoint.Endpoint{suite.bar127AWithTTL}
-	expectedDelete := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname}
-
-	p := &Plan{
-		Policies: []Policy{&SyncPolicy{}},
-		Current:  current,
-		Desired:  desired,
-	}
-
-	changes := p.Calculate().Changes
-	validateEntries(suite.T(), changes.Create, expectedCreate)
-	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
-	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
-	validateEntries(suite.T(), changes.Delete, expectedDelete)
-}
-
-func (suite *PlanTestSuite) TestNoChanges1() {
-	current := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname}
-	desired := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname}
-	expectedCreate := []*endpoint.Endpoint{}
-	expectedUpdateOld := []*endpoint.Endpoint{}
-	expectedUpdateNew := []*endpoint.Endpoint{}
-	expectedDelete := []*endpoint.Endpoint{}
-
-	p := &Plan{
-		Policies: []Policy{&SyncPolicy{}},
-		Current:  current,
-		Desired:  desired,
-	}
-
-	changes := p.Calculate().Changes
-	validateEntries(suite.T(), changes.Create, expectedCreate)
-	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
-	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
-	validateEntries(suite.T(), changes.Delete, expectedDelete)
-}
-
-func (suite *PlanTestSuite) TestNoChanges2() {
-	current := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname}
-	desired := []*endpoint.Endpoint{suite.fooV2Cname, suite.fooV1Cname} // different ordering of records shouldn't trigger changes
-	expectedCreate := []*endpoint.Endpoint{}
-	expectedUpdateOld := []*endpoint.Endpoint{}
-	expectedUpdateNew := []*endpoint.Endpoint{}
-	expectedDelete := []*endpoint.Endpoint{}
-
-	p := &Plan{
-		Policies: []Policy{&SyncPolicy{}},
-		Current:  current,
-		Desired:  desired,
-	}
-
-	changes := p.Calculate().Changes
-	validateEntries(suite.T(), changes.Create, expectedCreate)
-	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
-	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
-	validateEntries(suite.T(), changes.Delete, expectedDelete)
-}
-
 func (suite *PlanTestSuite) TestIgnoreTXT() {
 	current := []*endpoint.Endpoint{suite.fooV2TXT}
 	desired := []*endpoint.Endpoint{suite.fooV2Cname}
@@ -487,4 +424,67 @@ func TestNormalizeDNSName(t *testing.T) {
 		gotName := normalizeDNSName(r.dnsName)
 		assert.Equal(t, r.expect, gotName)
 	}
+}
+
+func (suite *PlanTestSuite) TestMultipleRecords() {
+	current := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname, suite.bar127A, suite.bar192A}
+	desired := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname, suite.fooV3CnameSameResource, suite.bar127AWithTTL, suite.bar192A}
+	expectedCreate := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname, suite.fooV3CnameSameResource} // change in the number of "foo" records triggers deletion/recreation
+	expectedUpdateOld := []*endpoint.Endpoint{suite.bar127A}
+	expectedUpdateNew := []*endpoint.Endpoint{suite.bar127AWithTTL}
+	expectedDelete := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname}
+
+	p := &Plan{
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Create, expectedCreate)
+	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
+	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
+	validateEntries(suite.T(), changes.Delete, expectedDelete)
+}
+
+func (suite *PlanTestSuite) TestNoChanges1() {
+	current := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname}
+	desired := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname}
+	expectedCreate := []*endpoint.Endpoint{}
+	expectedUpdateOld := []*endpoint.Endpoint{}
+	expectedUpdateNew := []*endpoint.Endpoint{}
+	expectedDelete := []*endpoint.Endpoint{}
+
+	p := &Plan{
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Create, expectedCreate)
+	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
+	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
+	validateEntries(suite.T(), changes.Delete, expectedDelete)
+}
+
+func (suite *PlanTestSuite) TestNoChanges2() {
+	current := []*endpoint.Endpoint{suite.fooV1Cname, suite.fooV2Cname}
+	desired := []*endpoint.Endpoint{suite.fooV2Cname, suite.fooV1Cname} // different ordering of records shouldn't trigger changes
+	expectedCreate := []*endpoint.Endpoint{}
+	expectedUpdateOld := []*endpoint.Endpoint{}
+	expectedUpdateNew := []*endpoint.Endpoint{}
+	expectedDelete := []*endpoint.Endpoint{}
+
+	p := &Plan{
+		Policies: []Policy{&SyncPolicy{}},
+		Current:  current,
+		Desired:  desired,
+	}
+
+	changes := p.Calculate().Changes
+	validateEntries(suite.T(), changes.Create, expectedCreate)
+	validateEntries(suite.T(), changes.UpdateNew, expectedUpdateNew)
+	validateEntries(suite.T(), changes.UpdateOld, expectedUpdateOld)
+	validateEntries(suite.T(), changes.Delete, expectedDelete)
 }

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -301,10 +301,10 @@ func (suite *PlanTestSuite) TestIdempotency() {
 func (suite *PlanTestSuite) TestDifferentTypes() {
 	current := []*endpoint.Endpoint{suite.fooV1Cname}
 	desired := []*endpoint.Endpoint{suite.fooV2Cname, suite.fooA5}
-	expectedCreate := []*endpoint.Endpoint{}
-	expectedUpdateOld := []*endpoint.Endpoint{suite.fooV1Cname}
-	expectedUpdateNew := []*endpoint.Endpoint{suite.fooA5}
-	expectedDelete := []*endpoint.Endpoint{}
+	expectedCreate := desired
+	expectedUpdateOld := []*endpoint.Endpoint{}
+	expectedUpdateNew := []*endpoint.Endpoint{}
+	expectedDelete := current
 
 	p := &Plan{
 		Policies: []Policy{&SyncPolicy{}},


### PR DESCRIPTION
My team is attempting to use external-dns to create DNS round-robining in Dyn.  In other words, we would like to:
- Have multiple (type=LoadBalanacer) Kubernetes services, all mapping to the same DNS name, say foo.com.
- Have external-dns create a DNS entry foo.com -> <load_balanacer_ip> for each service.

This doesn't work currently, and after some digging, I found a few open issues others have filed, and TODOs in the code related to supporting this.  I found a fairly simple way to add support for this, by modifying the logic in `plan/plan.go` so that it considers all of the endpoint.Endpoints associated with a hostname, instead of only considering one.

So what this PR does is:
- Changes the `planTableRow`'s `current` to `currents`, which is a list of Endpoints.
- In the routines that build up the create/delete/update list:
  - If the number of Endpoints for a hostname has changed, we delete all of the hostname's current endpoints and (re)create all of its candidate Endpoints.
  - Otherwise, Endpoints are treated as a sequence of (possible) updates.
  - Some somewhat more complicated logic could be introduced that would try harder to avoid recreating elements...
- A few unit tests have been added to verify the new behavior.
- A few unit tests have been removed that explicitly verified the old behavior (a single Endpoint per hostname only).