### PR TITLE
Document zone-id-filter flag in aws.md

### DIFF
--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -93,6 +93,7 @@ spec:
         - --aws-zone-type=public # only look at public hosted zones (valid values are public, private or no value for both)
         - --registry=txt
         - --txt-owner-id=my-hostedzone-identifier
+        - --zone-id-filter=  # optional; only see hosted zone with matching id (format: hostedzone/ZA3EXAMPLEHYO)
 ```
 
 ### Manifest (for clusters with RBAC enabled)
@@ -159,6 +160,7 @@ spec:
         - --aws-zone-type=public # only look at public hosted zones (valid values are public, private or no value for both)
         - --registry=txt
         - --txt-owner-id=my-hostedzone-identifier
+        - --zone-id-filter=  # optional; only see hosted zone with matching id (format: hostedzone/ZA3EXAMPLEHYO)
 ```
 
 


### PR DESCRIPTION
The --zone-id-filter (#422 ) is inadequately documented but is especially useful in Route53 where multiple private hosted zones can exist with the same domain name.