### PR TITLE
Propose a few doc changes to make the use of namespace more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ Locally run a single sync loop of ExternalDNS.
 $ external-dns --registry txt --txt-owner-id my-cluster-id --provider google --google-project example-project --source service --once --dry-run
 ```
 
-This should output the DNS records it will modify to match the managed zone with the DNS records you desire. Note TXT records having `my-cluster-id` value embedded. Those are used to ensure that ExternalDNS is aware of the records it manages.
+This should output the DNS records it will modify to match the managed zone with the DNS records you desire. It also assumes you are running in the `default` namespace. See the [FAQ](docs/faq.md) for more information regarding namespaces.
+
+Note: TXT records will have `my-cluster-id` value embedded. Those are used to ensure that ExternalDNS is aware of the records it manages.
 
 Once you're satisfied with the result, you can run ExternalDNS like you would run it in your cluster: as a control loop, and **not in dry-run** mode:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -280,3 +280,12 @@ As tags, you can use your version of choice or use `latest` that always resolves
 If you wish to build your own image, you can use the provided [Dockerfile](../Dockerfile) as a starting point.
 
 We are currently working with the Kubernetes community to provide official images for the project similarly to what is done with the other official Kubernetes projects, but we don't have an ETA on when those images will be available.
+
+### Why am I seeing time out errors even though I have connectivity to my cluster?
+
+If you're seeing an error such as this:
+```
+FATA[0060] failed to sync cache: timed out waiting for the condition
+```
+
+You may not have the correct permissions required to query all the necessary resources in your kubernetes cluster. Specifically, you may be running in a `namespace` that you don't have these permissions in. By default, commands are run against the `default` namespace. Try changing this to your particular namespace to see if that fixes the issue.

--- a/docs/tutorials/aws.md
+++ b/docs/tutorials/aws.md
@@ -43,7 +43,6 @@ Create a DNS zone which will contain the managed DNS records.
 $ aws route53 create-hosted-zone --name "external-dns-test.my-org.com." --caller-reference "external-dns-test-$(date +%s)"
 ```
 
-
 Make a note of the ID of the hosted zone you just created, which will serve as the value for my-hostedzone-identifier.
 
 ```console
@@ -66,6 +65,8 @@ In this case it's the ones shown above but your's will differ.
 
 Connect your `kubectl` client to the cluster you want to test ExternalDNS with.
 Then apply one of the following manifests file to deploy ExternalDNS. You can check if your cluster has RBAC by `kubectl api-versions | grep rbac.authorization.k8s.io`.
+
+For clusters with RBAC enabled, be sure to choose the correct `namespace`.
 
 ### Manifest (for clusters without RBAC enabled)
 ```yaml
@@ -162,8 +163,6 @@ spec:
       securityContext:
         fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files
 ```
-
-
 
 ## Arguments
 


### PR DESCRIPTION
A few documentation updates to attempt to make the use of namespace more clear. Specifically around issues that arise when using the wrong namespace.

I got stuck for a few days when first trying out external-dns when I didn't quite understand where the namespace came into play. Specifically I was seeing an error like below which I added to the FAQ. Might be helpful for folks we get stuck to be able to find this and a (potential) solution.

```
FATA[0060] failed to sync cache: timed out waiting for the condition
```

Open to making tweaks as necessary for this to fit in with existing docs.

Fixes #1216 