### PR TITLE
Update changelog with fix for retries flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+  - AWS: re-introduce accidentally removed `--aws-api-retries` flag (#1158) @coreypobrien
+
 ## v0.5.16 - 2019-08-16
 
   - Fix flaky unit test in provider package (#1151) @tariq1890


### PR DESCRIPTION
changelog entry for https://github.com/kubernetes-incubator/external-dns/pull/1158