### PR TITLE
Fix --aws-api-retries

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,6 +121,7 @@ func main() {
 				BatchChangeInterval:  cfg.AWSBatchChangeInterval,
 				EvaluateTargetHealth: cfg.AWSEvaluateTargetHealth,
 				AssumeRole:           cfg.AWSAssumeRole,
+				APIRetries:           cfg.AWSAPIRetries,
 				PreferCNAME:          cfg.AWSPreferCNAME,
 				DryRun:               cfg.DryRun,
 			},


### PR DESCRIPTION
This appears to be a regression caused by the accidental removal of this one line in #1080. The result is that `APIRetries` is never set, it defaults to 0 (i.e. "don't retry"), and we end up with intermittent `... level=error msg="Throttling: Rate exceeded\n\tstatus code: 400 ..."` errors.