### PR TITLE
Update Dockerfiles to follow best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,21 +13,25 @@
 # limitations under the License.
 
 # builder image
-FROM golang:1.12.5 as builder
+FROM golang:1.12.6 as builder
 
 WORKDIR /github.com/kubernetes-incubator/external-dns
 COPY . .
-RUN go mod vendor
-RUN make test
-RUN make build
+RUN go mod vendor && \
+    make test && \
+    make build
 
 # final image
 FROM alpine:3.9
 LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
 
-RUN apk add ca-certificates && update-ca-certificates
+RUN apk add --no-cache ca-certificates && \
+    update-ca-certificates
+
 COPY --from=builder /github.com/kubernetes-incubator/external-dns/build/external-dns /bin/external-dns
 
-USER nobody
+# Run as UID for nobody since k8s pod securityContext runAsNonRoot can't resolve the user ID:
+# https://github.com/kubernetes/kubernetes/issues/40958
+USER 65534
 
 ENTRYPOINT ["/bin/external-dns"]

--- a/Dockerfile.mini
+++ b/Dockerfile.mini
@@ -1,8 +1,35 @@
-FROM golang:1.12.5 as builder
-WORKDIR /external-dns
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.12.6 as builder
+
+WORKDIR /github.com/kubernetes-incubator/external-dns
 COPY . .
-RUN make build
+RUN apt-get update && \
+    apt-get install ca-certificates && \
+    update-ca-certificates && \
+    go mod vendor && \
+    make test && \
+    make build
 
 FROM gcr.io/distroless/static
-COPY --from=builder /external-dns/build/external-dns /external-dns
-ENTRYPOINT ["./external-dns"]
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /github.com/kubernetes-incubator/external-dns/build/external-dns /bin/external-dns
+
+# Run as UID for nobody since k8s pod securityContext runAsNonRoot can't resolve the user ID:
+# https://github.com/kubernetes/kubernetes/issues/40958
+USER 65534
+
+ENTRYPOINT ["/bin/external-dns"]

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ build.docker:
 	docker build --rm --tag "$(IMAGE):$(VERSION)" .
 
 build.mini:
-	docker build --rm --tag "$(IMAGE):$(VERSION)" -f Dockerfile.mini .
+	docker build --rm --tag "$(IMAGE):$(VERSION)-mini" -f Dockerfile.mini .
 
 clean:
 	@rm -rf build


### PR DESCRIPTION
* Update to the build image to the latest version of Go 1.12.x.
* Ensures all build commands must execute successfully.
* Removes APK index cache from final image, which reduces the final image size by ~2MB.
* Uses UID for `nobody` in order to work with the Kubernetes Pod securityContext runAsNonRoot as it cannot resolve the user ID.
* Adds "mini" to the mini Dockerfile image tag.
* Formatting and style changes. 