### PR TITLE
Add --ns1-endpoint and --ns1-ignoressl flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -206,6 +206,8 @@ func main() {
 			provider.NS1Config{
 				DomainFilter: domainFilter,
 				ZoneIDFilter: zoneIDFilter,
+				NS1Endpoint:  cfg.NS1Endpoint,
+				NS1IgnoreSSL: cfg.NS1IgnoreSSL,
 				DryRun:       cfg.DryRun,
 			},
 		)

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -292,7 +292,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("pdns-server", "When using the PowerDNS/PDNS provider, specify the URL to the pdns server (required when --provider=pdns)").Default(defaultConfig.PDNSServer).StringVar(&cfg.PDNSServer)
 	app.Flag("pdns-api-key", "When using the PowerDNS/PDNS provider, specify the API key to use to authorize requests (required when --provider=pdns)").Default(defaultConfig.PDNSAPIKey).StringVar(&cfg.PDNSAPIKey)
 	app.Flag("pdns-tls-enabled", "When using the PowerDNS/PDNS provider, specify whether to use TLS (default: false, requires --tls-ca, optionally specify --tls-client-cert and --tls-client-cert-key)").Default(strconv.FormatBool(defaultConfig.PDNSTLSEnabled)).BoolVar(&cfg.PDNSTLSEnabled)
-	app.Flag("ns1-endpoint", "When using the NS1 provider, specify the endpoint to target if not using Managed DNS (optional)").Default(defaultConfig.NS1Endpoint).StringVar(&cfg.NS1Endpoint)
+	app.Flag("ns1-endpoint", "When using the NS1 provider, specify the URL of the API endpoint to target (default: https://api.nsone.net/v1/)").Default(defaultConfig.NS1Endpoint).StringVar(&cfg.NS1Endpoint)
 	app.Flag("ns1-ignoressl", "When using the NS1 provider, specify whether to verify the SSL certificate (default: false)").Default(strconv.FormatBool(defaultConfig.NS1IgnoreSSL)).BoolVar(&cfg.NS1IgnoreSSL)
 
 	// Flags related to TLS communication

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -113,6 +113,8 @@ type Config struct {
 	RFC2136TSIGSecret           string `secure:"yes"`
 	RFC2136TSIGSecretAlg        string
 	RFC2136TAXFR                bool
+	NS1Endpoint                 string
+	NS1IgnoreSSL                bool
 }
 
 var defaultConfig = &Config{
@@ -186,6 +188,8 @@ var defaultConfig = &Config{
 	RFC2136TSIGSecret:           "",
 	RFC2136TSIGSecretAlg:        "",
 	RFC2136TAXFR:                true,
+	NS1Endpoint:                 "",
+	NS1IgnoreSSL:                false,
 }
 
 // NewConfig returns new Config object
@@ -288,6 +292,8 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("pdns-server", "When using the PowerDNS/PDNS provider, specify the URL to the pdns server (required when --provider=pdns)").Default(defaultConfig.PDNSServer).StringVar(&cfg.PDNSServer)
 	app.Flag("pdns-api-key", "When using the PowerDNS/PDNS provider, specify the API key to use to authorize requests (required when --provider=pdns)").Default(defaultConfig.PDNSAPIKey).StringVar(&cfg.PDNSAPIKey)
 	app.Flag("pdns-tls-enabled", "When using the PowerDNS/PDNS provider, specify whether to use TLS (default: false, requires --tls-ca, optionally specify --tls-client-cert and --tls-client-cert-key)").Default(strconv.FormatBool(defaultConfig.PDNSTLSEnabled)).BoolVar(&cfg.PDNSTLSEnabled)
+	app.Flag("ns1-endpoint", "When using the NS1 provider, specify the endpoint to target if not using Managed DNS (optional)").Default(defaultConfig.NS1Endpoint).StringVar(&cfg.NS1Endpoint)
+	app.Flag("ns1-ignoressl", "When using the NS1 provider, specify whether to verify the SSL certificate (default: false)").Default(strconv.FormatBool(defaultConfig.NS1IgnoreSSL)).BoolVar(&cfg.NS1IgnoreSSL)
 
 	// Flags related to TLS communication
 	app.Flag("tls-ca", "When using TLS communication, the path to the certificate authority to verify server communications (optionally specify --tls-client-cert for two-way TLS)").Default(defaultConfig.TLSCA).StringVar(&cfg.TLSCA)

--- a/pkg/apis/externaldns/types_test.go
+++ b/pkg/apis/externaldns/types_test.go
@@ -143,6 +143,8 @@ var (
 		CRDSourceAPIVersion:         "test.k8s.io/v1alpha1",
 		CRDSourceKind:               "Endpoint",
 		RcodezeroTXTEncrypt:         true,
+		NS1Endpoint:                 "https://api.example.com/v1",
+		NS1IgnoreSSL:                true,
 	}
 
 	// minimal config with istio gateway source and multiple ingressgateway load balancer services
@@ -284,6 +286,8 @@ func TestParseFlags(t *testing.T) {
 				"--crd-source-apiversion=test.k8s.io/v1alpha1",
 				"--crd-source-kind=Endpoint",
 				"--rcodezero-txt-encrypt",
+				"--ns1-endpoint=https://api.example.com/v1",
+				"--ns1-ignoressl",
 			},
 			envVars:  map[string]string{},
 			expected: overriddenConfig,
@@ -349,6 +353,8 @@ func TestParseFlags(t *testing.T) {
 				"EXTERNAL_DNS_CRD_SOURCE_APIVERSION":      "test.k8s.io/v1alpha1",
 				"EXTERNAL_DNS_CRD_SOURCE_KIND":            "Endpoint",
 				"EXTERNAL_DNS_RCODEZERO_TXT_ENCRYPT":      "1",
+				"EXTERNAL_DNS_NS1_ENDPOINT":               "https://api.example.com/v1",
+				"EXTERNAL_DNS_NS1_IGNORESSL":              "1",
 			},
 			expected: overriddenConfig,
 		},


### PR DESCRIPTION
This PR adds a flag to customize the API endpoint that the NS1 provider sends updates to (`--ns1-endpoint`).  This enables the NS1 provider to be used with on-prem or otherwise custom instances of NS1.

This PR also adds a flag to enable ignoring SSL verification on traffic sent and received by the NS1 provider (`--ns1-ignoressl`).  This is used for testing the provider against NS1 endpoints that are configured to use self-signed, or otherwise insecure, SSL certificates.