### PR TITLE
Support setting a default ingress target that can be overridden by the target annotation.

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ func main() {
 		CFAPIEndpoint:               cfg.CFAPIEndpoint,
 		CFUsername:                  cfg.CFUsername,
 		CFPassword:                  cfg.CFPassword,
+		DefaultIngressTarget:        cfg.DefaultIngressTarget,
 	}
 
 	// Lookup all the selected sources by names and pass them the desired configuration.

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -121,6 +121,7 @@ type Config struct {
 	NS1IgnoreSSL                bool
 	TransIPAccountName          string
 	TransIPPrivateKeyFile       string
+	DefaultIngressTarget        string
 }
 
 var defaultConfig = &Config{
@@ -202,6 +203,7 @@ var defaultConfig = &Config{
 	NS1IgnoreSSL:                false,
 	TransIPAccountName:          "",
 	TransIPPrivateKeyFile:       "",
+	DefaultIngressTarget:        "",
 }
 
 // NewConfig returns new Config object
@@ -354,6 +356,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("log-format", "The format in which log messages are printed (default: text, options: text, json)").Default(defaultConfig.LogFormat).EnumVar(&cfg.LogFormat, "text", "json")
 	app.Flag("metrics-address", "Specify where to serve the metrics and health check endpoint (default: :7979)").Default(defaultConfig.MetricsAddress).StringVar(&cfg.MetricsAddress)
 	app.Flag("log-level", "Set the level of logging. (default: info, options: panic, debug, info, warning, error, fatal").Default(defaultConfig.LogLevel).EnumVar(&cfg.LogLevel, allLogLevelsAsStrings()...)
+	app.Flag("default-ingress-target", "Specify a default target for DNS for Ingress records.").Default(defaultConfig.DefaultIngressTarget).StringVar(&cfg.DefaultIngressTarget)
 
 	_, err := app.Parse(args)
 	if err != nil {

--- a/source/gateway.go
+++ b/source/gateway.go
@@ -165,7 +165,7 @@ func (sc *gatewaySource) endpointsFromTemplate(config *istiomodel.Config) ([]*en
 		log.Warn(err)
 	}
 
-	targets := getTargetsFromTargetAnnotation(config.Annotations)
+	targets := getTargetsFromTargetAnnotation(config.Annotations, "")
 
 	if len(targets) == 0 {
 		targets, err = sc.targetsFromIstioIngressGatewayServices()
@@ -255,7 +255,7 @@ func (sc *gatewaySource) endpointsFromGatewayConfig(config istiomodel.Config) ([
 		log.Warn(err)
 	}
 
-	targets := getTargetsFromTargetAnnotation(config.Annotations)
+	targets := getTargetsFromTargetAnnotation(config.Annotations, "")
 
 	if len(targets) == 0 {
 		targets, err = sc.targetsFromIstioIngressGatewayServices()

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -49,10 +49,11 @@ type ingressSource struct {
 	combineFQDNAnnotation    bool
 	ignoreHostnameAnnotation bool
 	ingressInformer          extinformers.IngressInformer
+	defaultTarget            string
 }
 
 // NewIngressSource creates a new ingressSource with the given config.
-func NewIngressSource(kubeClient kubernetes.Interface, namespace, annotationFilter string, fqdnTemplate string, combineFqdnAnnotation bool, ignoreHostnameAnnotation bool) (Source, error) {
+func NewIngressSource(kubeClient kubernetes.Interface, namespace, annotationFilter string, fqdnTemplate string, combineFqdnAnnotation bool, ignoreHostnameAnnotation bool, defaultTarget string) (Source, error) {
 	var (
 		tmpl *template.Template
 		err  error
@@ -98,6 +99,7 @@ func NewIngressSource(kubeClient kubernetes.Interface, namespace, annotationFilt
 		combineFQDNAnnotation:    combineFqdnAnnotation,
 		ignoreHostnameAnnotation: ignoreHostnameAnnotation,
 		ingressInformer:          ingressInformer,
+		defaultTarget:            defaultTarget,
 	}
 	return sc, nil
 }
@@ -125,7 +127,7 @@ func (sc *ingressSource) Endpoints() ([]*endpoint.Endpoint, error) {
 			continue
 		}
 
-		ingEndpoints := endpointsFromIngress(ing, sc.ignoreHostnameAnnotation)
+		ingEndpoints := endpointsFromIngress(ing, sc.ignoreHostnameAnnotation, sc.defaultTarget)
 
 		// apply template if host is missing on ingress
 		if (sc.combineFQDNAnnotation || len(ingEndpoints) == 0) && sc.fqdnTemplate != nil {
@@ -173,7 +175,7 @@ func (sc *ingressSource) endpointsFromTemplate(ing *v1beta1.Ingress) ([]*endpoin
 		log.Warn(err)
 	}
 
-	targets := getTargetsFromTargetAnnotation(ing.Annotations)
+	targets := getTargetsFromTargetAnnotation(ing.Annotations, sc.defaultTarget)
 
 	if len(targets) == 0 {
 		targets = targetsFromIngressStatus(ing.Status)
@@ -229,7 +231,7 @@ func (sc *ingressSource) setResourceLabel(ingress *v1beta1.Ingress, endpoints []
 }
 
 // endpointsFromIngress extracts the endpoints from ingress object
-func endpointsFromIngress(ing *v1beta1.Ingress, ignoreHostnameAnnotation bool) []*endpoint.Endpoint {
+func endpointsFromIngress(ing *v1beta1.Ingress, ignoreHostnameAnnotation bool, defaultTarget string) []*endpoint.Endpoint {
 	var endpoints []*endpoint.Endpoint
 
 	ttl, err := getTTLFromAnnotations(ing.Annotations)
@@ -237,7 +239,7 @@ func endpointsFromIngress(ing *v1beta1.Ingress, ignoreHostnameAnnotation bool) [
 		log.Warn(err)
 	}
 
-	targets := getTargetsFromTargetAnnotation(ing.Annotations)
+	targets := getTargetsFromTargetAnnotation(ing.Annotations, defaultTarget)
 
 	if len(targets) == 0 {
 		targets = targetsFromIngressStatus(ing.Status)

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -92,3 +92,56 @@ func TestSuitableType(t *testing.T) {
 		}
 	}
 }
+
+func TestGetTargetsFromAnnotations(t *testing.T) {
+	for _, tc := range []struct {
+		title         string
+		annotations   map[string]string
+		defaultTarget string
+		expected      []string
+	}{
+		{
+			title:       "Target annotation not present and no default target.",
+			annotations: map[string]string{"foo": "bar"},
+		},
+		{
+			title:         "Target annotation not present and with default target.",
+			annotations:   map[string]string{"foo": "bar"},
+			defaultTarget: "google.com.",
+			expected:      []string{"google.com"},
+		},
+		{
+			title:         "Target annotation present and with default target.",
+			annotations:   map[string]string{targetAnnotationKey: "google.com."},
+			defaultTarget: "1.2.3.4",
+			expected:      []string{"google.com"},
+		},
+		{
+			title:       "Target annotation present and without default target.",
+			annotations: map[string]string{targetAnnotationKey: "google.com."},
+			expected:    []string{"google.com"},
+		},
+		{
+			title:         "Target annotation present and with multiple default targets.",
+			annotations:   map[string]string{targetAnnotationKey: "1.1.1.1"},
+			defaultTarget: "1.2.3.4,4.3.2.1",
+			expected:      []string{"1.1.1.1"},
+		},
+		{
+			title:         "Multiple target annotation present with default target.",
+			annotations:   map[string]string{targetAnnotationKey: "1.2.3.4,4.3.2.1"},
+			defaultTarget: "1.1.1.1",
+			expected:      []string{"1.2.3.4", "4.3.2.1"},
+		},
+		{
+			title:       "Multiple target annotation present without default target.",
+			annotations: map[string]string{targetAnnotationKey: "1.2.3.4,4.3.2.1"},
+			expected:    []string{"1.2.3.4", "4.3.2.1"},
+		},
+	} {
+		t.Run(tc.title, func(t *testing.T) {
+			targets := getTargetsFromTargetAnnotation(tc.annotations, tc.defaultTarget)
+			assert.Equal(t, endpoint.Targets(tc.expected), targets)
+		})
+	}
+}

--- a/source/store.go
+++ b/source/store.go
@@ -57,6 +57,7 @@ type Config struct {
 	CFAPIEndpoint               string
 	CFUsername                  string
 	CFPassword                  string
+	DefaultIngressTarget        string
 }
 
 // ClientGenerator provides clients
@@ -150,7 +151,7 @@ func BuildWithConfig(source string, p ClientGenerator, cfg *Config) (Source, err
 		if err != nil {
 			return nil, err
 		}
-		return NewIngressSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation)
+		return NewIngressSource(client, cfg.Namespace, cfg.AnnotationFilter, cfg.FQDNTemplate, cfg.CombineFQDNAndAnnotation, cfg.IgnoreHostnameAnnotation, cfg.DefaultIngressTarget)
 	case "istio-gateway":
 		kubernetesClient, err := p.KubeClient()
 		if err != nil {


### PR DESCRIPTION
This PR adds a flag `--default-ingress-target` that specifies a default target to use when creating DNS records for Ingress resources. When set, users do not need to set any annotations on Ingress resources in order for DNS records to be created for them, so this makes provisioning DNS even more transparent.