### PR TITLE
Google zones should be filter by their ID and Name

### DIFF
--- a/provider/google.go
+++ b/provider/google.go
@@ -161,7 +161,7 @@ func (p *GoogleProvider) Zones() (map[string]*dns.ManagedZone, error) {
 
 	f := func(resp *dns.ManagedZonesListResponse) error {
 		for _, zone := range resp.ManagedZones {
-			if p.domainFilter.Match(zone.DnsName) && p.zoneIDFilter.Match(fmt.Sprintf("%v", zone.Id)) {
+			if p.domainFilter.Match(zone.DnsName) && (p.zoneIDFilter.Match(fmt.Sprintf("%v", zone.Id)) || p.zoneIDFilter.Match(fmt.Sprintf("%v", zone.Name))) {
 				zones[zone.Name] = zone
 				log.Debugf("Matched %s (zone: %s)", zone.DnsName, zone.Name)
 			} else {


### PR DESCRIPTION
Before we only filter by the zone ID, which is an integer value, that is
not exposed in the GCP Console and by the related terraform resource.
This allows to filter by either ID or Name whatever is matching.

I also have added some testing for both cases. Wdyt?

This is quite important for using GCP private managed zones, which often have an overlapping name