### PR TITLE
add empty source

### DIFF
--- a/docs/contributing/sources-and-providers.md
+++ b/docs/contributing/sources-and-providers.md
@@ -25,6 +25,7 @@ All sources live in package `source`.
 * `FakeSource`: returns a random list of Endpoints for the purpose of testing providers without having access to a Kubernetes cluster.
 * `ConnectorSource`: returns a list of Endpoint objects which are served by a tcp server configured through `connector-source-server` flag.
 * `CRDSource`: returns a list of Endpoint objects sourced from the spec of CRD objects. For more details refer to [CRD source](../crd-source.md) documentation.
+* `EmptySource`: returns an empty list of Endpoint objects for the purpose of testing and cleaning out entries.
 
 ### Providers
 

--- a/pkg/apis/externaldns/types.go
+++ b/pkg/apis/externaldns/types.go
@@ -257,7 +257,7 @@ func (cfg *Config) ParseFlags(args []string) error {
 	app.Flag("cf-password", "The password to log into the cloud foundry API").Default(defaultConfig.CFPassword).StringVar(&cfg.CFPassword)
 
 	// Flags related to processing sources
-	app.Flag("source", "The resource types that are queried for endpoints; specify multiple times for multiple sources (required, options: service, ingress, fake, connector, istio-gateway, cloudfoundry, crd").Required().PlaceHolder("source").EnumsVar(&cfg.Sources, "service", "ingress", "istio-gateway", "cloudfoundry", "fake", "connector", "crd")
+	app.Flag("source", "The resource types that are queried for endpoints; specify multiple times for multiple sources (required, options: service, ingress, fake, connector, istio-gateway, cloudfoundry, crd, empty").Required().PlaceHolder("source").EnumsVar(&cfg.Sources, "service", "ingress", "istio-gateway", "cloudfoundry", "fake", "connector", "crd", "empty")
 	app.Flag("namespace", "Limit sources of endpoints to a specific namespace (default: all namespaces)").Default(defaultConfig.Namespace).StringVar(&cfg.Namespace)
 	app.Flag("annotation-filter", "Filter sources managed by external-dns via annotation using label selector semantics (default: all sources)").Default(defaultConfig.AnnotationFilter).StringVar(&cfg.AnnotationFilter)
 	app.Flag("fqdn-template", "A templated string that's used to generate DNS names from sources that don't define a hostname themselves, or to add a hostname suffix when paired with the fake source (optional). Accepts comma separated list for multiple global FQDN.").Default(defaultConfig.FQDNTemplate).StringVar(&cfg.FQDNTemplate)

--- a/source/empty.go
+++ b/source/empty.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import "github.com/kubernetes-incubator/external-dns/endpoint"
+
+// emptySource is a Source that returns no endpoints.
+type emptySource struct{}
+
+// Endpoints collects endpoints of all nested Sources and returns them in a single slice.
+func (e *emptySource) Endpoints() ([]*endpoint.Endpoint, error) {
+	return []*endpoint.Endpoint{}, nil
+}
+
+// NewEmptySource creates a new emptySource.
+func NewEmptySource() Source {
+	return &emptySource{}
+}

--- a/source/empty_test.go
+++ b/source/empty_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"testing"
+)
+
+func TestEmptySourceReturnsEmpty(t *testing.T) {
+	e := NewEmptySource()
+
+	endpoints, err := e.Endpoints()
+	if err != nil {
+		t.Errorf("Expected no error but got %s", err.Error())
+	}
+
+	count := len(endpoints)
+	if count != 0 {
+		t.Errorf("Expected 0 endpoints but got %d", count)
+	}
+}


### PR DESCRIPTION
Add `EmptySource` as a way to help clean up resources in cases where you lose a cluster. 

Our use case:

We spin up many Kubernetes clusters in our test environment with a set of domains that follow the pattern (stable-1, stable-2, stable-3, ...etc). However, since this is our test environment we kill forcefully delete clusters (accidentally or on purpose) without cleaning up services properly. I would like to have an empty source so when we do delete a cluster, we can clean up old DNS entries by using the same params just a different source (empty) without having to bring up the cluster again. 

The alternative to this was updating the `FakeSource` to include another param called `fake-count` or similar which told `FakeSource` to return `n` entries (would set `0` in this case). 

I chose to add a new source to make it explicit that this source will always return empty.