### PR TITLE
Improvements to the source CRD

### DIFF
--- a/source/crd.go
+++ b/source/crd.go
@@ -120,7 +120,7 @@ func (cs *crdSource) Endpoints() ([]*endpoint.Endpoint, error) {
 		// Make sure that all endpoints have targets for A or CNAME type
 		crdEndpoints := []*endpoint.Endpoint{}
 		for _, ep := range dnsEndpoint.Spec.Endpoints {
-			if (ep.RecordType == "CNAME" || ep.RecordType == "A") && len(ep.Targets) < 1 {
+			if (ep.RecordType == "CNAME" || ep.RecordType == "A"|| ep.RecordType == "AAAA") && len(ep.Targets) < 1 {
 				log.Warnf("Endpoint %s with DNSName %s has an empty list of targets", dnsEndpoint.ObjectMeta.Name, ep.DNSName)
 				continue
 			}
@@ -133,7 +133,7 @@ func (cs *crdSource) Endpoints() ([]*endpoint.Endpoint, error) {
 				}
 			}
 			if illegalTarget {
-				log.Warnf("Endpoint %s with DNSName %s has Target illegal target. The subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com')", dnsEndpoint.ObjectMeta.Name, ep.DNSName)
+				log.Warnf("Endpoint %s with DNSName %s has an illegal target. The subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com')", dnsEndpoint.ObjectMeta.Name, ep.DNSName)
 				continue
 			}
 

--- a/source/crd.go
+++ b/source/crd.go
@@ -110,7 +110,6 @@ func NewCRDSource(crdClient rest.Interface, namespace, kind string, scheme *runt
 // Endpoints returns endpoint objects.
 func (cs *crdSource) Endpoints() ([]*endpoint.Endpoint, error) {
 	endpoints := []*endpoint.Endpoint{}
-	crdEndpoints := []*endpoint.Endpoint{}
 
 	result, err := cs.List(&metav1.ListOptions{})
 	if err != nil {
@@ -119,7 +118,7 @@ func (cs *crdSource) Endpoints() ([]*endpoint.Endpoint, error) {
 
 	for _, dnsEndpoint := range result.Items {
 		// Make sure that all endpoints have targets for A or CNAME type
-		crdEndpoints = []*endpoint.Endpoint{}
+		crdEndpoints := []*endpoint.Endpoint{}
 		for _, ep := range dnsEndpoint.Spec.Endpoints {
 			if (ep.RecordType == "CNAME" || ep.RecordType == "A") && len(ep.Targets) < 1 {
 				log.Warnf("Endpoint %s with DNSName %s has an empty list of targets", dnsEndpoint.ObjectMeta.Name, ep.DNSName)

--- a/source/crd.go
+++ b/source/crd.go
@@ -120,7 +120,7 @@ func (cs *crdSource) Endpoints() ([]*endpoint.Endpoint, error) {
 		// Make sure that all endpoints have targets for A or CNAME type
 		crdEndpoints := []*endpoint.Endpoint{}
 		for _, ep := range dnsEndpoint.Spec.Endpoints {
-			if (ep.RecordType == "CNAME" || ep.RecordType == "A"|| ep.RecordType == "AAAA") && len(ep.Targets) < 1 {
+			if (ep.RecordType == "CNAME" || ep.RecordType == "A" || ep.RecordType == "AAAA") && len(ep.Targets) < 1 {
 				log.Warnf("Endpoint %s with DNSName %s has an empty list of targets", dnsEndpoint.ObjectMeta.Name, ep.DNSName)
 				continue
 			}

--- a/source/crd.go
+++ b/source/crd.go
@@ -126,27 +126,27 @@ func (cs *crdSource) Endpoints() ([]*endpoint.Endpoint, error) {
 			}
 
 			illegalTarget := false
-			for _, target := range ep.Targets{
-				if strings.HasSuffix(target, "."){
+			for _, target := range ep.Targets {
+				if strings.HasSuffix(target, ".") {
 					illegalTarget = true
 					break
 				}
 			}
-			if illegalTarget{
+			if illegalTarget {
 				log.Warnf("Endpoint %s with DNSName %s has Target illegal target. The subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com')", dnsEndpoint.ObjectMeta.Name, ep.DNSName)
 				continue
 			}
-			
-			if ep.Labels == nil{
+
+			if ep.Labels == nil {
 				ep.Labels = endpoint.NewLabels()
 			}
-			
+
 			crdEndpoints = append(crdEndpoints, ep)
 		}
 
 		cs.setResourceLabel(&dnsEndpoint, crdEndpoints)
 		endpoints = append(endpoints, crdEndpoints...)
-		
+
 		if dnsEndpoint.Status.ObservedGeneration == dnsEndpoint.Generation {
 			continue
 		}


### PR DESCRIPTION
Fixes #1106
Added "external-dns/resource=..." field to TXT record when a CRD is used as source.

Added warning when a CR has a target with a "." in the end, which would make external-dns constantly add and remove the record.

Signed-off-by: João Marçal <joao.marcal12@gmail.com>