### PR TITLE
Update rfc2136 tutorial for use with Microsoft DNS

### DIFF
--- a/docs/tutorials/rfc2136.md
+++ b/docs/tutorials/rfc2136.md
@@ -1,16 +1,16 @@
 # Configuring RFC2136 provider
 
-## Server credentials:
-- RFC2136 was developed for and tested with [BIND](https://www.isc.org/downloads/bind/) DNS server. 
-Next is assuming that you already have configured and working server, other way please check first BIND documents or tutorials.
-- So you should obtain from your administrators TSIG key. It will look like:
+## Using with BIND
+### Server credentials:
+- RFC2136 was developed for and tested with [BIND](https://www.isc.org/downloads/bind/) DNS server. This documentation assumes that you already have a configured and working server. If you don't, please check BIND documents or tutorials.
+- So you should obtain from your administrator a TSIG key. It will look like:
 ```text
 key "externaldns-key" {
 	algorithm hmac-sha256;
 	secret "XXXXXXXXXXXXXXXXXXXXXX==";
 };
 ```
-- `Warning!` Bind server configuration should enable for this key AFXR zone transfer protocol. It is used for listing DNS records.
+- **Warning!** Bind server configuration should enable this key for AFXR zone transfer. `external-dns` uses it for listing DNS records.
 
 ```text
 # cat /etc/named.conf
@@ -45,7 +45,7 @@ zone "example.com" {
 ...
 ```
 
-## RFC2136 provider configuration:
+### RFC2136 provider configuration:
 - Example fragment of real configuration of ExternalDNS service pod.
 
 ```text
@@ -60,8 +60,34 @@ zone "example.com" {
         - --rfc2136-tsig-axfr
 ...
 ```
-- `rfc2136_tsig_secret` - environment variable containing actual secret value from TSIG key. Something like `XXXXXXXXXXXXXXXXXXXXXX==`.
-- `rfc2136-tsig-keyname` - this is string parameter with secret key name it is should `MATCH!` with server key name. In example it is `externaldns-key`.
+- `--rfc2136-tsig-secret` - environment variable containing actual secret value from TSIG key. Something like `XXXXXXXXXXXXXXXXXXXXXX==`.
+- `--rfc2136-tsig-keyname` - this is a string parameter with the key name in the Kubernetes secret. It **must match** with key name on the DNS server. In this example it is `externaldns-key`.
  
+## Using with Microsoft DNS
 
-   
+While `external-dns` was not developed or tested against Microsoft DNS, it can be configured to work against it. YMMV.
+
+### DNS-side configuration
+
+1. Create a DNS zone
+2. Enable insecure dynamic updates for the zone
+3. Enable Zone Transfers from all servers
+
+### `external-dns` configuration
+
+You'll want to configure `external-dns` similarly to the following:
+
+```text
+...
+        - --provider=rfc2136
+        - --rfc2136-host=123.123.123.123
+        - --rfc2136-port=53
+        - --rfc2136-zone=your-domain.com
+        - --rfc2136-tsig-secret=not-needed
+        - --rfc2136-tsig-secret-alg=hmac-sha256
+        - --rfc2136-tsig-keyname=externaldns-key
+        - --rfc2136-tsig-axfr # needed to enable zone transfers, which is required for deletion of records.
+...
+```
+
+Since Microsoft DNS does not support secure updates via TSIG, this will let `external-dns` make insecure updates. Do this at your own risk.


### PR DESCRIPTION
Clean up the tutorial and update it to clarify usage with non-BIND DNS servers.

This clarifies the documentation related to issues brought up in #882, but it may or may not fix the issue OP was having.