### PR TITLE
Fix CloudFlare provider to return a single endpoint for each name/type.

### DIFF
--- a/provider/cloudflare_test.go
+++ b/provider/cloudflare_test.go
@@ -595,3 +595,225 @@ func validateCloudFlareZones(t *testing.T, zones []cloudflare.Zone, expected []c
 		assert.Equal(t, expected[i].Name, zone.Name)
 	}
 }
+
+func TestGroupByNameAndType(t *testing.T) {
+	testCases := []struct {
+		Name              string
+		Records           []cloudflare.DNSRecord
+		ExpectedEndpoints []*endpoint.Endpoint
+	}{
+		{
+			Name:              "empty",
+			Records:           []cloudflare.DNSRecord{},
+			ExpectedEndpoints: []*endpoint.Endpoint{},
+		},
+		{
+			Name: "single record - single target",
+			Records: []cloudflare.DNSRecord{
+				{
+					Name:    "foo.com",
+					Type:    endpoint.RecordTypeA,
+					Content: "10.10.10.1",
+					TTL:     defaultCloudFlareRecordTTL,
+				},
+			},
+			ExpectedEndpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.com",
+					Targets:    endpoint.Targets{"10.10.10.1"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  endpoint.TTL(defaultCloudFlareRecordTTL),
+					Labels:     endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{
+						{
+							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Value: "false",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "single record - multiple targets",
+			Records: []cloudflare.DNSRecord{
+				{
+					Name:    "foo.com",
+					Type:    endpoint.RecordTypeA,
+					Content: "10.10.10.1",
+					TTL:     defaultCloudFlareRecordTTL,
+				},
+				{
+					Name:    "foo.com",
+					Type:    endpoint.RecordTypeA,
+					Content: "10.10.10.2",
+					TTL:     defaultCloudFlareRecordTTL,
+				},
+			},
+			ExpectedEndpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.com",
+					Targets:    endpoint.Targets{"10.10.10.1", "10.10.10.2"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  endpoint.TTL(defaultCloudFlareRecordTTL),
+					Labels:     endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{
+						{
+							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Value: "false",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "multiple record - multiple targets",
+			Records: []cloudflare.DNSRecord{
+				{
+					Name:    "foo.com",
+					Type:    endpoint.RecordTypeA,
+					Content: "10.10.10.1",
+					TTL:     defaultCloudFlareRecordTTL,
+				},
+				{
+					Name:    "foo.com",
+					Type:    endpoint.RecordTypeA,
+					Content: "10.10.10.2",
+					TTL:     defaultCloudFlareRecordTTL,
+				},
+				{
+					Name:    "bar.de",
+					Type:    endpoint.RecordTypeA,
+					Content: "10.10.10.1",
+					TTL:     defaultCloudFlareRecordTTL,
+				},
+				{
+					Name:    "bar.de",
+					Type:    endpoint.RecordTypeA,
+					Content: "10.10.10.2",
+					TTL:     defaultCloudFlareRecordTTL,
+				},
+			},
+			ExpectedEndpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.com",
+					Targets:    endpoint.Targets{"10.10.10.1", "10.10.10.2"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  endpoint.TTL(defaultCloudFlareRecordTTL),
+					Labels:     endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{
+						{
+							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Value: "false",
+						},
+					},
+				},
+				{
+					DNSName:    "bar.de",
+					Targets:    endpoint.Targets{"10.10.10.1", "10.10.10.2"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  endpoint.TTL(defaultCloudFlareRecordTTL),
+					Labels:     endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{
+						{
+							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Value: "false",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "multiple record - mixed single/multiple targets",
+			Records: []cloudflare.DNSRecord{
+				{
+					Name:    "foo.com",
+					Type:    endpoint.RecordTypeA,
+					Content: "10.10.10.1",
+					TTL:     defaultCloudFlareRecordTTL,
+				},
+				{
+					Name:    "foo.com",
+					Type:    endpoint.RecordTypeA,
+					Content: "10.10.10.2",
+					TTL:     defaultCloudFlareRecordTTL,
+				},
+				{
+					Name:    "bar.de",
+					Type:    endpoint.RecordTypeA,
+					Content: "10.10.10.1",
+					TTL:     defaultCloudFlareRecordTTL,
+				},
+			},
+			ExpectedEndpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.com",
+					Targets:    endpoint.Targets{"10.10.10.1", "10.10.10.2"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  endpoint.TTL(defaultCloudFlareRecordTTL),
+					Labels:     endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{
+						{
+							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Value: "false",
+						},
+					},
+				},
+				{
+					DNSName:    "bar.de",
+					Targets:    endpoint.Targets{"10.10.10.1"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  endpoint.TTL(defaultCloudFlareRecordTTL),
+					Labels:     endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{
+						{
+							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Value: "false",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "unsupported record type",
+			Records: []cloudflare.DNSRecord{
+				{
+					Name:    "foo.com",
+					Type:    endpoint.RecordTypeA,
+					Content: "10.10.10.1",
+					TTL:     defaultCloudFlareRecordTTL,
+				},
+				{
+					Name:    "foo.com",
+					Type:    endpoint.RecordTypeA,
+					Content: "10.10.10.2",
+					TTL:     defaultCloudFlareRecordTTL,
+				},
+				{
+					Name:    "bar.de",
+					Type:    "NOT SUPPORTED",
+					Content: "10.10.10.1",
+					TTL:     defaultCloudFlareRecordTTL,
+				},
+			},
+			ExpectedEndpoints: []*endpoint.Endpoint{
+				{
+					DNSName:    "foo.com",
+					Targets:    endpoint.Targets{"10.10.10.1", "10.10.10.2"},
+					RecordType: endpoint.RecordTypeA,
+					RecordTTL:  endpoint.TTL(defaultCloudFlareRecordTTL),
+					Labels:     endpoint.Labels{},
+					ProviderSpecific: endpoint.ProviderSpecific{
+						{
+							Name:  "external-dns.alpha.kubernetes.io/cloudflare-proxied",
+							Value: "false",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, groupByNameAndType(tc.Records), tc.ExpectedEndpoints)
+	}
+}


### PR DESCRIPTION
#970 adds support for multiple target addresses to the CloudFlare provider. However, CloudFlare does not support "sets" of targets for each DNS name/type pair but instead returns a single entry for each name/type/target. This confuses the planner when calculating the set of changes, leading to #992 - where external-dns recreates the same entries over and over.

This pull request changes the CloudFlare provider's Records() method to group all supported records by name and type, and to return a single endpoint with all the targets for each name/type, allowing the planner to compute the correct set of changes.