### PR TITLE
Changed ttlMaximum to MaxInt32 to allow compilation on 32bit machines

### DIFF
--- a/source/source.go
+++ b/source/source.go
@@ -49,7 +49,7 @@ const (
 
 const (
 	ttlMinimum = 1
-	ttlMaximum = math.MaxUint32
+	ttlMaximum = math.MaxInt32
 )
 
 // Source defines the interface Endpoint sources should implement.


### PR DESCRIPTION
In its current state, `ttlMaximum` causes make to fail build with error:

```sh
source/source.go:71:39: constant 4294967295 overflows int
```

Because `math.MaxUint32` is an untyped integer constant it is converted
to type `int` when used as an interface param, type `int` is signed,
`MaxUint32` is larger than `MaxInt32` and causes the type int to overflow.

Converting `ttlMaximum` to `MaxInt32` stops this overflow.