### PR TITLE
sanitize dockerfiles for external-dns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # builder image
-FROM golang:1.12.4 as builder
+FROM golang:1.12.5 as builder
 
 WORKDIR /github.com/kubernetes-incubator/external-dns
 COPY . .
@@ -22,7 +22,7 @@ RUN make test
 RUN make build
 
 # final image
-FROM registry.opensource.zalan.do/stups/alpine:latest
+FROM alpine:3.9
 LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
 
 COPY --from=builder /github.com/kubernetes-incubator/external-dns/build/external-dns /bin/external-dns

--- a/Dockerfile.mini
+++ b/Dockerfile.mini
@@ -1,4 +1,4 @@
-FROM golang:1.12.4 as builder
+FROM golang:1.12.5 as builder
 WORKDIR /external-dns
 COPY . .
 RUN make build


### PR DESCRIPTION
This PR uses the latest base image and final image. The custom alpine image hasn't been updated in 2 years and it probably contains the recently reported CVE.