### PR TITLE
TXTRegistry: do not overwrite labels of records returned by the provider

### DIFF
--- a/internal/testutils/endpoint.go
+++ b/internal/testutils/endpoint.go
@@ -76,6 +76,24 @@ func SameEndpoints(a, b []*endpoint.Endpoint) bool {
 	return true
 }
 
+func SameEndpointLabels(a, b []*endpoint.Endpoint) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	sa := a[:]
+	sb := b[:]
+	sort.Sort(byAllFields(sa))
+	sort.Sort(byAllFields(sb))
+
+	for i := range sa {
+		if !reflect.DeepEqual(sa[i].Labels, sb[i].Labels) {
+			return false
+		}
+	}
+	return true
+}
+
 // SamePlanChanges verifies that two set of changes are the same
 func SamePlanChanges(a, b map[string][]*endpoint.Endpoint) bool {
 	return SameEndpoints(a["Create"], b["Create"]) && SameEndpoints(a["Delete"], b["Delete"]) &&

--- a/provider/inmemory.go
+++ b/provider/inmemory.go
@@ -131,7 +131,9 @@ func (im *InMemoryProvider) Records() ([]*endpoint.Endpoint, error) {
 		}
 
 		for _, record := range records {
-			endpoints = append(endpoints, endpoint.NewEndpoint(record.Name, record.Type, record.Target))
+			ep := endpoint.NewEndpoint(record.Name, record.Type, record.Target)
+			ep.Labels = record.Labels
+			endpoints = append(endpoints, ep)
 		}
 	}
 
@@ -205,6 +207,7 @@ func convertToInMemoryRecord(endpoints []*endpoint.Endpoint) []*inMemoryRecord {
 			Type:   ep.RecordType,
 			Name:   ep.DNSName,
 			Target: ep.Targets[0],
+			Labels: ep.Labels,
 		})
 	}
 	return records
@@ -246,6 +249,7 @@ type inMemoryRecord struct {
 	Type   string
 	Name   string
 	Target string
+	Labels endpoint.Labels
 }
 
 type zone map[string][]*inMemoryRecord

--- a/registry/txt.go
+++ b/registry/txt.go
@@ -99,7 +99,9 @@ func (im *TXTRegistry) Records() ([]*endpoint.Endpoint, error) {
 	}
 
 	for _, ep := range endpoints {
-		ep.Labels = endpoint.NewLabels()
+		if ep.Labels == nil {
+			ep.Labels = endpoint.NewLabels()
+		}
 		if labels, ok := labelMap[ep.DNSName]; ok {
 			for k, v := range labels {
 				ep.Labels[k] = v

--- a/registry/txt_test.go
+++ b/registry/txt_test.go
@@ -71,12 +71,12 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 	p.CreateZone(testZone)
 	p.ApplyChanges(context.Background(), &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			newEndpointWithOwner("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
-			newEndpointWithOwner("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwnerAndLabels("foo.test-zone.example.org", "foo.loadbalancer.com", endpoint.RecordTypeCNAME, "", endpoint.Labels{"foo": "somefoo"}),
+			newEndpointWithOwnerAndLabels("bar.test-zone.example.org", "my-domain.com", endpoint.RecordTypeCNAME, "", endpoint.Labels{"bar": "somebar"}),
 			newEndpointWithOwner("txt.bar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("txt.bar.test-zone.example.org", "baz.test-zone.example.org", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("qux.test-zone.example.org", "random", endpoint.RecordTypeTXT, ""),
-			newEndpointWithOwner("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
+			newEndpointWithOwnerAndLabels("tar.test-zone.example.org", "tar.loadbalancer.com", endpoint.RecordTypeCNAME, "", endpoint.Labels{"tar": "sometar"}),
 			newEndpointWithOwner("txt.tar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner-2\"", endpoint.RecordTypeTXT, ""),
 			newEndpointWithOwner("foobar.test-zone.example.org", "foobar.loadbalancer.com", endpoint.RecordTypeCNAME, ""),
 			newEndpointWithOwner("foobar.test-zone.example.org", "\"heritage=external-dns,external-dns/owner=owner\"", endpoint.RecordTypeTXT, ""),
@@ -89,6 +89,7 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "",
+				"foo":                  "somefoo",
 			},
 		},
 		{
@@ -97,6 +98,7 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "owner",
+				"bar":                  "somebar",
 			},
 		},
 		{
@@ -121,6 +123,7 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 			RecordType: endpoint.RecordTypeCNAME,
 			Labels: map[string]string{
 				endpoint.OwnerLabelKey: "owner-2",
+				"tar":                  "sometar",
 			},
 		},
 		{
@@ -137,6 +140,7 @@ func testTXTRegistryRecordsPrefixed(t *testing.T) {
 	records, _ := r.Records()
 
 	assert.True(t, testutils.SameEndpoints(records, expectedRecords))
+	assert.True(t, testutils.SameEndpointLabels(records, expectedRecords))
 }
 
 func testTXTRegistryRecordsNoPrefix(t *testing.T) {
@@ -430,8 +434,17 @@ helper methods
 */
 
 func newEndpointWithOwner(dnsName, target, recordType, ownerID string) *endpoint.Endpoint {
+	return newEndpointWithOwnerAndLabels(dnsName, target, recordType, ownerID, nil)
+}
+
+func newEndpointWithOwnerAndLabels(dnsName, target, recordType, ownerID string, labels endpoint.Labels) *endpoint.Endpoint {
 	e := endpoint.NewEndpoint(dnsName, recordType, target)
 	e.Labels[endpoint.OwnerLabelKey] = ownerID
+	if labels != nil {
+		for k, v := range labels {
+			e.Labels[k] = v
+		}
+	}
 	return e
 }
 


### PR DESCRIPTION
This modifies TXTRegistry.Records() so it won't overwrite any endpoint labels returned by the provider's Records() implementation. This is currently needed to get the designate provider half working because it stores internal recordset IDs in labels and expects them to still be there when ApplyChanges() is called. The change should should be harmless though and not affect other providers.