### PR TITLE
fix: support namespaces on the hostnames in istio gateway

### DIFF
--- a/source/gateway.go
+++ b/source/gateway.go
@@ -273,6 +273,15 @@ func (sc *gatewaySource) endpointsFromGatewayConfig(config istiomodel.Config) ([
 			if host == "" {
 				continue
 			}
+
+			parts := strings.Split(host, "/")
+
+			// If the input hostname is of the form my-namespace/foo.bar.com, remove the namespace
+			// before appending it to the list of endpoints to create
+			if len(parts) == 2 {
+				host = parts[1]
+			}
+
 			endpoints = append(endpoints, endpointsForHostname(host, targets, ttl, providerSpecific)...)
 		}
 	}

--- a/source/gateway_test.go
+++ b/source/gateway_test.go
@@ -193,6 +193,25 @@ func testEndpointsFromGatewayConfig(t *testing.T) {
 			},
 		},
 		{
+			title: "one namespaced rule.host one lb.hostname",
+			lbServices: []fakeIngressGatewayService{
+				{
+					hostnames: []string{"lb.com"}, // Kubernetes omits the trailing dot
+				},
+			},
+			config: fakeGatewayConfig{
+				dnsnames: [][]string{
+					{"my-namespace/foo.bar"}, // Kubernetes requires removal of trailing dot
+				},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "foo.bar",
+					Targets: endpoint.Targets{"lb.com"},
+				},
+			},
+		},
+		{
 			title: "one rule.host one lb.IP",
 			lbServices: []fakeIngressGatewayService{
 				{


### PR DESCRIPTION
One feature that's supported for the Istio Gateway resource is the ability to
restrict what namespace may provide a VirtualService for a given hostname/domain
by specifying it in the form `my-namespace/my-domain.com` which restricts the
availability of `my-domain.com` to the `my-namespace` namespace.

When creating the associated DNS records, the namespace should not be included.

Fixes #1095