### PR TITLE
fixed an issue with handling multiple oci zones

### DIFF
--- a/provider/oci.go
+++ b/provider/oci.go
@@ -106,8 +106,8 @@ func NewOCIProvider(cfg OCIConfig, domainFilter DomainFilter, zoneIDFilter ZoneI
 	}, nil
 }
 
-func (p *OCIProvider) zones(ctx context.Context) (map[string]*dns.ZoneSummary, error) {
-	zones := make(map[string]*dns.ZoneSummary)
+func (p *OCIProvider) zones(ctx context.Context) (map[string]dns.ZoneSummary, error) {
+	zones := make(map[string]dns.ZoneSummary)
 
 	log.Debugf("Matching zones against domain filters: %v", p.domainFilter.filters)
 	var page *string
@@ -123,7 +123,7 @@ func (p *OCIProvider) zones(ctx context.Context) (map[string]*dns.ZoneSummary, e
 
 		for _, zone := range resp.Items {
 			if p.domainFilter.Match(*zone.Name) && p.zoneIDFilter.Match(*zone.Id) {
-				zones[*zone.Name] = &zone
+				zones[*zone.Name] = zone
 				log.Debugf("Matched %q (%q)", *zone.Name, *zone.Id)
 			} else {
 				log.Debugf("Filtered %q (%q)", *zone.Name, *zone.Id)
@@ -272,7 +272,7 @@ func newRecordOperation(ep *endpoint.Endpoint, opType dns.RecordOperationOperati
 }
 
 // operationsByZone segments a slice of RecordOperations by their zone.
-func operationsByZone(zones map[string]*dns.ZoneSummary, ops []dns.RecordOperation) map[string][]dns.RecordOperation {
+func operationsByZone(zones map[string]dns.ZoneSummary, ops []dns.RecordOperation) map[string][]dns.RecordOperation {
 	changes := make(map[string][]dns.RecordOperation)
 
 	zoneNameIDMapper := zoneIDName{}

--- a/provider/oci_test.go
+++ b/provider/oci_test.go
@@ -112,7 +112,7 @@ func newOCIProvider(client ociDNSClient, domainFilter DomainFilter, zoneIDFilter
 	}
 }
 
-func validateOCIZones(t *testing.T, actual, expected map[string]*dns.ZoneSummary) {
+func validateOCIZones(t *testing.T, actual, expected map[string]dns.ZoneSummary) {
 	require.Len(t, actual, len(expected))
 
 	for k, a := range actual {
@@ -201,13 +201,13 @@ func TestOCIZones(t *testing.T) {
 		name         string
 		domainFilter DomainFilter
 		zoneIDFilter ZoneIDFilter
-		expected     map[string]*dns.ZoneSummary
+		expected     map[string]dns.ZoneSummary
 	}{
 		{
 			name:         "DomainFilter_com",
 			domainFilter: NewDomainFilter([]string{"com"}),
 			zoneIDFilter: NewZoneIDFilter([]string{""}),
-			expected: map[string]*dns.ZoneSummary{
+			expected: map[string]dns.ZoneSummary{
 				"foo.com": {
 					Id:   common.String("ocid1.dns-zone.oc1..e1e042ef0bfbb5c251b9713fd7bf8959"),
 					Name: common.String("foo.com"),
@@ -221,7 +221,7 @@ func TestOCIZones(t *testing.T) {
 			name:         "DomainFilter_foo.com",
 			domainFilter: NewDomainFilter([]string{"foo.com"}),
 			zoneIDFilter: NewZoneIDFilter([]string{""}),
-			expected: map[string]*dns.ZoneSummary{
+			expected: map[string]dns.ZoneSummary{
 				"foo.com": {
 					Id:   common.String("ocid1.dns-zone.oc1..e1e042ef0bfbb5c251b9713fd7bf8959"),
 					Name: common.String("foo.com"),
@@ -231,7 +231,7 @@ func TestOCIZones(t *testing.T) {
 			name:         "ZoneIDFilter_ocid1.dns-zone.oc1..e1e042ef0bfbb5c251b9713fd7bf8959",
 			domainFilter: NewDomainFilter([]string{""}),
 			zoneIDFilter: NewZoneIDFilter([]string{"ocid1.dns-zone.oc1..e1e042ef0bfbb5c251b9713fd7bf8959"}),
-			expected: map[string]*dns.ZoneSummary{
+			expected: map[string]dns.ZoneSummary{
 				"foo.com": {
 					Id:   common.String("ocid1.dns-zone.oc1..e1e042ef0bfbb5c251b9713fd7bf8959"),
 					Name: common.String("foo.com"),
@@ -360,13 +360,13 @@ func TestNewRecordOperation(t *testing.T) {
 func TestOperationsByZone(t *testing.T) {
 	testCases := []struct {
 		name     string
-		zones    map[string]*dns.ZoneSummary
+		zones    map[string]dns.ZoneSummary
 		ops      []dns.RecordOperation
 		expected map[string][]dns.RecordOperation
 	}{
 		{
 			name: "basic",
-			zones: map[string]*dns.ZoneSummary{
+			zones: map[string]dns.ZoneSummary{
 				"foo": {
 					Id:   common.String("foo"),
 					Name: common.String("foo.com"),
@@ -414,7 +414,7 @@ func TestOperationsByZone(t *testing.T) {
 			},
 		}, {
 			name: "does_not_include_zones_with_no_changes",
-			zones: map[string]*dns.ZoneSummary{
+			zones: map[string]dns.ZoneSummary{
 				"foo": {
 					Id:   common.String("foo"),
 					Name: common.String("foo.com"),


### PR DESCRIPTION
When more than one oci dns zone exists as a candidate zone for the new/updated records, the zone map was incorrectly built that results in having a map with all keys as zone names while the value will be the same object (the last one in the list). This has caused as the map is copying address of a loop var. This fix addresses that issue.